### PR TITLE
fix: handle null case for check group

### DIFF
--- a/package/src/commands/test.ts
+++ b/package/src/commands/test.ts
@@ -23,8 +23,10 @@ export default class Test extends Command {
     const checks = Object.entries(checksMap).map(([key, check]) => {
       check.logicalId = key
       // TODO: Add the group to check in a cleaner form
-      check.group = groupsMap[check.groupId.ref]
-      delete check.groupId
+      if (check.groupId) {
+        check.group = groupsMap[check.groupId.ref]
+        delete check.groupId
+      }
       return check
     })
     const reporter = new ListReporter(checks)


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

### Notes for the reviewer
Running `checkly test` on checks without a group currently fails with: _TypeError: Cannot read property 'ref' of undefined_. This PR fixes this by properly handling the case where a check isn't in a group.
