### PR TITLE
fix: handle import type statement [sc-0]

### DIFF
--- a/package/src/services/check-parser/__tests__/check-parser-fixtures/typescript-example/entrypoint.ts
+++ b/package/src/services/check-parser/__tests__/check-parser-fixtures/typescript-example/entrypoint.ts
@@ -2,6 +2,7 @@ import { add } from './dep1'
 import { subtract as random } from './dep4'
 import { subtract } from './dep2'
 import * as axios from 'axios'
+import type { UniqueType } from './type'
 
 export function doMath (num: number): number {
   return add(num, subtract(10, 7))

--- a/package/src/services/check-parser/__tests__/check-parser-fixtures/typescript-example/type.ts
+++ b/package/src/services/check-parser/__tests__/check-parser-fixtures/typescript-example/type.ts
@@ -1,0 +1,3 @@
+export type UniqueType = {
+  field: string
+}

--- a/package/src/services/check-parser/__tests__/check-parser.spec.ts
+++ b/package/src/services/check-parser/__tests__/check-parser.spec.ts
@@ -88,6 +88,7 @@ describe('dependency-parser - parser()', () => {
       toAbsolutePath('dep2.ts'),
       toAbsolutePath('dep3.ts'),
       toAbsolutePath('dep4.js'),
+      toAbsolutePath('type.ts'),
     ])
   })
 

--- a/package/src/services/check-parser/parser.ts
+++ b/package/src/services/check-parser/parser.ts
@@ -6,6 +6,13 @@ import { TSESTree } from '@typescript-eslint/typescript-estree'
 import { Collector } from './collector'
 import { DependencyParseError } from './errors'
 
+// Our custom configuration to handle walking errors
+// This is to handle 'import type { Type }'
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const ignore = (_node: any, _st: any, _c: any) => {}
+walk.base.TSParameterProperty = ignore
+walk.base.TSTypeAliasDeclaration = ignore
+
 type Module = {
   localDependencies: Array<string>,
   npmDependencies: Array<string>

--- a/package/src/services/check-parser/parser.ts
+++ b/package/src/services/check-parser/parser.ts
@@ -2,16 +2,20 @@ import * as path from 'path'
 import * as fs from 'fs'
 import * as acorn from 'acorn'
 import * as walk from 'acorn-walk'
-import { TSESTree } from '@typescript-eslint/typescript-estree'
+import { TSESTree, AST_NODE_TYPES } from '@typescript-eslint/typescript-estree'
 import { Collector } from './collector'
 import { DependencyParseError } from './errors'
 
 // Our custom configuration to handle walking errors
-// This is to handle 'import type { Type }'
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const ignore = (_node: any, _st: any, _c: any) => {}
-walk.base.TSParameterProperty = ignore
-walk.base.TSTypeAliasDeclaration = ignore
+Object.values(AST_NODE_TYPES).forEach((astType) => {
+  // Only handle the TS specific ones
+  if (!astType.startsWith('TS')) {
+    return
+  }
+  walk.base[astType] = walk.base[astType] ?? ignore
+})
 
 type Module = {
   localDependencies: Array<string>,


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

### Notes for the reviewer
Handle the import type syntax of typescript

Closes https://github.com/checkly/checkly-cli/issues/440