### PR TITLE
feat: add link command

### DIFF
--- a/sdk/api/modules/projects.js
+++ b/sdk/api/modules/projects.js
@@ -5,6 +5,10 @@ const projects = ({ api, apiVersion = 'next' }) => {
     return api.get(`/${apiVersion}/${PATH}`)
   }
 
+  function get (id) {
+    return api.get(`/${apiVersion}/${PATH}/${id}`)
+  }
+
   function create (project) {
     return api.post(`/${apiVersion}/${PATH}`, project)
   }
@@ -22,6 +26,7 @@ const projects = ({ api, apiVersion = 'next' }) => {
 
   return {
     getAll,
+    get,
     create,
     deploy,
     delete: deleteProject

--- a/src/commands/link.js
+++ b/src/commands/link.js
@@ -1,0 +1,29 @@
+const { Command } = require('@oclif/command')
+
+const link = require('../modules/link')
+const { id } = require('./../services/args')
+const { force } = require('./../services/flags')
+
+class LinkCommand extends Command {
+  static args = [
+    {
+      ...id,
+      description: 'Specify the projectId'
+    }
+  ]
+
+  async run () {
+    const { flags, args } = this.parse(LinkCommand)
+    const { force } = flags
+
+    link({ force, projectId: args.id })
+  }
+}
+
+LinkCommand.description = 'Link your checkly directory with an existing project'
+
+LinkCommand.flags = {
+  force
+}
+
+module.exports = LinkCommand

--- a/src/modules/link/index.js
+++ b/src/modules/link/index.js
@@ -1,0 +1,54 @@
+const fs = require('fs')
+const path = require('path')
+const YAML = require('yaml')
+const consola = require('consola')
+const { prompt } = require('inquirer')
+
+const { projects } = require('./../../services/api')
+const { promptConfirm } = require('./../../services/prompts')
+
+const { findChecklyDir, getGlobalSettings } = require('../../services/utils')
+
+async function link ({ projectId, force }) {
+  let project
+
+  if (projectId) {
+    const { data } = await projects.get(projectId)
+    project = data
+  } else {
+    const { data } = await projects.getAll()
+    const { projectKey } = await prompt([
+      {
+        name: 'projectKey',
+        type: 'list',
+        choices: data.map(({ id, name }) => `${id} - ${name}`)
+      }
+    ])
+
+    project = data.find(({ id, name }) => `${id} - ${name}` === projectKey)
+  }
+
+  if (!force) {
+    const { confirm } = await prompt([
+      promptConfirm({
+        message: `You are about to link your checkly directory with the project ${project.id}, do you want to continue?`
+      })
+    ])
+
+    if (!confirm) {
+      return
+    }
+  }
+
+  const dirName = findChecklyDir()
+
+  const settings = YAML.parse(getGlobalSettings())
+  settings.projectId = parseInt(project.id)
+  settings.projectName = project.name
+
+  fs.writeFileSync(path.join(dirName, 'settings.yml'), YAML.stringify(settings))
+
+  consola.success(`Your local checkly directory is now linked to the project ${project.id}`)
+}
+
+module.exports = link

--- a/test/commands/help.spec.js
+++ b/test/commands/help.spec.js
@@ -23,6 +23,7 @@ COMMANDS
   groups    Manage Groups
   help      display help for checkly
   init      Initialise a new Checkly Project
+  link      Link your checkly directory with an existing project
   login     Login with a Checkly API Key
   logout    Logout and clear local conf
   projects  Manage Projects


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## ⚙️ Affected Components

- [x] Commands
- [x] Modules
- [ ] Services
- [ ] SDK
- [ ] Tests

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### 📝 Notes for the Reviewer

The `link` command allows users to link their local `checkly` directory with an existing project:
- The user can specify the target `projectId` as a command argument
- If the `projectId` is not set, the command will fetch the existing projects and prompt a list

> This command will only affect your local director (at least for now). It's only an interactive way to update project properties in the `global` settings file. Users will need to run `deploy` in order to impact changes in our DB state

> Resolves #153

