### PR TITLE
feat: add accounts command to handle checkly accounts

### DIFF
--- a/src/commands/accounts.js
+++ b/src/commands/accounts.js
@@ -1,0 +1,33 @@
+const { Command } = require('@oclif/command')
+
+const accounts = require('./../modules/accounts')
+const { output } = require('./../services/flags')
+
+class AccountsCommand extends Command {
+  static args = [
+    {
+      name: 'action',
+      required: true,
+      description: 'Specify the type of accounts action to run',
+      default: 'list',
+      options: ['list'],
+    },
+  ]
+
+  async run() {
+    const { args, flags } = this.parse(AccountsCommand)
+
+    switch (args.action) {
+      default:
+        return accounts.list({ ...flags })
+    }
+  }
+}
+
+AccountsCommand.description = 'Manage accounts'
+
+AccountsCommand.flags = {
+  output,
+}
+
+module.exports = AccountsCommand

--- a/src/modules/accounts/index.js
+++ b/src/modules/accounts/index.js
@@ -1,0 +1,5 @@
+const list = require('./list')
+
+module.exports = {
+  list,
+}

--- a/src/modules/accounts/list.js
+++ b/src/modules/accounts/list.js
@@ -1,0 +1,28 @@
+const chalk = require('chalk')
+const consola = require('consola')
+
+const config = require('./../../services/config')
+const { print } = require('./../../services/utils')
+const { accounts } = require('./../../services/api')
+
+async function listAccounts({ output } = {}) {
+  try {
+    const { data } = await accounts.find()
+
+    if (output === 'human') {
+      data.map((account) => {
+        if (account.id === config.data.get('accountId')) {
+          account.id = chalk.blue.bold('✔ ' + account.id)
+        }
+
+        return account
+      })
+    }
+
+    print(data, { output })
+  } catch (err) {
+    consola.error(err)
+  }
+}
+
+module.exports = listAccounts

--- a/src/services/flags.js
+++ b/src/services/flags.js
@@ -1,7 +1,7 @@
 const { flags } = require('@oclif/command')
 
 const config = require('../services/config')
-const defaultOutput = config.data.get('output')
+const defaultOutput = config.data.get('output') || 'human'
 
 module.exports = {
   output: flags.string({

--- a/src/services/login-util.js
+++ b/src/services/login-util.js
@@ -2,7 +2,6 @@ const http = require('http')
 const crypto = require('crypto')
 const consola = require('consola')
 const axios = require('axios')
-const config = require('./config')
 
 // TODO: Move this to ./sdk
 const AUTH0_DOMAIN = 'checkly'


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## ⚙️ Affected Components
* [x] Commands
* [x] Modules
* [ ] Services
* [ ] SDK

### 📝 Notes for the Reviewer
Add `accounts` command for Checkly accounts handling. 
For now, the only command implemented in the module is `list`.

> Resolves #48 