### PR TITLE
feat: add group selection when creating checks

### DIFF
--- a/src/modules/add/check.js
+++ b/src/modules/add/check.js
@@ -8,11 +8,31 @@ const { locations: locationsApi } = require('../../services/api')
 const apiTemplates = require('../../templates/api')
 const browserTemplates = require('../../templates/browser')
 
+const parser = require('../../parser')
+const NONE = '(none)'
+
 async function check (checklyDir) {
   const { data } = await locationsApi.getAll()
   const regions = data.map(({ region }) => region)
 
   consola.info('Creating new check file')
+
+  const { groups } = await parser()
+  let selectedGroup
+
+  if (Object.keys(groups).length) {
+    const { group } = await prompt([
+      {
+        name: 'group',
+        type: 'list',
+        message: 'In which group do you want to create the check?',
+        choices: [NONE, ...Object.keys(groups)],
+        default: [NONE]
+      }
+    ])
+
+    selectedGroup = group === NONE ? null : group
+  }
 
   const { name, type, url, locations } = await prompt([
     {
@@ -78,7 +98,8 @@ async function check (checklyDir) {
   ])
 
   const key = name.toLowerCase().replace(/ /g, '-').trim()
-  let filePath = path.join(checklyDir, 'checks', key + '.yml')
+  const checkPath = selectedGroup ? `checks/${selectedGroup}` : 'checks'
+  let filePath = path.join(checklyDir, checkPath, key + '.yml')
   let tryIndex = 0
 
   while (fs.existsSync(filePath)) {


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## ⚙️ Affected Components

- [x] Commands
- [x] Modules
- [ ] Services
- [ ] SDK
- [ ] Tests

### 📝 Notes for the Reviewer

Allow selecting a group when running `add check` command

> Resolves #113 