### PR TITLE
feat: allow users to pass logical id to run checks

### DIFF
--- a/src/parser/index.js
+++ b/src/parser/index.js
@@ -31,19 +31,6 @@ module.exports = async () => {
     ...checkAlertChannelSubscriptions
   }
 
-  console.log(
-    JSON.stringify(
-      {
-        alertChannels,
-        checks,
-        groups,
-        alertChannelSubscriptions
-      },
-      null,
-      2
-    )
-  )
-
   return {
     alertChannels,
     checks,


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## ⚙️ Affected Components

- [ ] Commands
- [ ] Modules
- [ ] Services
- [ ] SDK
- [ ] Tests

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### 📝 Notes for the Reviewer

This is an idea on how `checkly-cli run` would work with logical ids we have in the repo

`checkly-cli run example-api.yml`. This is not the path but the logical ids what the parser returns. We can also change the command to something like `checkly-cli run .checkly/checks/example-api.yml`