### PR TITLE
feat: support checkly test on private locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,10 +367,10 @@ This very powerful when combined with passing environment variables using one of
 can target staging, test and preview environment with specific URLs, credentials and other common variables that differ 
 between environments.
 
-- `--env <key=value>` or `-e`: Pass environment variables to the check execution runtime. Variables passed here overwrite
+- `--env <key=value>` or `-e`: Pass environment variables to the check execution runtime. Variables passed here overwrite any existing variables stored in your Checkly account.
 - `--grep <pattern>` or `-g`: Only run checks where the check name matches a regular expression.
 - `--location <location>` or `-l`: Run checks against a specified location, e.g. `eu-west-1`. Defaults to `us-east-1`.
-any existing variables stored in your Checkly account.
+- `--private-location <private location ID>`: Run checks against the specified private location.
 - `--env-file`: You can read variables from a `.env` file by passing the file path e.g. `--env-file="./.env"`
 
 ### `npx checkly deploy`

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
     },
     "examples/typescript-project": {
       "version": "0.0.0",
+      "extraneous": true,
       "license": "ISC",
       "devDependencies": {
         "@checkly/cli": "*",
@@ -2184,22 +2185,6 @@
       "integrity": "sha512-KX8gMYA9ujBPOd1HFsV9e0iEx7Uoj8AG/3YsW4TtWQTg4lJvr82qNm7o/cFQfYRIt+jw7Ew/4oL4A22zOT+IRA==",
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@playwright/test": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.29.1.tgz",
-      "integrity": "sha512-iQxk2DX5U9wOGV3+/Jh9OHPsw5H3mleUL2S4BgQuwtlAfK3PnKvn38m4Rg9zIViGHVW24opSm99HQm/UFLEy6w==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "playwright-core": "1.29.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -9897,18 +9882,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/playwright-core": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.29.1.tgz",
-      "integrity": "sha512-20Ai3d+lMkWpI9YZYlxk8gxatfgax5STW8GaMozAHwigLiyiKQrdkt7gaoT9UQR8FIVDg6qVXs9IoZUQrDjIIg==",
-      "dev": true,
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -10817,10 +10790,6 @@
       "engines": {
         "node": ">=4.2.0"
       }
-    },
-    "node_modules/typescript-project": {
-      "resolved": "examples/typescript-project",
-      "link": true
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
@@ -16814,16 +16783,6 @@
       "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-3.0.3.tgz",
       "integrity": "sha512-KX8gMYA9ujBPOd1HFsV9e0iEx7Uoj8AG/3YsW4TtWQTg4lJvr82qNm7o/cFQfYRIt+jw7Ew/4oL4A22zOT+IRA=="
     },
-    "@playwright/test": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.29.1.tgz",
-      "integrity": "sha512-iQxk2DX5U9wOGV3+/Jh9OHPsw5H3mleUL2S4BgQuwtlAfK3PnKvn38m4Rg9zIViGHVW24opSm99HQm/UFLEy6w==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "playwright-core": "1.29.1"
-      }
-    },
     "@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -22587,12 +22546,6 @@
         }
       }
     },
-    "playwright-core": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.29.1.tgz",
-      "integrity": "sha512-20Ai3d+lMkWpI9YZYlxk8gxatfgax5STW8GaMozAHwigLiyiKQrdkt7gaoT9UQR8FIVDg6qVXs9IoZUQrDjIIg==",
-      "dev": true
-    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -23244,15 +23197,6 @@
       "version": "4.9.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
       "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg=="
