### PR TITLE
fix: send checks paginations params as qs

### DIFF
--- a/sdk/api/modules/checks.js
+++ b/sdk/api/modules/checks.js
@@ -8,11 +8,8 @@ const checks = ({ api, apiVersion = 'v1' }) => {
     return api.get(`/${apiVersion}/${PATH}/${id}`)
   }
 
-  async function getAll ({ limit, page } = {}) {
-    const { data, headers } = await api.get(`/${apiVersion}/${PATH}`, {
-      limit,
-      page
-    })
+  async function getAll ({ limit = 100, page = 1 } = {}) {
+    const { data, headers } = await api.get(`/${apiVersion}/${PATH}?limit=${limit}&page=${page}`)
     const result = PAGINATION_REGEX.exec(headers[CONTENT_RANGE_HEADER])
     const endIndex = parseInt(result[2])
     const total = parseInt(result[3])

--- a/test/commands/checks.spec.js
+++ b/test/commands/checks.spec.js
@@ -13,7 +13,7 @@ describe('checks [cmd]', () => {
 
   test
     .nock('https://api.checklyhq.com', (api) =>
-      api.get('/v1/checks').reply(200, mockChecksListResponse, {
+      api.get('/v1/checks?limit=100&page=1').reply(200, mockChecksListResponse, {
         'content-range': `0-${mockChecksListResponse.length - 1}/${mockChecksListResponse.length}`
       })
     )

--- a/test/commands/deploy.assertions.spec.js
+++ b/test/commands/deploy.assertions.spec.js
@@ -86,7 +86,6 @@ describe('e2e test that assertions get persisted', () => {
     })
 
     const { data } = await checks.getAll()
-
     return data.find((x) => x.name === check.name)
   }
 


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## ⚙️ Affected Components

- [ ] Commands
- [ ] Modules
- [ ] Services
- [x] SDK
- [ ] Tests

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### 📝 Notes for the Reviewer

<!-- Anything the reviewer should pay extra attention to. -->

### 🏗️ New Dependency Submission

Fix checks pagination sending limit & page params as query string