### PR TITLE
fix: use constant number of MQTT topics for running checks

### DIFF
--- a/package/src/services/socket-client.ts
+++ b/package/src/services/socket-client.ts
@@ -24,6 +24,7 @@ export class SocketClient {
   /**
   * Subscribe to topics on the socket.
   * Due to implementation details, wildcards aren't supported.
+  * Note that AWS has a limit of 8 topics per subscribe request.
   */
   async subscribe (topicHandlers: Record<string, (message: any) => Promise<void>|void>): Promise<void> {
     for (const [topic, handler] of Object.entries(topicHandlers)) {


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

### Notes for the reviewer
Resolves https://github.com/checkly/checkly-cli/issues/400

Currently during `checkly test`, we use separate MQTT topics for reading the result of each check. With the number of MQTT topics scaling with the number of checks, the CLI hits the topic-subscriptions-per-connection limit of our MQTT provider when there are ~25 checks.

With this PR, the results for all checks come over the same MQTT topic. This then avoids reaching the MQTT limits when there are many checks. Since there are no longer separate topics per check, the CLI can no longer use this for correlating incoming messages with the corresponding check. Instead, the CLI will rely on the `logicalId` being passed in the incoming messages.

PR is marked as draft since changes are needed in the backend to support the `logicalId` being set in `sourceInfo`.