### PR TITLE
chore: remove unused API path config

### DIFF
--- a/package/src/rest/api.ts
+++ b/package/src/rest/api.ts
@@ -12,33 +12,28 @@ export function getDefaults () {
   const environments = {
     production: {
       apiUrl: 'https://api.checklyhq.com',
-      apiVersion: 'v1',
     },
 
     development: {
       apiUrl: 'http://localhost:3000',
-      apiVersion: 'v1',
     },
 
     test: {
       apiUrl: 'https://api-test.checklyhq.com',
-      apiVersion: 'v1',
     },
 
     staging: {
       apiUrl: 'https://api-test.checklyhq.com',
-      apiVersion: 'v1',
     },
   }
 
   const env = config.getEnv()
   const apiKey = config.getApiKey()
   const accountId = config.getAccountId()
-  const basePath = environments[env].apiVersion
   const baseURL = environments[env].apiUrl
   const Authorization = `Bearer ${apiKey}`
 
-  return { baseURL, basePath, accountId, Authorization }
+  return { baseURL, accountId, Authorization }
 }
 
 function init (): AxiosInstance {


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

### Notes for the reviewer
We don't actually use the `apiVersion` field. I think that it's not so useful and that we should just remove it.
