### PR TITLE
chore: report cli version in http headers

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -35,6 +35,7 @@
     ],
     "hooks": {
       "prerun": [
+        "./dist/hooks/configure-api-client",
         "./dist/hooks/auth-check"
       ]
     }

--- a/package/src/hooks/configure-api-client.ts
+++ b/package/src/hooks/configure-api-client.ts
@@ -1,0 +1,14 @@
+import { Hook } from '@oclif/core'
+import { api } from '../rest/api'
+
+// eslint-disable-next-line require-await
+const hook: Hook.Prerun = async function ({ config: oclifConfig }) {
+  api.interceptors.request.use((config) => {
+    if (config.headers) {
+      config.headers['x-checkly-cli-version'] = oclifConfig.version
+    }
+    return config
+  })
+}
+
+export default hook

--- a/package/src/hooks/configure-api-client.ts
+++ b/package/src/hooks/configure-api-client.ts
@@ -3,12 +3,7 @@ import { api } from '../rest/api'
 
 // eslint-disable-next-line require-await
 const hook: Hook.Prerun = async function ({ config: oclifConfig }) {
-  api.interceptors.request.use((config) => {
-    if (config.headers) {
-      config.headers['x-checkly-cli-version'] = oclifConfig.version
-    }
-    return config
-  })
+  api.defaults.headers['x-checkly-cli-version'] = oclifConfig.version
 }
 
 export default hook

--- a/package/src/rest/api.ts
+++ b/package/src/rest/api.ts
@@ -8,6 +8,8 @@ import Assets from './assets'
 import Runtimes from './runtimes'
 import PrivateLocations from './private-locations'
 
+import { Config } from '@oclif/core'
+
 export function getDefaults () {
   const environments = {
     production: {
@@ -55,7 +57,7 @@ function init (): AxiosInstance {
 
   return api
 }
-const api = init()
+export const api = init()
 
 export const accounts = new Accounts(api)
 export const projects = new Projects(api)


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

### Notes for the reviewer
Knowing which agents are in-use could be helpful for making product decisions. This PR adds a `x-checkly-cli-version` header which will be incldued on requests to the Checkly backend.