### PR TITLE
feat: add query and header support for webhook alerts [sc-0]

### DIFF
--- a/package/src/constructs/api-check.ts
+++ b/package/src/constructs/api-check.ts
@@ -1,8 +1,6 @@
 import { Check, CheckProps } from './check'
-
-import KeyValuePair from './key-value-pair'
-export type QueryParamProps = KeyValuePair
-export type HeaderProps = KeyValuePair
+import { HttpHeader } from './http-header'
+import { QueryParam } from './query-param'
 export interface Assertion {
   source: string,
   property: string,
@@ -32,8 +30,8 @@ export interface Request {
   assertions: Array<Assertion>
   body?: string
   bodyType?: BodyType
-  headers?: Array<HeaderProps>
-  queryParameters?: Array<QueryParamProps>
+  headers?: Array<HttpHeader>
+  queryParameters?: Array<QueryParam>
   basicAuth?: BasicAuth
 }
 export interface ApiCheckProps extends CheckProps {

--- a/package/src/constructs/environment-variable.ts
+++ b/package/src/constructs/environment-variable.ts
@@ -1,13 +1,2 @@
 import KeyValuePair from './key-value-pair'
-export type EnvironmentVariableProps = KeyValuePair
-
-export class EnvironmentVariable {
-  key: string
-  value: string
-  locked: boolean
-  constructor (props: EnvironmentVariableProps) {
-    this.key = props.key
-    this.value = props.value
-    this.locked = props.locked || false
-  }
-}
+export type EnvironmentVariable = KeyValuePair

--- a/package/src/constructs/http-header.ts
+++ b/package/src/constructs/http-header.ts
@@ -1,0 +1,2 @@
+import KeyValuePair from './key-value-pair'
+export type HttpHeader = KeyValuePair

--- a/package/src/constructs/query-param.ts
+++ b/package/src/constructs/query-param.ts
@@ -1,0 +1,2 @@
+import KeyValuePair from './key-value-pair'
+export type QueryParam = KeyValuePair

--- a/package/src/constructs/webhook-alert-channel.ts
+++ b/package/src/constructs/webhook-alert-channel.ts
@@ -1,4 +1,6 @@
 import { AlertChannel, AlertChannelProps } from './alert-channel'
+import { HttpHeader } from './http-header'
+import { QueryParam } from './query-param'
 
 export interface WebhookAlertChannelProps extends AlertChannelProps {
   name: string
@@ -7,6 +9,8 @@ export interface WebhookAlertChannelProps extends AlertChannelProps {
   template?: string
   // We can create a http enum to be shared with api checks
   method?: string
+  headers?: Array<HttpHeader>
+  queryParameters?: Array<QueryParam>
 }
 
 export class WebhookAlertChannel extends AlertChannel {
@@ -15,6 +19,8 @@ export class WebhookAlertChannel extends AlertChannel {
   url: URL
   template?: string
   method?: string
+  headers?: Array<HttpHeader>
+  queryParameters?: Array<QueryParam>
   constructor (logicalId: string, props: WebhookAlertChannelProps) {
     super(logicalId, props)
     this.name = props.name
@@ -22,6 +28,8 @@ export class WebhookAlertChannel extends AlertChannel {
     this.url = props.url
     this.template = props.template
     this.method = props.method
+    this.headers = props.headers
+    this.queryParameters = props.queryParameters
     this.register(AlertChannel.__checklyType, logicalId, this.synthesize())
   }
 
@@ -35,6 +43,8 @@ export class WebhookAlertChannel extends AlertChannel {
         url: this.url,
         template: this.template,
         method: this.method,
+        headers: this.headers,
+        queryParameters: this.queryParameters,
       },
     }
   }


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

### Notes for the reviewer
* Add headers and query params to webhook alerts
* Turn env vars also into an interface given it was the only `KeyValuePair` that was a class