### PR TITLE
fix: use empty array if environmentVariables is nullish [sc-0]

### DIFF
--- a/package/src/constructs/check-group.ts
+++ b/package/src/constructs/check-group.ts
@@ -115,8 +115,8 @@ export class CheckGroup extends Construct {
     this.privateLocations = props.privateLocations
     this.concurrency = props.concurrency
     this.apiCheckDefaults = props.apiCheckDefaults || defaultApiCheckDefaults
-    this.browserCheckDefaults = props.browserCheckDefaults || {}
-    this.environmentVariables = props.environmentVariables
+    this.browserCheckDefaults = props.browserCheckDefaults ?? {}
+    this.environmentVariables = props.environmentVariables ?? []
     this.alertChannels = props.alertChannels ?? []
     const fileAbsolutePath = Session.checkFileAbsolutePath!
     if (props.browserChecks?.testMatch) {

--- a/package/src/constructs/check.ts
+++ b/package/src/constructs/check.ts
@@ -92,7 +92,7 @@ export abstract class Check extends Construct {
     this.tags = props.tags
     this.frequency = props.frequency
     this.runtimeId = props.runtimeId
-    this.environmentVariables = props.environmentVariables
+    this.environmentVariables = props.environmentVariables ?? []
     // Alert channel subscriptions will be synthesized separately in the Project construct.
     // This is due to the way things are organized on the BE.
     this.alertChannels = props.alertChannels ?? []


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

### Notes for the reviewer
Resolves https://github.com/checkly/checkly-cli/issues/442

- Use an empty array `[]` when `environmentVariables` is nullish (`null` or `undefined`) in checks and check-groups.
### New dependency submission
<!-- Please explain here why we need the new dependency. -->
