### PR TITLE
feat: add support for CheckGroups

### DIFF
--- a/checkly.config.js
+++ b/checkly.config.js
@@ -1,4 +1,4 @@
-const { Project, BrowserCheck, EmailAlertChannel } = require('./sdk/constructs')
+const { Project, BrowserCheck, EmailAlertChannel, CheckGroup } = require('./sdk/constructs')
 
 // Change the CHECK_ENV env variable to create different projects
 const environment = process.env.CHECK_ENV ?? 'prod'
@@ -25,6 +25,20 @@ const signupCheck = new BrowserCheck('signup', {
 // We track them because they belong to the check.
 // A downside is that when the check is removed, we remove the alert channel...
 project.addCheck(signupCheck)
+
+const loginCheck = new BrowserCheck('login', {
+  name: 'Login Check',
+  activated: true,
+  script: 'console.log("logging in")',
+})
+
+const checkGroup = new CheckGroup('my-group', {
+  name: 'Critical Checks',
+  checks: [loginCheck],
+})
+
+// Note that loginCheck is added automatically when the group is added.
+project.addCheckGroup(checkGroup)
 
 const emailAlertChannel2 = new EmailAlertChannel('email-again', {
   address: 'another-alert-channel@checklyhq.com',

--- a/sdk/constructs/Check.js
+++ b/sdk/constructs/Check.js
@@ -30,6 +30,7 @@ class Check extends Construct {
       locations: this.locations,
       tags: this.tags,
       frequency: this.frequency,
+      groupId: this.groupId,
     }
   }
 }

--- a/sdk/constructs/CheckGroup.js
+++ b/sdk/constructs/CheckGroup.js
@@ -1,0 +1,29 @@
+const Construct = require('./Construct')
+
+class CheckGroup extends Construct {
+  constructor (logicalId, props) {
+    super(logicalId)
+    this.name = props.name
+    this.activated = props.activated
+    this.muted = props.muted
+    this.tags = props.tags
+    this.locations = props.locations
+    this.checks = props.checks ?? []
+    this.checks.forEach(check => {
+      check.groupId = { ref: logicalId }
+    })
+    // TODO: Add additional fields
+  }
+
+  synthesize () {
+    return {
+      name: this.name,
+      activated: this.activated,
+      muted: this.muted,
+      tags: this.tags,
+      locations: this.locations,
+    }
+  }
+}
+
+module.exports = CheckGroup

--- a/sdk/constructs/index.js
+++ b/sdk/constructs/index.js
@@ -2,10 +2,12 @@ const EmailAlertChannel = require('./EmailAlertChannel')
 const Project = require('./Project')
 const BrowserCheck = require('./BrowserCheck')
 const ValidationError = require('./ValidationError')
+const CheckGroup = require('./CheckGroup')
 
 module.exports = {
   EmailAlertChannel,
   Project,
   BrowserCheck,
   ValidationError,
+  CheckGroup,
 }


### PR DESCRIPTION
This PR adds support for CheckGroups. 

Currently the groups need to be build bottom up. You first create the checks, then create a group containing the checks, then add it to the project:
```
const loginCheck = new BrowserCheck('login', {
  name: 'Login Check',
  script: 'console.log("logging in")',
})

const checkGroup = new CheckGroup('my-group', {
  name: 'Critical Checks',
  checks: [loginCheck],
})

// Note that loginCheck is added automatically when the group is added.
project.addCheckGroup(checkGroup)
```

It might be interesting to also allow the other way around, adding the `CheckGroup` to the checks:
```
const checkGroup = new CheckGroup('my-group', {
  name: 'Critical Checks',
})

const loginCheck = new BrowserCheck('login', {
  name: 'Login Check',
  script: 'console.log("logging in")',
  group: checkGroup
})
```