### PR TITLE
chore: update release docs and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,6 @@ jobs:
           cache: "npm"
           cache-dependency-path: package-lock.json
       - run: npm config set fund false && npm set audit false
-      - run: npm install --workspaces
+      - run: npm ci --workspaces
       - run: npm run lint --workspace package
       - run: npm run test --workspace package

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,9 @@ Make sure you are on the same NodeJS version if you are using `nvm` or `fnm`
 
 ## Releasing
 
-To release the project to NPM, create a new release in GitHub [here](https://github.com/checkly/checkly-cli/releases/new).
+To release the project to NPM:
 
-This new tag will then automatically be released by the corresponding GitHub action [here](https://github.com/checkly/checkly-cli/actions/workflows/release.yml).
+1. Update the `version` field in [package/package.json](./package/package.json)
+2. Create a new release in GitHub [here](https://github.com/checkly/checkly-cli/releases/new)
+
+The new version will then automatically be released by the corresponding GitHub action [here](https://github.com/checkly/checkly-cli/actions/workflows/release.yml).


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

### Notes for the reviewer
When releasing, we need to update the package version in `package.json` by hand. This PR adds that to the docs to make the process more clear.

To detect issues in the `package-lock.json` early, we also switch to `npm ci` in the Test GitHub Action.