### PR TITLE
chore: include account information in deploy logs

### DIFF
--- a/package/src/commands/deploy.ts
+++ b/package/src/commands/deploy.ts
@@ -62,7 +62,7 @@ export default class Deploy extends Command {
 
     try {
       await api.projects.deploy(project.synthesize(), { dryRun: preview })
-      console.info(`Successfully deployed project ${project.name} to account "${account.name}."`)
+      console.info(`Successfully deployed project "${project.name}" to account "${account.name}".`)
     } catch (err: any) {
       if (err?.response?.status === 400) {
         console.error(`Failed to deploy the project due to a missing field. ${err.response.data.message}`)


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

### Notes for the reviewer
As suggested in https://github.com/checkly/checkly-cli/issues/372, it would be nice to let users now the name of the project that they're deploying to with `checkly deploy`. This avoids the need for them to run an extra `whoami` command.

This PR adds the logging with an extra call to the accounts API. 
```
$ npx checkly deploy
? You are about to deploy your project "Simple Project" to account "chris@checklyhq.com". Do you want to continue? Yes
Successfully deployed project "Simple Project" to account "chris@checklyhq.com".
```

Resolved #372 