### PR TITLE
feat: add ES Modules support

### DIFF
--- a/package/src/services/__tests__/check-dependency-parser-fixtures/esmodules-example/dep1.js
+++ b/package/src/services/__tests__/check-dependency-parser-fixtures/esmodules-example/dep1.js
@@ -1,0 +1,2 @@
+export const value = 'Hello World'
+

--- a/package/src/services/__tests__/check-dependency-parser-fixtures/esmodules-example/dep2.js
+++ b/package/src/services/__tests__/check-dependency-parser-fixtures/esmodules-example/dep2.js
@@ -1,0 +1,2 @@
+const value = 'Another value'
+export default value

--- a/package/src/services/__tests__/check-dependency-parser-fixtures/esmodules-example/dep3.js
+++ b/package/src/services/__tests__/check-dependency-parser-fixtures/esmodules-example/dep3.js
@@ -1,0 +1,1 @@
+export const dep3 = 'Dependency 3'

--- a/package/src/services/__tests__/check-dependency-parser-fixtures/esmodules-example/entrypoint.js
+++ b/package/src/services/__tests__/check-dependency-parser-fixtures/esmodules-example/entrypoint.js
@@ -1,0 +1,5 @@
+export { value } from './dep1'
+import dep2 from './dep2'
+import { dep3 } from './dep3'
+
+console.log('Received ', dep2, dep3)

--- a/package/src/services/__tests__/check-dependency-parser.spec.ts
+++ b/package/src/services/__tests__/check-dependency-parser.spec.ts
@@ -89,6 +89,17 @@ describe('dependency-parser - parseDependencies()', () => {
     ])
   })
 
+  it('should handle ES Modules', () => {
+    const toAbsolutePath = (filename: string) => path.join(__dirname, 'check-dependency-parser-fixtures', 'esmodules-example', filename)
+    const parser = new Parser(defaultNpmModules)
+    const dependencies = parser.parseDependencies(toAbsolutePath('entrypoint.js'))
+    expect(dependencies.sort()).toEqual([
+      toAbsolutePath('dep1.js'),
+      toAbsolutePath('dep2.js'),
+      toAbsolutePath('dep3.js'),
+    ])
+  })
+
   /*
    * There is an unhandled edge-case when require() is reassigned.
    * Even though the check might execute fine, we throw an error for a missing dependency.


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

### Notes for the reviewer

Resolves https://github.com/checkly/checkly-cli/issues/426

This PR adds support for ES Modules `import`+`export` syntax. The backend already supports this since we run all check files (even JS files) through the TypeScript compiler, which then outputs commonJS. All that's needed is to detect dependencies which are imported with ES Modules in `check-dependency-parser`.

This will only generally work for runtimes >= 2022.10, since we don't always apply the TypeScript compiler. Testing on an older runtime gave the following error:
```
    ERROR, 5:45:02 PM, Failed to compile check script: /tmp/1kqb2b8lddbsuwy/src/services/docs/__checks__/docs-search.spec.js:1
     import { defaults } from './defaults'
     ^^^^^^

    SyntaxError: 'import' and 'export' may only appear at the top level
        at Object.<anonymous> (/tmp/1kqb2b8lddbsuwy/script.js:61:47)
        at Module._compile (internal/modules/cjs/loader.js:1085:14)
        at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
        at Module.load (internal/modules/cjs/loader.js:950:32)
```

It might make sense to add a better error message in the future. We could track the runtime version in `check-dependency-parser` and throw an error if we encounter an import expression. On the other hand, I'm not sure whether it's worth the extra effort.