### PR TITLE
fix: correctly detect missing ts-node/typescript dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ First, install the CLI.
 npm i --save-dev @checkly/cli 
 ```
 
+To use TypeScript, also install `ts-node` and `typescript`:
+
+```bash
+npm i --save-dev ts-node typescript
+```
+
 Create a `checkly.config.js` (or `checkly.config.ts`) at the root of your project.
 
 ```js

--- a/package/src/services/util.ts
+++ b/package/src/services/util.ts
@@ -41,6 +41,7 @@ export async function loadTsFile (filepath: string): Promise<any> {
   return exported
 }
 
+// To avoid a dependency on typescript for users with no TS checks, we need to dynamically import ts-node
 let tsCompiler: Service
 async function getTsCompiler (): Promise<Service> {
   if (tsCompiler) return tsCompiler
@@ -52,9 +53,10 @@ async function getTsCompiler (): Promise<Service> {
       },
     })
   } catch (err: any) {
-    if (err.code === 'ERR_MODULE_NOT_FOUND') {
+    if (err.code === 'ERR_MODULE_NOT_FOUND' || err.code === 'MODULE_NOT_FOUND') {
       throw new Error('Please install ts-node and typescript to use TypeScript configuration files')
     }
+    throw err
   }
   return tsCompiler
 }


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

### Notes for the reviewer

Resolves #338 and Resolves #325

To support projects with TypeScript (either in the configuration files or in Browser Check Playwright files) - we need `typescript` and `ts-node`. We could simply add these to the `package.json`, but that would be a large dependency and might be inconvenient for users who just use plain JS. With this PR, we import TypeScript dependencies lazily - so that they're only needed for projects actually using TypeScript. 

Users with TypeScript files should run `npm install --save-dev ts-node typescript`. If a missing TypeScript dependency is detected, we return a clear error.

When parsing a `checkly.config.ts` file, the error is:
```
$ npx checkly test
    Error: Please install ts-node and typescript to use TypeScript configuration files
```

If the config files are in JS, but a Playwright file is using TypeScript, the error is:
```
$ npx checkly test
    Error: Encountered an error parsing check files for
    /Users/clample/projects/checkly-cli/examples/typescript-project/src/__checks__/demo.spec.ts.

    The following files couldn't be parsed:
        /Users/clample/projects/checkly-cli/examples/typescript-project/src/__checks__/demo.spec.ts - Please
    install typescript to use TypeScript in check files
 ```