### PR TITLE
chore: add workflow for publishing to npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,16 @@
+name: Publish Package to npmjs
+on: workflow_dispatch
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci --workspace package
+      - run: npm publish --workspace package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/examples/simple-project/package.json
+++ b/examples/simple-project/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@checkly/cli": "0.0.1"
+    "@checkly/cli": "*"
   },
   "author": "",
   "license": "ISC",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@checkly/cli": "0.0.1"
+        "@checkly/cli": "*"
       }
     },
     "node_modules/@checkly/cli": {
@@ -10356,7 +10356,7 @@
     },
     "package": {
       "name": "@checkly/cli",
-      "version": "0.0.1",
+      "version": "0.3.0-alpha1",
       "license": "Apache-2.0",
       "dependencies": {
         "@oclif/core": "1.21.0",
@@ -22836,7 +22836,7 @@
     "simple-project": {
       "version": "file:examples/simple-project",
       "requires": {
-        "@checkly/cli": "0.0.1"
+        "@checkly/cli": "*"
       }
     },
     "sisteransi": {

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@checkly/cli",
-  "version": "0.0.1",
+  "version": "0.3.0-alpha1",
   "description": "Checkly CLI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

### Notes for the reviewer

Adds a simple workflow dispatch job based on [GH Action docs](https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages). 

We also had a more sophisticated GH Action before - [here](https://github.com/checkly/checkly-cli/blob/947bc829b43cfabf37ff7e1b13cadf6e334a96a5/.github/workflows/release.yml). I think that it makes sense to use a simpler setup for now, though.