### PR TITLE
fix: allow ts files to import js [sc-0]

### DIFF
--- a/package/src/constructs/browser-check.ts
+++ b/package/src/constructs/browser-check.ts
@@ -73,7 +73,7 @@ export class BrowserCheck extends Check {
       throw new Error(`${runtimeId} is not supported`)
     }
     const parser = new Parser(Object.keys(runtime.dependencies))
-    const parsed = parser.parseDependencies(entry)
+    const parsed = parser.parse(entry)
     // Maybe we can get the parsed deps with the content immediately
     const content = fs.readFileSync(entry, { encoding: 'utf8' })
 

--- a/package/src/services/check-parser/__tests__/check-parser-fixtures/typescript-example/dep4.js
+++ b/package/src/services/check-parser/__tests__/check-parser-fixtures/typescript-example/dep4.js
@@ -1,0 +1,3 @@
+export function subtract (num1, num2) {
+  return num1 - num2
+}

--- a/package/src/services/check-parser/__tests__/check-parser-fixtures/typescript-example/entrypoint.ts
+++ b/package/src/services/check-parser/__tests__/check-parser-fixtures/typescript-example/entrypoint.ts
@@ -1,4 +1,5 @@
 import { add } from './dep1'
+import { subtract as random } from './dep4'
 import { subtract } from './dep2'
 import * as axios from 'axios'
 

--- a/package/src/services/check-parser/__tests__/check-parser.spec.ts
+++ b/package/src/services/check-parser/__tests__/check-parser.spec.ts
@@ -7,17 +7,17 @@ const defaultNpmModules = [
   'jsonwebtoken', 'lodash', 'mocha', 'moment', 'otpauth', 'playwright', 'uuid',
 ]
 
