### PR TITLE
fix: dont assign defaults to browser check default [sc-0]

### DIFF
--- a/package/src/services/project-parser.ts
+++ b/package/src/services/project-parser.ts
@@ -46,7 +46,7 @@ export async function parseProject (opts: ProjectParseOpts): Promise<Project> {
   Session.project = project
   Session.basePath = directory
   Session.checkDefaults = Object.assign({}, BASE_CHECK_DEFAULTS, checkDefaults)
-  Session.browserCheckDefaults = Object.assign({}, BASE_CHECK_DEFAULTS, browserCheckDefaults)
+  Session.browserCheckDefaults = browserCheckDefaults
   Session.availableRuntimes = availableRuntimes
 
   // TODO: Do we really need all of the ** globs, or could we just put node_modules?


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

### Notes for the reviewer
Dont assign base defaults to browser check default. When a user sets a runtime in checkDefaults and leave it empty in browserCheckDefaults, the default will still kick in here