### PR TITLE
fix: use Checkly auth0 domain

### DIFF
--- a/package/src/auth/index.ts
+++ b/package/src/auth/index.ts
@@ -3,11 +3,10 @@ import * as os from 'os'
 import * as http from 'http'
 import * as crypto from 'crypto'
 
-const AUTH0_DOMAIN = 'checkly'
 const AUTH0_CLIENT_ID = 'mBtwLFVm39GVZ1HpSRBSdRiLFucYxmMb'
 
 export const generateAuthenticationUrl = (codeChallenge: string, scope: string, state: string) => {
-  const url = new URL(`https://${AUTH0_DOMAIN}.eu.auth0.com/authorize`)
+  const url = new URL('https://auth.checklyhq.com/authorize')
   const params = new URLSearchParams({
     client_id: AUTH0_CLIENT_ID,
     code_challenge: codeChallenge,
@@ -107,7 +106,7 @@ export async function getAccessToken (code: string, codeVerifier: string) {
   })
 
   const tokenResponse = await axios.post(
-    `https://${AUTH0_DOMAIN}.eu.auth0.com/oauth/token`,
+    'https://auth.checklyhq.com/oauth/token',
     tokenParams,
     {
       headers: {


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

### Notes for the reviewer
![image](https://user-images.githubusercontent.com/10483186/212654270-5c3b54fe-df42-406e-ba88-9e3288d08f40.png)


Currently logging in with `npx checkly login` and using GitHub OAuth fails. After logging in with GitHub, the webpage redirects to the error page shown above. The reason is that the initial `/authorize` request to Auth0 goes to `checkly.eu.auth0.com`, but the `/callback` call to Auth0 goes to `auth.checklyhq.com`. This setup isn't supported by Auth0 - both requests are required to same domain ([relevant forum post](https://community.auth0.com/t/you-may-have-pressed-the-back-button-but-i-really-didnt/23877/16)). 

To fix the issue, we can just use the `auth.checklyhq.com` domain. This is the one that's already used when you do a normal login from the Checkly webapp.

I've tested with GitHub OAuth, Email+Password, and Google OAuth.