### PR TITLE
fix: pass groupId as a subscription as well [sc-0]

### DIFF
--- a/examples/simple-project/checkly.config.js
+++ b/examples/simple-project/checkly.config.js
@@ -2,7 +2,9 @@
 const path = require('path')
 const { constructs } = require('@checkly/cli')
 
-const { CheckGroup } = constructs
+const { CheckGroup, SmsAlertChannel } = constructs
+
+const smsChannel = new SmsAlertChannel('sms-channel', {phoneNumber: '0125'})
 
 const browser = new CheckGroup('group-1', {
   name: 'simple-check-1',
@@ -11,5 +13,6 @@ const browser = new CheckGroup('group-1', {
   activated: true,
   runtimeId: '2022.10',
   locations: ['eu-central-1'],
+  alertChannels: [smsChannel],
   pattern: '**/*.checkly.js'
 })

--- a/package/src/constructs/alert-channel-subscription.ts
+++ b/package/src/constructs/alert-channel-subscription.ts
@@ -27,6 +27,7 @@ export class AlertChannelSubscription extends Construct {
     return {
       alertChannelId: this.alertChannelId,
       checkId: this.checkId,
+      groupId: this.groupId,
       activated: this.activated,
     }
   }


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

### Notes for the reviewer
Pass groupId in the alert subscription as well