### PR TITLE
chore: use NODE_ENV to setup env

### DIFF
--- a/src/services/config.js
+++ b/src/services/config.js
@@ -3,7 +3,7 @@ const consola = require('consola')
 const config = new Conf()
 
 const key = process.env.CHECKLY_API_KEY || config.apiKey
-const env = process.env.CHECKLY_ENV
+const env = process.env.NODE_ENV || config.env
 
 if (!key) {
   consola.error(


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## ⚙️ Affected Components
* [ ] Commands
* [ ] Modules
* [ ] Services
* [ ] SDK

### 📝 Notes for the Reviewer

Resolves https://github.com/checkly/checkly-cli/commit/378cbe2e34fc543667beaa71c379e538312c6ea2#comments

Beyond this fix, I do not expect this ENV configuration is used by customers. This should be focused on us and development purposes 