### PR TITLE
chore: rename checkMatch to testMatch [sc-0]

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ const config = {
     checkMatch: '**/*.check.js',
     browserChecks: {
       frequency: 10,
-      checkMatch: '**/*.spec.js',
+      testMatch: '**/*.spec.js',
     }
   },
   cli: {

--- a/examples/simple-project/checkly.config.js
+++ b/examples/simple-project/checkly.config.js
@@ -7,7 +7,7 @@ const config = {
     runtimeId: '2022.10',
     checkMatch: '**/*.check.js',
     browserChecks: {
-      checkMatch: '**/__checks__/*.spec.js',
+      testMatch: '**/__checks__/*.spec.js',
     },
   },
   cli: {

--- a/examples/simple-project/src/__checks__/simple.spec.js
+++ b/examples/simple-project/src/__checks__/simple.spec.js
@@ -1,4 +1,4 @@
-// This file matches browserChecks.checkMatch, so it will automatically be turned into a browser check
+// This file matches browserChecks.testMatch, so it will automatically be turned into a browser check
 
 // Require two other files
 const dep1 = require('./dep1')

--- a/package/src/commands/deploy.ts
+++ b/package/src/commands/deploy.ts
@@ -36,7 +36,7 @@ export default class Deploy extends Command {
       projectName: checklyConfig.projectName,
       repoUrl: checklyConfig.repoUrl,
       checkMatch: checklyConfig.checks?.checkMatch,
-      browserCheckMatch: checklyConfig.checks?.browserChecks?.checkMatch,
+      browserCheckMatch: checklyConfig.checks?.browserChecks?.testMatch,
       ignoreDirectoriesMatch: checklyConfig.checks?.ignoreDirectoriesMatch,
       checkDefaults: checklyConfig.checks,
       browserCheckDefaults: checklyConfig.checks?.browserChecks,

--- a/package/src/commands/test.ts
+++ b/package/src/commands/test.ts
@@ -79,7 +79,7 @@ export default class Test extends Command {
       projectName: checklyConfig.projectName,
       repoUrl: checklyConfig.repoUrl,
       checkMatch: checklyConfig.checks?.checkMatch,
-      browserCheckMatch: checklyConfig.checks?.browserChecks?.checkMatch,
+      browserCheckMatch: checklyConfig.checks?.browserChecks?.testMatch,
       ignoreDirectoriesMatch: checklyConfig.checks?.ignoreDirectoriesMatch,
       checkDefaults: checklyConfig.checks,
       browserCheckDefaults: checklyConfig.checks?.browserChecks,

--- a/package/src/services/checkly-config-loader.ts
+++ b/package/src/services/checkly-config-loader.ts
@@ -28,7 +28,7 @@ export type ChecklyConfig = {
     checkMatch?: string,
     ignoreDirectoriesMatch?: string[],
     browserChecks?: CheckConfigDefaults & {
-      checkMatch?: string,
+      testMatch?: string,
     },
   },
   cli?: {


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

### Notes for the reviewer
Rename `checkMatch` for the `browser` block to `testMatch`