### PR TITLE
feat: add checkly directoty parser

### DIFF
--- a/src/parser/check-parser.js
+++ b/src/parser/check-parser.js
@@ -1,0 +1,65 @@
+const fs = require('fs')
+const YAML = require('yaml')
+const consola = require('consola')
+
+const { CHECK } = require('./file-parser')
+const { getGlobalSettings } = require('./helper')
+
+const { settings } = YAML.parse(getGlobalSettings())
+function parseCheck(check, groupSettings = null) {
+  if (check.error) {
+    consola.warn(`Skipping file ${check.filePath}: ${check.error} `)
+    return null
+  }
+
+  const parsedCheck = YAML.parse(fs.readFileSync(check.filePath, 'utf8'))
+
+  if (!parsedCheck) {
+    consola.warn(`Skipping file ${check.filePath}: FileEmpty`)
+    return null
+  }
+
+  parsedCheck.settings = { ...settings, ...parsedCheck.settings }
+
+  if (groupSettings) {
+    // TODO: Remove settings that are not allowed to override by a check (like locations)
+    parsedCheck.settings = {
+      ...settings,
+      ...groupSettings,
+      ...parsedCheck.settings,
+    }
+  }
+
+  return parsedCheck
+}
+
+function parseChecksTree(tree, parent = null) {
+  const parsedTree = parent ? { checks: [] } : { checks: [], groups: [] }
+
+  tree.forEach((leaf) => {
+    if (leaf.type === CHECK) {
+      const parsedCheck = parseCheck(leaf, parent)
+      parsedCheck && parsedTree.checks.push(parsedCheck)
+      return
+    }
+
+    // We only allow two level of directory nesting: root checks and checks within a group.
+    if (parent) {
+      return
+    }
+
+    const groupSettings = YAML.parse(fs.readFileSync(leaf.settings, 'utf8'))
+
+    parsedTree.groups.push({
+      name: leaf.name,
+      settings: groupSettings.settings,
+      ...parseChecksTree(leaf.checks, groupSettings.settings),
+    })
+  })
+
+  return parsedTree
+}
+
+module.exports = {
+  parseChecksTree,
+}

--- a/src/parser/file-parser.js
+++ b/src/parser/file-parser.js
@@ -1,0 +1,89 @@
+const fs = require('fs')
+const path = require('path')
+
+const MAX_NESTING_LEVEL = 1
+const SETTINGS = 'settings'
+const CHECK = 'check'
+const GROUP = 'group'
+const YML = '.yml'
+
+const { isProjectValid, CHECKS_DIR_PATH } = require('./helper')
+
+function parseChecklyFile(filePath, nestingLevel = 1, prefix = '') {
+  const fileStats = fs.lstatSync(filePath)
+  const basename = path.basename(filePath)
+  const name = `${prefix}${basename}`
+  const ext = path.extname(filePath)
+
+  const file =
+    basename === `${SETTINGS}${YML}`
+      ? {
+          filePath,
+          type: SETTINGS,
+        }
+      : {
+          name,
+          filePath,
+          type: CHECK,
+          error: ext !== YML ? 'InvalidFileExtension' : null,
+        }
+
+  if (fileStats.isDirectory()) {
+    if (nestingLevel <= MAX_NESTING_LEVEL) {
+      nestingLevel += 1
+      file.checks = fs
+        .readdirSync(filePath)
+        .map((f) =>
+          parseChecklyFile(`${filePath}/${f}`, nestingLevel, name + '/')
+        )
+      file.type = GROUP
+      file.error = null
+    } else {
+      file.error = 'InvalidNestingLevel'
+    }
+  }
+
+  return file
+}
+
+function parseChecklySettings(files) {
+  return files.map((file) => {
+    if (file.type === GROUP) {
+      const settingsIndex = file.checks.findIndex((c) => c.type === 'settings')
+      if (settingsIndex !== -1) {
+        file.settings = file.checks[settingsIndex].filePath
+        file.checks.splice(settingsIndex, 1)
+        delete file.settings.type
+      }
+    }
+    return file
+  })
+}
+
+function parseChecklyDirectory() {
+  if (!isProjectValid()) {
+    throw new Error('Invalid checkly project')
+  }
+
+  try {
+    const checksDirStats = fs.lstatSync(CHECKS_DIR_PATH)
+
+    if (!checksDirStats.isDirectory()) {
+      throw new Error('Missing checks directory')
+    }
+
+    const files = fs.readdirSync(CHECKS_DIR_PATH)
+    const parsedFiles = files.map((file) =>
+      parseChecklyFile(path.join(CHECKS_DIR_PATH, file))
+    )
+    return parseChecklySettings(parsedFiles)
+  } catch (err) {
+    throw new Error(err.message)
+  }
+}
+
+module.exports = {
+  CHECK,
+  GROUP,
+  parseChecklyDirectory,
+}

--- a/src/parser/helper.js
+++ b/src/parser/helper.js
@@ -1,0 +1,35 @@
+const fs = require('fs')
+const path = require('path')
+
+const CHECKLY_DIR_NAME = './.checkly'
+
+const CWD = process.cwd()
+const CHECKLY_DIR_PATH = path.join(CWD, CHECKLY_DIR_NAME)
+const CHECKS_DIR_PATH = path.join(CWD, CHECKLY_DIR_NAME, '/checks')
+const SETTINGS_FILE = path.join(CWD, CHECKLY_DIR_NAME, '/settings.yml')
+
+const hasChecklyDirectory = () => fs.existsSync(CHECKLY_DIR_PATH)
+const hasChecksDirectory = () => fs.existsSync(CHECKS_DIR_PATH)
+const hasGlobalSettingsFile = () => fs.existsSync(SETTINGS_FILE)
+const isProjectValid = () =>
+  hasChecklyDirectory() && hasChecksDirectory() && hasGlobalSettingsFile()
+
+function getGlobalSettings() {
+  if (!hasGlobalSettingsFile) {
+    throw new Error('Missing settings file')
+  }
+
+  return fs.readFileSync(SETTINGS_FILE, 'utf8')
+}
+
+module.exports = {
+  CWD,
+  CHECKLY_DIR_PATH,
+  CHECKS_DIR_PATH,
+  SETTINGS_FILE,
+  hasChecklyDirectory,
+  hasChecksDirectory,
+  hasGlobalSettingsFile,
+  isProjectValid,
+  getGlobalSettings,
+}

--- a/src/parser/index.js
+++ b/src/parser/index.js
@@ -1,0 +1,4 @@
+const { parseChecklyDirectory } = require('./file-parser')
+const { parseChecksTree } = require('./check-parser')
+
+module.exports = () => parseChecksTree(parseChecklyDirectory())


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## ⚙️ Affected Components
* [ ] Commands
* [ ] Modules
* [x] Services
* [ ] SDK

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
### 📝 Notes for the Reviewer

Checkly directory parser
1. File parser  scans `.checkly` directory and look for checks, groups and settings files
2. Check parser builds a checks tree based on the file parser
