### PR TITLE
fix: remove this.exit from accounts command

### DIFF
--- a/src/commands/accounts.js
+++ b/src/commands/accounts.js
@@ -21,8 +21,6 @@ class AccountsCommand extends Command {
       default:
         accounts.list({ ...flags })
     }
-
-    this.exit(0)
   }
 }
 

--- a/test/commands/accounts.spec.js
+++ b/test/commands/accounts.spec.js
@@ -24,5 +24,4 @@ describe('accounts [cmd]', () => {
     .command(['accounts', '--output', 'json'])
     .stdout()
     .it('list all user accounts', (ctx) => {})
-  // .exit(0)
 })


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## ⚙️ Affected Components

- [x] Commands
- [ ] Modules
- [ ] Services
- [ ] SDK
- [ ] Tests

### 📝 Notes for the Reviewer
Remove `exit` from accounts command and fix output

> Resolves #139 139