-    },
-    "typescript-project": {
-      "version": "file:examples/typescript-project",
-      "requires": {
-        "@checkly/cli": "*",
-        "@playwright/test": "1.29.1",
-        "ts-node": "10.9.1",
-        "typescript": "4.9.4"
-      }
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package/src/commands/test.ts
+++ b/package/src/commands/test.ts
@@ -146,17 +146,17 @@ export default class Test extends Command {
     await runner.run()
   }
 
-  async prepareRunLocation (publicLocation: string, privateLocation?: string): Promise<RunLocation> {
-    if (!privateLocation) {
+  async prepareRunLocation (publicLocation: string, privateLocationSlugName?: string): Promise<RunLocation> {
+    if (!privateLocationSlugName) {
       return { type: 'PUBLIC', region: publicLocation }
     }
     const { data: privateLocations } = await api.privateLocations.getAll()
-    const hasPrivateLocation = privateLocations.some(({ slugName }) => slugName === privateLocation)
-    if (hasPrivateLocation) {
-      return { type: 'PRIVATE', slugName: privateLocation }
+    const privateLocation = privateLocations.find(({ slugName }) => slugName === privateLocationSlugName)
+    if (privateLocation) {
+      return { type: 'PRIVATE', id: privateLocation.id, slugName: privateLocationSlugName }
     }
     // We can use a null-assertion operator safely since account ID was validated in auth-check hook
     const { data: account } = await api.accounts.get(config.getAccountId()!)
-    this.error(`The specified private location ${privateLocation} was not found on account "${account.name}".`, { exit: 1 })
+    this.error(`The specified private location ${privateLocationSlugName} was not found on account "${account.name}".`, { exit: 1 })
   }
 }

--- a/package/src/commands/test.ts
+++ b/package/src/commands/test.ts
@@ -157,6 +157,6 @@ export default class Test extends Command {
     }
     // We can use a null-assertion operator safely since account ID was validated in auth-check hook
     const { data: account } = await api.accounts.get(config.getAccountId()!)
-    this.error(`The specified private location ${privateLocationSlugName} was not found on account "${account.name}".`, { exit: 1 })
+    this.error(`The specified private location "${privateLocationSlugName}" was not found on account "${account.name}".`, { exit: 1 })
   }
 }

--- a/package/src/commands/test.ts
+++ b/package/src/commands/test.ts
@@ -3,11 +3,12 @@ import { Command, Flags } from '@oclif/core'
 import { parse } from 'dotenv'
 import { isCI } from 'ci-info'
 
-import { runtimes } from '../rest/api'
+import * as api from '../rest/api'
+import config from '../services/config'
 import ListReporter from '../reporters/list'
 import CiReporter from '../reporters/ci'
 import { parseProject } from '../services/project-parser'
-import CheckRunner, { Events } from '../services/check-runner'
+import CheckRunner, { Events, RunLocation } from '../services/check-runner'
 import { loadChecklyConfig } from '../services/checkly-config-loader'
 import { filterByFileNamePattern, filterByCheckNamePattern } from '../services/test-filters'
 import type { Runtime } from '../rest/runtimes'
@@ -28,6 +29,10 @@ export default class Test extends Command {
       char: 'l',
       description: 'The location to run the checks at.',
       default: 'eu-central-1',
+    }),
+    'private-location': Flags.string({
+      description: 'The private location to run checks at.',
+      exclusive: ['location'],
     }),
     grep: Flags.string({
       char: 'g',
@@ -63,16 +68,18 @@ export default class Test extends Command {
   async run (): Promise<void> {
     const { flags, argv: filePatterns } = await this.parse(Test)
     const {
-      location,
+      location: publicLocation,
+      'private-location': privateLocation,
       grep,
       env,
       'env-file': envFile,
     } = flags
     const cwd = process.cwd()
+    const location = await this.prepareRunLocation(publicLocation, privateLocation)
 
     const testEnvVars = await getEnvs(envFile, env)
     const checklyConfig = await loadChecklyConfig(cwd)
-    const { data: avilableRuntimes } = await runtimes.getAll()
+    const { data: avilableRuntimes } = await api.runtimes.getAll()
     const project = await parseProject({
       directory: cwd,
       projectLogicalId: checklyConfig.logicalId,
@@ -137,5 +144,19 @@ export default class Test extends Command {
     })
     runner.on(Events.RUN_FINISHED, () => reporter.onEnd())
     await runner.run()
+  }
+
+  async prepareRunLocation (publicLocation: string, privateLocation?: string): Promise<RunLocation> {
+    if (!privateLocation) {
+      return { type: 'PUBLIC', region: publicLocation }
+    }
+    const { data: privateLocations } = await api.privateLocations.getAll()
+    const hasPrivateLocation = privateLocations.some(({ slugName }) => slugName === privateLocation)
+    if (hasPrivateLocation) {
+      return { type: 'PRIVATE', slugName: privateLocation }
+    }
+    // We can use a null-assertion operator safely since account ID was validated in auth-check hook
+    const { data: account } = await api.accounts.get(config.getAccountId()!)
+    this.error(`The specified private location ${privateLocation} was not found on account "${account.name}".`, { exit: 1 })
   }
 }

--- a/package/src/reporters/abstract-list.ts
+++ b/package/src/reporters/abstract-list.ts
@@ -3,17 +3,18 @@ import * as indentString from 'indent-string'
 
 import { Reporter } from './reporter'
 import { formatCheckTitle, CheckStatus } from './util'
+import type { RunLocation } from '../services/check-runner'
 
 export default abstract class AbstractListReporter implements Reporter {
   _clearString = ''
-  runLocation: string
+  runLocation: RunLocation
   // Map from file -> check logicalId -> check+result.
   // This lets us print a structured list of the checks.
   // Map remembers the original insertion order, so each time we print the summary will be consistent.
   checkFilesMap: Map<string, Map<string, { check?: any, result?: any, titleString: string }>>
   numChecks: number
 
-  constructor (runLocation: string, checks: Array<any>) {
+  constructor (runLocation: RunLocation, checks: Array<any>) {
     this.numChecks = checks.length
     this.runLocation = runLocation
 
@@ -80,5 +81,13 @@ export default abstract class AbstractListReporter implements Reporter {
     console.log(statusString)
     // Ansi escape code for erasing the line and moving the cursor up
     this._clearString = '\r\x1B[K\r\x1B[1A'.repeat(statusString.split('\n').length + 1)
+  }
+
+  _runLocationString (): string {
+    if (this.runLocation.type === 'PUBLIC') {
+      return this.runLocation.region
+    } else {
+      return `private location ${this.runLocation.slugName}`
+    }
   }
 }

--- a/package/src/reporters/ci.ts
+++ b/package/src/reporters/ci.ts
@@ -5,7 +5,7 @@ import { formatCheckTitle, formatCheckResult, CheckStatus } from './util'
 
 export default class CiReporter extends AbstractListReporter {
   onBegin () {
-    console.log(`\nRunning ${this.numChecks} checks in ${this.runLocation}:\n`)
+    console.log(`\nRunning ${this.numChecks} checks in ${this._runLocationString()}:\n`)
     this._printSummary({ skipCheckCount: true })
   }
 

--- a/package/src/reporters/list.ts
+++ b/package/src/reporters/list.ts
@@ -5,7 +5,7 @@ import { formatCheckTitle, formatCheckResult, CheckStatus } from './util'
 
 export default class ListReporter extends AbstractListReporter {
   onBegin () {
-    console.log(`\nRunning ${this.numChecks} checks in ${this.runLocation}.\n`)
+    console.log(`\nRunning ${this.numChecks} checks in ${this._runLocationString()}.\n`)
     this._printSummary()
   }
 

--- a/package/src/rest/api.ts
+++ b/package/src/rest/api.ts
@@ -6,6 +6,7 @@ import Checks from './checks'
 import Sockets from './sockets'
 import Assets from './assets'
 import Runtimes from './runtimes'
+import PrivateLocations from './private-locations'
 
 export function getDefaults () {
   const environments = {
@@ -67,3 +68,4 @@ export const checks = new Checks(api)
 export const sockets = new Sockets(api)
 export const assets = new Assets(api)
 export const runtimes = new Runtimes(api)
+export const privateLocations = new PrivateLocations(api)

--- a/package/src/rest/private-locations.ts
+++ b/package/src/rest/private-locations.ts
@@ -1,0 +1,16 @@
+import type { AxiosInstance } from 'axios'
+
+interface PrivateLocation {
+  slugName: string
+}
+
+export default class PrivateLocations {
+  api: AxiosInstance
+  constructor (api: AxiosInstance) {
+    this.api = api
+  }
+
+  getAll () {
+    return this.api.get<Array<PrivateLocation>>('/v1/private-locations')
+  }
+}

--- a/package/src/rest/private-locations.ts
+++ b/package/src/rest/private-locations.ts
@@ -1,7 +1,8 @@
 import type { AxiosInstance } from 'axios'
 
 interface PrivateLocation {
-  slugName: string
+  slugName: string,
+  id: string,
 }
 
 export default class PrivateLocations {

--- a/package/src/services/check-runner.ts
+++ b/package/src/services/check-runner.ts
@@ -16,6 +16,7 @@ export enum Events {
 
 type PrivateRunLocation = {
   type: 'PRIVATE',
+  id: string,
   slugName: string,
 }
 type PublicRunLocation = {

--- a/package/src/services/check-runner.ts
+++ b/package/src/services/check-runner.ts
@@ -13,11 +13,22 @@ export enum Events {
   RUN_STARTED = 'RUN_STARTED',
   RUN_FINISHED = 'RUN_FINISHED'
 }
+
+type PrivateRunLocation = {
+  type: 'PRIVATE',
+  slugName: string,
+}
+type PublicRunLocation = {
+  type: 'PUBLIC',
+  region: string,
+}
+export type RunLocation = PublicRunLocation | PrivateRunLocation
+
 export default class CheckRunner extends EventEmitter {
   checks: any[]
-  location: string
+  location: RunLocation
   concurrency: number
-  constructor (checks: any[], location: string, concurrency = 5) {
+  constructor (checks: any[], location: RunLocation, concurrency = 5) {
     super()
     this.checks = checks
     this.location = location


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

### Notes for the reviewer
Relates to https://github.com/checkly/checkly-cli/issues/352 and https://github.com/checkly/checkly-cli/issues/386

This PR adds support for running checks on private locations for `checkly test`. The PR adds a `--private-location` flag that can be used to pass the slug name of a private location.

#### Error handling
Passing both `--location` and `--private-location`:
```
$ npx checkly test --location eu-central-1 --private-location test
 ›   Error: The following error occurred:
 ›     --location=eu-central-1 cannot also be provided when using --private-location
 ›   See more help with --help
```

Passing an invalid private location (gives non-zero status code)
```
$ npx checkly test --private-location test
 ›   Error: The specified private location test was not found on account "chris@checklyhq.com".
$ echo $?
1
```