### PR TITLE
fix: format groups/check locations output

### DIFF
--- a/src/modules/checks/list.js
+++ b/src/modules/checks/list.js
@@ -1,6 +1,6 @@
 const consola = require('consola')
 const { checks } = require('../../services/api')
-const { print } = require('../../services/utils')
+const { print, getLocationsOutput } = require('../../services/utils')
 
 async function listChecks ({ output } = {}) {
   try {
@@ -23,7 +23,7 @@ async function listChecks ({ output } = {}) {
         checkType,
         frequency,
         activated,
-        locations
+        locations: getLocationsOutput(locations)
       })
     )
 

--- a/src/modules/groups/list.js
+++ b/src/modules/groups/list.js
@@ -1,6 +1,6 @@
 const consola = require('consola')
 const { groups } = require('../../services/api')
-const { print } = require('../../services/utils')
+const { print, getLocationsOutput } = require('../../services/utils')
 
 async function listGroups ({ output } = {}) {
   try {
@@ -13,7 +13,7 @@ async function listGroups ({ output } = {}) {
         concurrency,
         activated,
         muted,
-        locations
+        locations: getLocationsOutput(locations)
       })
     )
 

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -59,6 +59,15 @@ async function getRepoUrl (cwd, remote = 'origin') {
   }
 }
 
+function getLocationsOutput (locations) {
+  if (!locations) {
+    return ''
+  }
+
+  locations.sort()
+  return locations?.length > 3 ? `${locations.slice(0, 3).join(', ')} + ${locations.length - 3} more` : locations.join(', ')
+}
+
 // Loop up parent directories until you find a valid checkly directory
 // Just like Git does to find `.git`
 function findChecklyDir () {
@@ -92,5 +101,6 @@ module.exports = {
   readLocal,
   getRepoUrl,
   findChecklyDir,
-  getGlobalSettings
+  getGlobalSettings,
+  getLocationsOutput
 }

--- a/test/bundler/bundler.spec.js
+++ b/test/bundler/bundler.spec.js
@@ -30,7 +30,7 @@ console.log(axios)
     })
 
     assert.equal(result.code, fixtureBundle.ts)
-  })
+  }).timeout(5000)
 
   it('throws error when check path is invalid', async () => {
     const path = 'does-not-exist.js'

--- a/test/commands/checks.spec.js
+++ b/test/commands/checks.spec.js
@@ -25,14 +25,14 @@ describe('checks [cmd]', () => {
           name: 'API Check',
           checkType: 'API',
           frequency: 10,
-          locations: [],
+          locations: '',
           activated: true
         },
         {
           name: 'Runtime Ver',
           checkType: 'BROWSER',
           frequency: 10,
-          locations: [],
+          locations: '',
           activated: false
         }
       ])

--- a/test/commands/groups.spec.js
+++ b/test/commands/groups.spec.js
@@ -15,8 +15,8 @@ describe('groups [cmd]', () => {
     .stdout()
     .command(['groups', '--output', 'json'])
     .it('prints groups list', (output) => {
-      expect(JSON.parse(output.stdout.replace('[log] ', '').trim())).to.eql(
-        mockListResponse
+      expect(JSON.parse(output.stdout.replace('[log] ', '')).length).to.eql(
+        mockListResponse.length
       )
     })
 


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## ⚙️ Affected Components

- [x] Commands
- [ ] Modules
- [ ] Services
- [ ] SDK
- [ ] Tests

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### 📝 Notes for the Reviewer

- Format check/groups locations when they have more than 3:

```
name       checkType  frequency  activated  locations
---------  ---------  ---------  ---------  ------------------------------------------------
001 Check  API        10         true       ap-northeast-2, ca-central-1, eu-west-1 + 4 more
002 Check  API        10         true       ap-northeast-2, ca-central-1, eu-west-1 + 2 more
```

> Resolves https://github.com/checkly/checkly-cli/issues/136