### PR TITLE
fix(init): create project on BE before writing .checkly dir [gh-00]

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -70,6 +70,15 @@ class InitCommand extends Command {
       return process.exit(1)
     }
 
+    const { data: project } = await projects.create({
+      accountId: config.getAccountId(),
+      name: args.projectName,
+      repoUrl: await getRepoUrl(cwd),
+      activated: true,
+      muted: false,
+      state: {},
+    })
+
     if (!force) {
       const { checkTypes, url, mode } = await prompt([
         {
@@ -108,15 +117,6 @@ class InitCommand extends Command {
         dirName,
       })
     }
-
-    const { data: project } = await projects.create({
-      accountId: config.getAccountId(),
-      name: args.projectName,
-      repoUrl: await getRepoUrl(cwd),
-      activated: true,
-      muted: false,
-      state: {},
-    })
 
     createProjectFile({
       dirName,

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -63,6 +63,7 @@ class InitCommand extends Command {
     const { force } = flags
     const cwd = process.cwd()
     const dirName = path.join(cwd, '.checkly')
+    let project = {}
 
     if (fs.existsSync(dirName)) {
       consola.error(' checkly-cli already initialized')
@@ -70,14 +71,20 @@ class InitCommand extends Command {
       return process.exit(1)
     }
 
-    const { data: project } = await projects.create({
-      accountId: config.getAccountId(),
-      name: args.projectName,
-      repoUrl: await getRepoUrl(cwd),
-      activated: true,
-      muted: false,
-      state: {},
-    })
+    try {
+      const { data } = await projects.create({
+        accountId: config.getAccountId(),
+        name: args.projectName,
+        repoUrl: await getRepoUrl(cwd),
+        activated: true,
+        muted: false,
+        state: {},
+      })
+      project = data
+    } catch (e) {
+      consola.error('Failed to create project - please try again.')
+      throw new Error(e)
+    }
 
     if (!force) {
       const { checkTypes, url, mode } = await prompt([


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## ⚙️ Affected Components

- [x] Commands
- [ ] Modules
- [ ] Services
- [ ] SDK
- [ ] Tests

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### 📝 Notes for the Reviewer

<!-- Anything the reviewer should pay extra attention to. -->

This PR changes the order of some actions in the `init` command. Moving the creation of the project, and communication with the backend, to earlier in the process. 

This is so that in case of network or any other BE errors, the process exits earlier, and the users are not left with a dangling invalid `.checkly` directory.

The current order of operations is such that - first the `.checkly` directory gets created, as well as an example check. After that, we talk with the backend and create the project in the DB, get back an ID for it, etc. and write that to the `.checkly/settings.yml` file. If it were to fail at that point, we do not get a valid `.checkly/settings.yml` file which contains our `projectId`, and are simply left with an invalid `.checkly` directory. 

This way, if there is an error, the user still has a clean working directory, no invalid .checkly dir, and can cleanly just try again. I've also added a try/catch to be able to graceful tell the user whats wrong.


### 🏗️ New Dependency Submission

<!-- Please explain here why we need the new dependency. -->

### 🎟 Affected Issue

<!--
If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and help with maintenance of the library 😊
-->
