### PR TITLE
chore: add no-console linting

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -88,7 +88,8 @@
     "rules": {
       "@typescript-eslint/type-annotation-spacing": 2,
       "@typescript-eslint/no-explicit-any": 0,
-      "@typescript-eslint/ban-ts-comment": 0
+      "@typescript-eslint/ban-ts-comment": 0,
+      "no-console": 2
     },
     "extends": [
       "@checkly/eslint-config",
@@ -97,6 +98,14 @@
     "parser": "@typescript-eslint/parser",
     "plugins": [
       "@typescript-eslint"
+    ],
+    "overrides": [
+      {
+        "files": ["src/commands/*", "src/reporters/*"],
+        "rules": {
+          "no-console": 0
+        }
+      }
     ]
   },
   "jest": {

--- a/package/src/auth/index.ts
+++ b/package/src/auth/index.ts
@@ -89,6 +89,8 @@ export function startServer (codeVerifier: string): Promise<string> {
     })
 
     server.listen(4242).on('error', err => {
+      // TODO: Update error handling to not have a console.log here.
+      // eslint-disable-next-line no-console
       console.log('Unable to start an HTTP server on port 4242.', err)
       reject(err)
     })

--- a/package/src/services/config.ts
+++ b/package/src/services/config.ts
@@ -1,3 +1,5 @@
+// TODO: Update error handling to not print to the console and exit from this file.
+/* eslint-disable no-console */
 import Conf from 'conf'
 
 import type { Runtime } from '../rest/runtimes'


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

### Notes for the reviewer
Relates to https://github.com/checkly/checkly-cli/issues/395

This PR adds the [no-console](https://eslint.org/docs/latest/rules/no-console) lint, with exceptions for the `commands` and `reporters` directories. This should make sure that we keep user facing logs in these directories, rather than scattered throughout the codebase.

We already have logs (and `process.exit`) in two files, though. I left todo's in these files, and I'll fix the error handling here later on.
