### PR TITLE
feat: allow setting default run locations in checkly config

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ module.exports = config;
 ```
 
 - `checkMatch`: By default, Checkly looks for files matching `.*check\.(js|ts)`.
+- `cli`: Sets default values for command line flags. Command line flags can still be set to override the config file.
+  - `runLocation`: The default run location for `checkly test`
+  - `privateRunLocation`: A [private location](https://www.checklyhq.com/docs/private-locations/) for `checkly test`. Both `runLocation` and `privateRunLocation` can't be set at once.
 
 ## Local configuration
 

--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ module.exports = config;
 ```
 
 - `checkMatch`: By default, Checkly looks for files matching `.*check\.(js|ts)`.
-- `cli`: Sets default values for command line flags. Command line flags can still be set to override the config file.
+- `cli`: Sets default values for command line flags. Setting command line flags will still override these values.
   - `runLocation`: The default run location for `checkly test`.
-  - `privateRunLocation`: A [private location](https://www.checklyhq.com/docs/private-locations/) for `checkly test`. Both `runLocation` and `privateRunLocation` can't be set at once.
+  - `privateRunLocation`: A [private run location](https://www.checklyhq.com/docs/private-locations/) for `checkly test`. Both `runLocation` and `privateRunLocation` can't be set at once.
 
 ## Local configuration
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ module.exports = config;
 
 - `checkMatch`: By default, Checkly looks for files matching `.*check\.(js|ts)`.
 - `cli`: Sets default values for command line flags. Command line flags can still be set to override the config file.
-  - `runLocation`: The default run location for `checkly test`
+  - `runLocation`: The default run location for `checkly test`.
   - `privateRunLocation`: A [private location](https://www.checklyhq.com/docs/private-locations/) for `checkly test`. Both `runLocation` and `privateRunLocation` can't be set at once.
 
 ## Local configuration

--- a/package/src/commands/test.ts
+++ b/package/src/commands/test.ts
@@ -147,6 +147,7 @@ export default class Test extends Command {
     await runner.run()
   }
 
+  // eslint-disable-next-line require-await
   async prepareRunLocation (
     configOptions: { runLocation?: string, privateRunLocation?: string } = {},
     cliFlags: { runLocation?: string, privateRunLocation?: string },
@@ -158,7 +159,7 @@ export default class Test extends Command {
       return this.preparePrivateRunLocation(cliFlags.privateRunLocation)
     } else if (configOptions.runLocation && configOptions.privateRunLocation) {
       this.error(
-        'Both runLocation and privateRunLocation fields were set in the Checkly config file.' + 
+        'Both runLocation and privateRunLocation fields were set in the Checkly config file.' +
         ` Please only specify one run location. The configured locations were "${configOptions.runLocation}" and "${configOptions.privateRunLocation}"`,
         { exit: 1 },
       )

--- a/package/src/commands/test.ts
+++ b/package/src/commands/test.ts
@@ -8,10 +8,12 @@ import config from '../services/config'
 import ListReporter from '../reporters/list'
 import CiReporter from '../reporters/ci'
 import { parseProject } from '../services/project-parser'
-import CheckRunner, { Events, RunLocation } from '../services/check-runner'
+import CheckRunner, { Events, RunLocation, PrivateRunLocation } from '../services/check-runner'
 import { loadChecklyConfig } from '../services/checkly-config-loader'
 import { filterByFileNamePattern, filterByCheckNamePattern } from '../services/test-filters'
 import type { Runtime } from '../rest/runtimes'
+
+const DEFAULT_REGION = 'eu-central-1'
 
 async function getEnvs (envFile: string|undefined, envArgs: Array<string>) {
   if (envFile) {
@@ -28,7 +30,6 @@ export default class Test extends Command {
     location: Flags.string({
       char: 'l',
       description: 'The location to run the checks at.',
-      default: 'eu-central-1',
     }),
     'private-location': Flags.string({
       description: 'The private location to run checks at.',
@@ -68,17 +69,17 @@ export default class Test extends Command {
   async run (): Promise<void> {
     const { flags, argv: filePatterns } = await this.parse(Test)
     const {
-      location: publicLocation,
-      'private-location': privateLocation,
+      location: runLocation,
+      'private-location': privateRunLocation,
       grep,
       env,
       'env-file': envFile,
     } = flags
     const cwd = process.cwd()
-    const location = await this.prepareRunLocation(publicLocation, privateLocation)
 
     const testEnvVars = await getEnvs(envFile, env)
     const checklyConfig = await loadChecklyConfig(cwd)
+    const location = await this.prepareRunLocation(checklyConfig.cli, { runLocation, privateRunLocation })
     const { data: avilableRuntimes } = await api.runtimes.getAll()
     const project = await parseProject({
       directory: cwd,
@@ -146,10 +147,31 @@ export default class Test extends Command {
     await runner.run()
   }
 
-  async prepareRunLocation (publicLocation: string, privateLocationSlugName?: string): Promise<RunLocation> {
-    if (!privateLocationSlugName) {
-      return { type: 'PUBLIC', region: publicLocation }
+  async prepareRunLocation (
+    configOptions: { runLocation?: string, privateRunLocation?: string } = {},
+    cliFlags: { runLocation?: string, privateRunLocation?: string },
+  ): Promise<RunLocation> {
+    // Command line options take precedence
+    if (cliFlags.runLocation) {
+      return { type: 'PUBLIC', region: cliFlags.runLocation }
+    } else if (cliFlags.privateRunLocation) {
+      return this.preparePrivateRunLocation(cliFlags.privateRunLocation)
+    } else if (configOptions.runLocation && configOptions.privateRunLocation) {
+      this.error(
+        'Both runLocation and privateRunLocation fields were set in the Checkly config file.' + 
+        ` Please only specify one run location. The configured locations were "${configOptions.runLocation}" and "${configOptions.privateRunLocation}"`,
+        { exit: 1 },
+      )
+    } else if (configOptions.runLocation) {
+      return { type: 'PUBLIC', region: configOptions.runLocation }
+    } else if (configOptions.privateRunLocation) {
+      return this.preparePrivateRunLocation(configOptions.privateRunLocation)
+    } else {
+      return { type: 'PUBLIC', region: DEFAULT_REGION }
     }
+  }
+
+  async preparePrivateRunLocation (privateLocationSlugName: string): Promise<PrivateRunLocation> {
     const { data: privateLocations } = await api.privateLocations.getAll()
     const privateLocation = privateLocations.find(({ slugName }) => slugName === privateLocationSlugName)
     if (privateLocation) {

--- a/package/src/services/check-runner.ts
+++ b/package/src/services/check-runner.ts
@@ -14,12 +14,12 @@ export enum Events {
   RUN_FINISHED = 'RUN_FINISHED'
 }
 
-type PrivateRunLocation = {
+export type PrivateRunLocation = {
   type: 'PRIVATE',
   id: string,
   slugName: string,
 }
-type PublicRunLocation = {
+export type PublicRunLocation = {
   type: 'PUBLIC',
   region: string,
 }

--- a/package/src/services/checkly-config-loader.ts
+++ b/package/src/services/checkly-config-loader.ts
@@ -33,6 +33,7 @@ export type ChecklyConfig = {
   },
   cli?: {
     runLocation?: string,
+    privateRunLocation?: string,
   }
 }
 


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

### Notes for the reviewer
Closes https://github.com/checkly/checkly-cli/issues/352

This PR adds support for `cli.runLocation` and `cli.privateRunLocation` in the checkly config file. These default locations will then be used for `checkly test` runs.