-describe('dependency-parser - parseDependencies()', () => {
+describe('dependency-parser - parser()', () => {
   it('should handle JS file with no dependencies', () => {
     const parser = new Parser(defaultNpmModules)
-    const dependencies = parser.parseDependencies(path.join(__dirname, 'check-parser-fixtures', 'no-dependencies.js'))
+    const dependencies = parser.parse(path.join(__dirname, 'check-parser-fixtures', 'no-dependencies.js'))
     expect(dependencies).toHaveLength(0)
   })
 
   it('should handle JS file with dependencies', () => {
     const toAbsolutePath = (filename: string) => path.join(__dirname, 'check-parser-fixtures', 'simple-example', filename)
     const parser = new Parser(defaultNpmModules)
-    const dependencies = parser.parseDependencies(toAbsolutePath('entrypoint.js'))
+    const dependencies = parser.parse(toAbsolutePath('entrypoint.js'))
     expect(dependencies.sort()).toEqual([
       toAbsolutePath('dep1.js'),
       toAbsolutePath('dep2.js'),
@@ -29,7 +29,7 @@ describe('dependency-parser - parseDependencies()', () => {
     const missingEntrypoint = path.join(__dirname, 'check-parser-fixtures', 'does-not-exist.js')
     try {
       const parser = new Parser(defaultNpmModules)
-      parser.parseDependencies(missingEntrypoint)
+      parser.parse(missingEntrypoint)
     } catch (err) {
       expect(err).toMatchObject({ missingFiles: [missingEntrypoint] })
     }
@@ -39,7 +39,7 @@ describe('dependency-parser - parseDependencies()', () => {
     const toAbsolutePath = (filename: string) => path.join(__dirname, 'check-parser-fixtures', filename)
     try {
       const parser = new Parser(defaultNpmModules)
-      parser.parseDependencies(toAbsolutePath('missing-dependencies.js'))
+      parser.parse(toAbsolutePath('missing-dependencies.js'))
     } catch (err) {
       expect(err).toMatchObject({ missingFiles: [toAbsolutePath('does-not-exist.js'), toAbsolutePath('does-not-exist2.js')] })
     }
@@ -49,7 +49,7 @@ describe('dependency-parser - parseDependencies()', () => {
     const entrypoint = path.join(__dirname, 'check-parser-fixtures', 'syntax-error.js')
     try {
       const parser = new Parser(defaultNpmModules)
-      parser.parseDependencies(entrypoint)
+      parser.parse(entrypoint)
     } catch (err) {
       expect(err).toMatchObject({ parseErrors: [{ file: entrypoint, error: 'Unexpected token (4:70)' }] })
     }
@@ -59,7 +59,7 @@ describe('dependency-parser - parseDependencies()', () => {
     const entrypoint = path.join(__dirname, 'check-parser-fixtures', 'unsupported-dependencies.js')
     try {
       const parser = new Parser(defaultNpmModules)
-      parser.parseDependencies(entrypoint)
+      parser.parse(entrypoint)
     } catch (err) {
       expect(err).toMatchObject({ unsupportedNpmDependencies: [{ file: entrypoint, unsupportedDependencies: ['left-pad', 'right-pad'] }] })
     }
@@ -68,7 +68,7 @@ describe('dependency-parser - parseDependencies()', () => {
   it('should handle circular dependencies', () => {
     const toAbsolutePath = (filename: string) => path.join(__dirname, 'check-parser-fixtures', 'circular-dependencies', filename)
     const parser = new Parser(defaultNpmModules)
-    const dependencies = parser.parseDependencies(toAbsolutePath('entrypoint.js'))
+    const dependencies = parser.parse(toAbsolutePath('entrypoint.js'))
     // Circular dependencies are allowed in Node.js
     // We just need to test that parsing the dependencies doesn't loop indefinitely
     // https://nodejs.org/api/modules.html#modules_cycles
@@ -81,18 +81,19 @@ describe('dependency-parser - parseDependencies()', () => {
   it('should parse typescript dependencies', () => {
     const toAbsolutePath = (filename: string) => path.join(__dirname, 'check-parser-fixtures', 'typescript-example', filename)
     const parser = new Parser(defaultNpmModules)
-    const dependencies = parser.parseDependencies(toAbsolutePath('entrypoint.ts'))
+    const dependencies = parser.parse(toAbsolutePath('entrypoint.ts'))
     expect(dependencies.sort()).toEqual([
       toAbsolutePath('dep1.ts'),
       toAbsolutePath('dep2.ts'),
       toAbsolutePath('dep3.ts'),
+      toAbsolutePath('dep4.js'),
     ])
   })
 
   it('should handle ES Modules', () => {
     const toAbsolutePath = (filename: string) => path.join(__dirname, 'check-parser-fixtures', 'esmodules-example', filename)
     const parser = new Parser(defaultNpmModules)
-    const dependencies = parser.parseDependencies(toAbsolutePath('entrypoint.js'))
+    const dependencies = parser.parse(toAbsolutePath('entrypoint.js'))
     expect(dependencies.sort()).toEqual([
       toAbsolutePath('dep1.js'),
       toAbsolutePath('dep2.js'),
@@ -108,6 +109,6 @@ describe('dependency-parser - parseDependencies()', () => {
   it.skip('should ignore cases where require is reassigned', () => {
     const entrypoint = path.join(__dirname, 'check-parser-fixtures', 'reassign-require.js')
     const parser = new Parser(defaultNpmModules)
-    parser.parseDependencies(entrypoint)
+    parser.parse(entrypoint)
   })
 })

--- a/package/src/services/check-parser/collector.ts
+++ b/package/src/services/check-parser/collector.ts
@@ -12,21 +12,23 @@ export type ParseError = {
 
 export class Collector {
   entrypoint: string
+  entrypointContent: string
   missingFiles: string[] = []
   parseErrors: ParseError[] = []
   unsupportedNpmDependencies: UnsupportedNpmDependencies[] = []
-  dependencies = new Set<string>()
+  dependencies = new Map<string, string>()
 
-  constructor (entrypoint: string) {
+  constructor (entrypoint: string, entrypointContent: string) {
     this.entrypoint = entrypoint
+    this.entrypointContent = entrypointContent
   }
 
   hasDependency (path: string) {
     return this.dependencies.has(path)
   }
 
-  addDependency (path: string) {
-    this.dependencies.add(path)
+  addDependency (path: string, content: string) {
+    this.dependencies.set(path, content)
   }
 
   addUnsupportedNpmDependencies (file: string, unsupportedDependencies: string[]) {
@@ -53,7 +55,6 @@ export class Collector {
   }
 
   getDependencies () {
-    this.dependencies.delete(this.entrypoint)
-    return Array.from(this.dependencies)
+    return Array.from(this.dependencies.keys())
   }
 }


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

### Notes for the reviewer
* Allow more flexible setup for different extensions
* Allow TS files to import JS files
* Inline parsing errors to remove top try/catch

Closes https://github.com/checkly/checkly-cli/issues/423