### PR TITLE
fix: run cmd file reading

### DIFF
--- a/sdk/helper.js
+++ b/sdk/helper.js
@@ -1,0 +1,19 @@
+const { join } = require('path')
+const { statSync, readdirSync } = require('fs')
+
+const getLocalFiles = (path, fileContents = []) => {
+  const fileNames = readdirSync(path)
+
+  fileNames.forEach((file) => {
+    if (statSync(path + '/' + file).isDirectory()) {
+      fileContents = getLocalFiles(path + '/' + file, fileContents)
+    } else {
+      fileContents.push(join(path, '/', file))
+    }
+  })
+  return fileContents
+}
+
+module.exports = {
+  getLocalFiles,
+}

--- a/sdk/index.js
+++ b/sdk/index.js
@@ -1,5 +1,7 @@
 const endpoints = require('./endpoints')
-const { readdir, readFile } = require('fs/promises')
+const path = require('path')
+const { getLocalFiles } = require('./helper')
+const { readFile } = require('fs/promises')
 
 function init({ api, baseHost, basePath }) {
   const checks = {
@@ -11,9 +13,14 @@ function init({ api, baseHost, basePath }) {
     },
 
     async getAllLocal() {
-      const checks = await readdir(`.checkly/checks`)
+      const checks = await getLocalFiles(
+        path.join(process.cwd(), `.checkly/checks`)
+      )
+
       return Promise.all(
-        checks.map((check) => readFile(`.checkly/checks/${check}`, 'utf-8'))
+        checks
+          .filter((check) => !check.includes('settings.yml'))
+          .map((check) => readFile(path.join(check), 'utf-8'))
       )
     },
 


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## ⚙️ Affected Components
* [x] Commands
* [ ] Modules
* [ ] Services
* [ ] SDK

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
### 📝 Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

The `run` cmd didnt take into account `cwd` or anything like that. Also it wouldn't read check files nested inside groups, only those directly in `.checkly/checks/*.yml`. 

This is refactored to support all that and therefore fix the `run` cmd on prod / for group checks.

### 🏗️ New Dependency Submission
<!-- Please explain here why we need the new dependency. -->

### 🎟 Affected Issue
<!--
If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and help with maintenance of the library 😊
-->