### PR TITLE
chore: add readme to package

### DIFF
--- a/package/README.md
+++ b/package/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@checkly/cli",
-  "version": "0.3.0-alpha1",
+  "version": "0.3.0-alpha2",
   "description": "Checkly CLI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

### Notes for the reviewer
The top-level README isn't being published to NPM packages. This PR adds a symlink, which should hopefully fix this.
