### PR TITLE
chore: only show the formatted fields

### DIFF
--- a/src/modules/projects/list.js
+++ b/src/modules/projects/list.js
@@ -11,10 +11,6 @@ async function listProjects ({ output } = {}) {
         id,
         name,
         repoUrl,
-        activated,
-        muted,
-        state,
-        accountId,
         /* eslint-disable camelcase */
         created_at,
         updated_at
@@ -23,10 +19,6 @@ async function listProjects ({ output } = {}) {
         id,
         name,
         repoUrl,
-        activated,
-        muted,
-        state,
-        accountId,
         /* eslint-disable camelcase */
         created_at,
         updated_at


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## ⚙️ Affected Components

- [ ] Commands
- [ ] Modules
- [ ] Services
- [ ] SDK
- [ ] Tests

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### 📝 Notes for the Reviewer

Only shows the formatted fields for the project endpoint

### 🏗️ New Dependency Submission

<!-- Please explain here why we need the new dependency. -->

### 🎟 Affected Issue

<!--
If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #140 
```

the connected issue will be automatically closed once the PR is merged and help with maintenance of the library 😊
-->
