### PR TITLE
fix: terminate  when no checks

### DIFF
--- a/package/e2e/__tests__/test.spec.ts
+++ b/package/e2e/__tests__/test.spec.ts
@@ -15,4 +15,15 @@ describe('test', () => {
     expect(result.stdout).toContain(secretEnv)
     expect(result.status).not.toBe(0)
   })
+
+  it('Should terminate when no checks are found', () => {
+    const result = runChecklyCli({
+      args: ['test', 'does-not-exist.js'],
+      apiKey: config.get('apiKey'),
+      accountId: config.get('accountId'),
+      directory: path.join(__dirname, 'fixtures/test-project'),
+      timeout: 5000,
+    })
+    expect(result.status).toBe(0)
+  })
 })

--- a/package/e2e/run-checkly.ts
+++ b/package/e2e/run-checkly.ts
@@ -9,6 +9,7 @@ export function runChecklyCli (options: {
   apiKey?: string,
   accountId?: string,
   env?: object,
+  timeout?: number,
 }) {
   const {
     directory,
@@ -16,6 +17,7 @@ export function runChecklyCli (options: {
     apiKey,
     accountId,
     env = {},
+    timeout = 10000,
   } = options
   return childProcess.spawnSync(CHECKLY_PATH, args, {
     env: {
@@ -26,5 +28,6 @@ export function runChecklyCli (options: {
     },
     cwd: directory ?? process.cwd(),
     encoding: 'utf-8',
+    timeout,
   })
 }

--- a/package/src/services/check-runner.ts
+++ b/package/src/services/check-runner.ts
@@ -119,11 +119,14 @@ export default class CheckRunner extends EventEmitter {
 
   private allChecksFinished (): Promise<void> {
     let finishedCheckCount = 0
-    const checks = this.checks
+    const numChecks = this.checks.size
+    if (numChecks === 0) {
+      return Promise.resolve()
+    }
     return new Promise((resolve) => {
       this.on(Events.CHECK_FINISHED, () => {
         finishedCheckCount++
-        if (finishedCheckCount === checks.size) resolve()
+        if (finishedCheckCount === numChecks) resolve()
       })
     })
   }


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

### Notes for the reviewer
Resolves https://github.com/checkly/checkly-cli/issues/443

When no checks are detected, `checkly test` would hang indefinitely. This PR adds a fix and an integration test to make sure that there are no regressions.