### PR TITLE
Update accounts api module name

### DIFF
--- a/sdk/index.js
+++ b/sdk/index.js
@@ -64,10 +64,6 @@ function init({ api, baseHost, basePath }) {
   }
 
   const accounts = {
-    findOne() {
-      return api.get(`/next/${endpoints.ACCOUNTS.GET}`)
-    },
-
     find() {
       return api.get(`/next/${endpoints.ACCOUNTS.GET}`)
     },

--- a/src/commands/login.js
+++ b/src/commands/login.js
@@ -5,7 +5,7 @@ const { prompt } = require('inquirer')
 const { Command, flags } = require('@oclif/command')
 
 const raccoon = require('./../services/raccoon')
-const { account } = require('./../services/api')
+const { accounts } = require('./../services/api')
 const {
   generateAuthenticationUrl,
   getAccessToken,
@@ -87,8 +87,6 @@ class LoginCommand extends Command {
 
         const { sub: userExternalId, name } = jwt_decode(idToken)
 
-        console.log('ACA', userExternalId)
-
         consola.info(` Successfully logged in as ${chalk.blue.bold(name)}`)
         const keyResponse = await getApiKey({
           userExternalId,
@@ -108,7 +106,7 @@ class LoginCommand extends Command {
       config.auth.set('apiKey', apiKey)
       api.refresh()
 
-      const { data } = await account.findOne()
+      const { data } = await accounts.findMe()
       const { accountId, name } = data
 
       config.data.set('accountId', accountId)

--- a/src/commands/whoami.js
+++ b/src/commands/whoami.js
@@ -1,12 +1,12 @@
 const { Command } = require('@oclif/command')
-const { account } = require('./../services/api')
+const { accounts } = require('./../services/api')
 const { output } = require('./../services/flags')
 const { print } = require('./../services/utils')
 
 class WhoamiCommand extends Command {
   async run() {
     const { flags } = this.parse(WhoamiCommand)
-    const { data } = await account.findMe()
+    const { data } = await accounts.findMe()
     print(data, flags)
   }
 }


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## ⚙️ Affected Components
* [x] Commands
* [ ] Modules
* [ ] Services
* [ ] SDK

### 📝 Notes for the Reviewer
Fix `accounts` module name in `whoami` and `login` commands.