### PR TITLE
chore: improve NPM release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,10 @@
 name: Publish Package to npmjs
-on: workflow_dispatch
+on:
+  release:
+    types: [created]
 jobs:
   build:
+    if: ${{ github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -16,3 +19,29 @@ jobs:
       - run: npm publish --workspace package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # Slack failure alert
+      - name: Slack Failure Notification
+        if: ${{ failure() }}
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_USERNAME: Checkly Github Bot
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_CHANNEL: proj-local-workflow
+          SLACK_ICON: https://github.com/checkly.png?size=48
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_TITLE: ':red_circle: NPM release failed'
+          SLACK_MESSAGE: by ${{ github.actor }}
+          SLACK_FOOTER: ''
+      # Slack success alert
+      - name: Slack Success Notification
+        if: ${{ success() }}
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_USERNAME: Checkly Github Bot
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_CHANNEL: proj-local-workflow
+          SLACK_ICON: https://github.com/checkly.png?size=48
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_TITLE: ':white_check_mark: NPM release succeeded'
+          SLACK_MESSAGE: by ${{ github.actor }}
+          SLACK_FOOTER: ''

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # checkly-cli
 
+## Running locally
+
 To run the project locally, use:
 ```
 ./bin/dev help
@@ -17,3 +19,9 @@ npm run lint --workspace package
 ```
 
 When running commands from the `package` directory, the `--workspace package` flag isn't necessary.
+
+## Releasing
+
+To release the project to NPM, create a new release in GitHub [here](https://github.com/checkly/checkly-cli/releases/new).
+
+This new tag will then automatically be released by the corresponding GitHub action [here](https://github.com/checkly/checkly-cli/actions/workflows/release.yml).

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@checkly/cli",
-  "version": "0.3.0-alpha3",
+  "version": "0.3.0-alpha4",
   "description": "Checkly CLI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

### Notes for the reviewer
GitHub releases are useful since they automatically create a git tag and they let us publish release notes. This PR switches our release action to be triggered by GitHub releases. It also adds a slack notification and a brief update in the CONTRIBUTING.md.