### PR TITLE
fix: set default value for activated

### DIFF
--- a/examples/simple-project/src/services/__checks__/search-service.check.js
+++ b/examples/simple-project/src/services/__checks__/search-service.check.js
@@ -11,8 +11,6 @@ new BrowserCheck('search-service-check', {
   code: {
     entrypoint: path.join(__dirname, 'search-service.spec.js')
   },
-  activated: true,
-  muted: false,
 })
 
 // We can define multiple checks in a single *.check.js file.
@@ -21,6 +19,4 @@ new BrowserCheck('search-selection-check', {
   code: {
     entrypoint: path.join(__dirname, 'search-selection.spec.js')
   },
-  activated: true,
-  muted: false,
 })

--- a/package/src/constructs/check.ts
+++ b/package/src/constructs/check.ts
@@ -43,7 +43,9 @@ export abstract class Check extends Construct {
     Check.applyDefaultCheckConfig(props)
     // TODO: Throw an error if required properties are still missing after applying the defaults.
     this.name = props.name
-    this.activated = props.activated
+    // `activated` is required by the server side schema.
+    // Until the server side is changed to set a default value rather than throw an error, we set a default value here.
+    this.activated = props.activated ?? true
     this.muted = props.muted
     this.doubleCheck = props.doubleCheck
     this.shouldFail = props.shouldFail

--- a/package/src/services/project-parser.ts
+++ b/package/src/services/project-parser.ts
@@ -85,11 +85,9 @@ function loadAllBrowserChecks (
     }
     const browserCheck = new BrowserCheck(relPath, {
       name: path.basename(checkFile),
-      activated: true, // TODO: Set an appropriate default for `activated` at the API level with Joi, then remove this.
       code: {
         entrypoint: checkFile,
       },
-      // TODO: Apply the base configuration
     })
   }
 }


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

### Notes for the reviewer
Currently it's necessary to set `activated` for checks. Otherwise, deploying fails with a Joi validation error https://github.com/checkly/checkly-cli/pull/344#issuecomment-1367364193.

This PR sets a default of `true` for `activated`. I also opened a PR to fix this on the backend by setting the default there instead.