### PR TITLE
chore: remove check.activated default

### DIFF
--- a/package/src/constructs/check.ts
+++ b/package/src/constructs/check.ts
@@ -44,9 +44,7 @@ export abstract class Check extends Construct {
     Check.applyDefaultCheckConfig(props)
     // TODO: Throw an error if required properties are still missing after applying the defaults.
     this.name = props.name
-    // `activated` is required by the server side schema.
-    // Until the server side is changed to set a default value rather than throw an error, we set a default value here.
-    this.activated = props.activated ?? true
+    this.activated = props.activated
     this.muted = props.muted
     this.doubleCheck = props.doubleCheck
     this.shouldFail = props.shouldFail


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

### Notes for the reviewer
A default value for `check.activated` is now set on the server side. We can safely remove this default value in the client.