### PR TITLE
chore: read logs for ad-hoc run

### DIFF
--- a/checkly.config.js
+++ b/checkly.config.js
@@ -28,6 +28,13 @@ const signupCheck = new BrowserCheck('signup', {
 // A downside is that when the check is removed, we remove the alert channel...
 project.addCheck(signupCheck)
 
+const failingCheck = new BrowserCheck('fail', {
+  name: 'Failing Check',
+  activated: true,
+  script: 'throw new Error(\'Error during login\')',
+})
+project.addCheck(failingCheck)
+
 const loginCheck = new BrowserCheck('login', {
   name: 'Login Check',
   activated: true,

--- a/sdk/api/index.js
+++ b/sdk/api/index.js
@@ -1,3 +1,4 @@
+const assets = require('./modules/assets')
 const checks = require('./modules/checks')
 const groups = require('./modules/groups')
 const sockets = require('./modules/sockets')
@@ -16,11 +17,12 @@ function init ({ api, apiVersion = 'v1' }) {
     runtimes: runtimes({ api, apiVersion }),
 
     accounts: accounts({ api, apiVersion: 'next' }),
+    assets: assets({ api, apiVersion: 'next' }),
     projects: projects({ api, apiVersion: 'next' }),
-    sockets: sockets({ api, apiVersion: 'next' })
+    sockets: sockets({ api, apiVersion: 'next' }),
   }
 }
 
 module.exports = {
-  init
+  init,
 }

--- a/sdk/api/modules/assets.js
+++ b/sdk/api/modules/assets.js
@@ -1,0 +1,13 @@
+const PATH = 'assets'
+
+const assets = ({ api, apiVersion = 'next' }) => {
+  function get (assetType, region, key) {
+    return api.get(`/${apiVersion}/${PATH}/${assetType}/${region}/${encodeURIComponent(key)}`)
+  }
+
+  return {
+    get,
+  }
+}
+
+module.exports = assets

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -12,7 +12,7 @@ class RunCommand extends Command {
   static args = [{
     name: 'checkPath',
     required: false,
-    description: 'Which check would you like to execute?'
+    description: 'Which check would you like to execute?',
   }]
 
   async run () {
@@ -31,7 +31,7 @@ class RunCommand extends Command {
       consola.error(`Check not found, invalid check path ${checkPath}.`)
     }
 
-    check.checkType === CHECK_TYPES.BROWSER
+    check.checkType === CHECK_TYPES.BROWSER.toUpperCase()
       ? run.browserCheck({ check, location: flags.location })
       : run.apiCheck({ check, location: flags.location })
   }
@@ -42,8 +42,8 @@ RunCommand.flags = {
   location: flags.string({
     char: 'l',
     description: 'Where should the check run at?',
-    default: 'eu-central-1'
-  })
+    default: 'eu-central-1',
+  }),
 }
 
 RunCommand.description = 'Run and test your checks on Checkly'


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

### 📝 Notes for the Reviewer
When the CLI was created, logs for ad-hoc BCR's were published over websocket. This has changed, though. This PR updates the CLI  to fetch logs for BCR's from the new public assets API https://github.com/checkly/checkly-backend/pull/3700.

For now, it simply prints the logs with a `console.log` statement. More work will be needed to nicely print the check result.
