### PR TITLE
feat: Allow configuring default alert channels in checkly config

### DIFF
--- a/package/src/commands/deploy.ts
+++ b/package/src/commands/deploy.ts
@@ -29,7 +29,7 @@ export default class Deploy extends Command {
     const { flags } = await this.parse(Deploy)
     const { force, preview } = flags
     const cwd = process.cwd()
-    const checklyConfig = await loadChecklyConfig(cwd)
+    const { config: checklyConfig, constructs: checklyConfigConstructs } = await loadChecklyConfig(cwd)
     const { data: avilableRuntimes } = await runtimes.getAll()
     const project = await parseProject({
       directory: cwd,
@@ -45,6 +45,7 @@ export default class Deploy extends Command {
         acc[runtime.name] = runtime
         return acc
       }, <Record<string, Runtime>> {}),
+      checklyConfigConstructs,
     })
     // We can use a null-assertion operator safely since account ID was validated in auth-check hook
     const { data: account } = await api.accounts.get(config.getAccountId()!)

--- a/package/src/commands/test.ts
+++ b/package/src/commands/test.ts
@@ -84,7 +84,7 @@ export default class Test extends Command {
     const filePatterns = argv as string[]
 
     const testEnvVars = await getEnvs(envFile, env)
-    const checklyConfig = await loadChecklyConfig(cwd)
+    const { config: checklyConfig, constructs: checklyConfigConstructs } = await loadChecklyConfig(cwd)
     const location = await this.prepareRunLocation(checklyConfig.cli, { runLocation, privateRunLocation })
     const { data: availableRuntimes } = await api.runtimes.getAll()
     const project = await parseProject({
@@ -101,6 +101,7 @@ export default class Test extends Command {
         acc[runtime.name] = runtime
         return acc
       }, <Record<string, Runtime>> {}),
+      checklyConfigConstructs,
     })
     const { checks: checksMap, groups: groupsMap } = project.data
     const checks = Object.entries(checksMap)

--- a/package/src/constructs/alert-channel-subscription.ts
+++ b/package/src/constructs/alert-channel-subscription.ts
@@ -1,5 +1,6 @@
 import { Ref } from './ref'
 import { Construct } from './construct'
+import { Session } from './project'
 
 export interface AlertChannelSubscriptionProps {
     alertChannelId: Ref
@@ -39,12 +40,12 @@ export class AlertChannelSubscription extends Construct {
    * @param props alert channel subscription configuration properties
    */
   constructor (logicalId: string, props: AlertChannelSubscriptionProps) {
-    super(logicalId)
+    super(AlertChannelSubscription.__checklyType, logicalId)
     this.alertChannelId = props.alertChannelId
     this.checkId = props.checkId
     this.groupId = props.groupId
     this.activated = props.activated
-    this.register(AlertChannelSubscription.__checklyType, this.logicalId, this.synthesize())
+    Session.registerConstruct(this)
   }
 
   synthesize () {

--- a/package/src/constructs/alert-channel.ts
+++ b/package/src/constructs/alert-channel.ts
@@ -46,7 +46,7 @@ export abstract class AlertChannel extends Construct {
    * @param props alert channel configuration properties
    */
   constructor (logicalId: string, props: AlertChannelProps) {
-    super(logicalId)
+    super(AlertChannel.__checklyType, logicalId)
     this.sendRecovery = props.sendRecovery
     this.sendFailure = props.sendFailure
     this.sendDegraded = props.sendDegraded

--- a/package/src/constructs/api-check.ts
+++ b/package/src/constructs/api-check.ts
@@ -1,5 +1,6 @@
 import { Check, CheckProps } from './check'
 import { HttpHeader } from './http-header'
+import { Session } from './project'
 import { QueryParam } from './query-param'
 export interface Assertion {
   source: string,
@@ -97,7 +98,7 @@ export class ApiCheck extends Check {
     this.localTearDownScript = props.localTearDownScript
     this.degradedResponseTime = props.degradedResponseTime
     this.maxResponseTime = props.maxResponseTime
-    this.register(Check.__checklyType, this.logicalId, this.synthesize())
+    Session.registerConstruct(this)
     this.addSubscriptions()
   }
 

--- a/package/src/constructs/browser-check.ts
+++ b/package/src/constructs/browser-check.ts
@@ -68,7 +68,7 @@ export class BrowserCheck extends Check {
     } else {
       throw new Error('Unrecognized type for the code property')
     }
-    this.register(Check.__checklyType, this.logicalId, this.synthesize())
+    Session.registerConstruct(this)
     this.addSubscriptions()
   }
 

--- a/package/src/constructs/check-group.ts
+++ b/package/src/constructs/check-group.ts
@@ -105,7 +105,7 @@ export class CheckGroup extends Construct {
   static readonly __checklyType = 'groups'
 
   constructor (logicalId: string, props: CheckGroupProps) {
-    super(logicalId)
+    super(CheckGroup.__checklyType, logicalId)
     this.name = props.name
     this.activated = props.activated
     this.muted = props.muted
@@ -122,7 +122,7 @@ export class CheckGroup extends Construct {
     if (props.browserChecks?.testMatch) {
       this.__addChecks(fileAbsolutePath, props.browserChecks)
     }
-    this.register(CheckGroup.__checklyType, this.logicalId, this.synthesize())
+    Session.registerConstruct(this)
     this.__addSubscriptions()
   }
 

--- a/package/src/constructs/check.ts
+++ b/package/src/constructs/check.ts
@@ -79,7 +79,7 @@ export abstract class Check extends Construct {
   static readonly __checklyType = 'checks'
 
   constructor (logicalId: string, props: CheckProps) {
-    super(logicalId)
+    super(Check.__checklyType, logicalId)
     Check.applyDefaultCheckConfig(props)
     // TODO: Throw an error if required properties are still missing after applying the defaults.
     this.name = props.name

--- a/package/src/constructs/construct.ts
+++ b/package/src/constructs/construct.ts
@@ -1,20 +1,16 @@
-import { Session } from './project'
 import { Ref } from './ref'
 
-export class Construct {
+export abstract class Construct {
+  type: string
   logicalId: string
-  constructor (logicalId: string) {
+  constructor (type: string, logicalId: string) {
     this.logicalId = logicalId
+    this.type = type
   }
 
   ref () {
     return Ref.from(this.logicalId)
   }
 
-  register (type: string, logicalId: string, resource: any) {
-    if (!Session.project) {
-      throw new Error('A project is not registered to the session')
-    }
-    Session.project.addResource(type, logicalId, resource)
-  }
+  abstract synthesize(): any
 }

--- a/package/src/constructs/email-alert-channel.ts
+++ b/package/src/constructs/email-alert-channel.ts
@@ -1,4 +1,5 @@
 import { AlertChannel, AlertChannelProps } from './alert-channel'
+import { Session } from './project'
 
 export interface EmailAlertChannelProps extends AlertChannelProps {
   /**
@@ -25,7 +26,7 @@ export class EmailAlertChannel extends AlertChannel {
   constructor (logicalId: string, props: EmailAlertChannelProps) {
     super(logicalId, props)
     this.address = props.address
-    this.register(AlertChannel.__checklyType, logicalId, this.synthesize())
+    Session.registerConstruct(this)
   }
 
   synthesize () {

--- a/package/src/constructs/opsgenie-alert-channel.ts
+++ b/package/src/constructs/opsgenie-alert-channel.ts
@@ -1,4 +1,5 @@
 import { AlertChannel, AlertChannelProps } from './alert-channel'
+import { Session } from './project'
 
 export enum OpsgeniePriority {
   P1 = 'P1',
@@ -57,7 +58,7 @@ export class OpsgenieAlertChannel extends AlertChannel {
     this.apiKey = props.apiKey
     this.region = props.region
     this.priority = props.priority
-    this.register(AlertChannel.__checklyType, logicalId, this.synthesize())
+    Session.registerConstruct(this)
   }
 
   synthesize () {

--- a/package/src/constructs/pagerduty-alert-channel.ts
+++ b/package/src/constructs/pagerduty-alert-channel.ts
@@ -1,4 +1,5 @@
 import { AlertChannel, AlertChannelProps } from './alert-channel'
+import { Session } from './project'
 
 export interface PagerdutyAlertChannelProps extends AlertChannelProps {
   /**
@@ -39,7 +40,7 @@ export class PagerdutyAlertChannel extends AlertChannel {
     this.account = props.account
     this.serviceName = props.serviceName
     this.serviceKey = props.serviceKey
-    this.register(AlertChannel.__checklyType, logicalId, this.synthesize())
+    Session.registerConstruct(this)
   }
 
   synthesize () {

--- a/package/src/constructs/project.ts
+++ b/package/src/constructs/project.ts
@@ -15,9 +15,10 @@ export interface ProjectProps {
   repoUrl: string
 }
 
-export class Project extends Construct {
+export class Project {
   name: string
   repoUrl: string
+  logicalId: string
   data: Record<string, Record<string, any>> = {
     checks: {},
     groups: {},
@@ -32,7 +33,6 @@ export class Project extends Construct {
    * @param props project configuration properties
    */
   constructor (logicalId: string, props: ProjectProps) {
-    super(logicalId)
     if (!props.name) {
       // TODO: Can we collect a list of validation errors and return them all at once? This might be better UX.
       throw new ValidationError('The project must have a name specified')
@@ -40,6 +40,7 @@ export class Project extends Construct {
 
     this.name = props.name
     this.repoUrl = props.repoUrl
+    this.logicalId = logicalId
   }
 
   addResource (type: string, logicalId: string, resource: any) {
@@ -63,11 +64,22 @@ export class Project extends Construct {
 }
 
 export class Session {
-  static project: Project
+  static project?: Project
   static basePath?: string
   static checkDefaults?: CheckConfigDefaults
   static browserCheckDefaults?: CheckConfigDefaults
   static checkFilePath?: string
   static checkFileAbsolutePath?: string
   static availableRuntimes: Record<string, Runtime>
+  static checklyConfigConstructs?: Array<Construct>
+
+  static registerConstruct (construct: Construct) {
+    if (Session.project) {
+      Session.project.addResource(construct.type, construct.logicalId, construct.synthesize())
+    } else if (Session.checklyConfigConstructs) {
+      Session.checklyConfigConstructs.push(construct)
+    } else {
+      throw new Error('Internal Error: Session is not properly configured for using a construct. Please contact Checkly support.')
+    }
+  }
 }

--- a/package/src/constructs/slack-alert-channel.ts
+++ b/package/src/constructs/slack-alert-channel.ts
@@ -1,4 +1,5 @@
 import { AlertChannel, AlertChannelProps } from './alert-channel'
+import { Session } from './project'
 
 export interface SlackAlertChannelProps extends AlertChannelProps {
   url: URL
@@ -25,7 +26,7 @@ export class SlackAlertChannel extends AlertChannel {
     super(logicalId, props)
     this.url = props.url
     this.channel = props.channel
-    this.register(AlertChannel.__checklyType, logicalId, this.synthesize())
+    Session.registerConstruct(this)
   }
 
   synthesize () {

--- a/package/src/constructs/sms-alert-channel.ts
+++ b/package/src/constructs/sms-alert-channel.ts
@@ -1,4 +1,5 @@
 import { AlertChannel, AlertChannelProps } from './alert-channel'
+import { Session } from './project'
 
 export interface SmsAlertChannelProps extends AlertChannelProps {
   /**
@@ -25,7 +26,7 @@ export class SmsAlertChannel extends AlertChannel {
   constructor (logicalId: string, props: SmsAlertChannelProps) {
     super(logicalId, props)
     this.phoneNumber = props.phoneNumber
-    this.register(AlertChannel.__checklyType, logicalId, this.synthesize())
+    Session.registerConstruct(this)
   }
 
   synthesize () {

--- a/package/src/constructs/webhook-alert-channel.ts
+++ b/package/src/constructs/webhook-alert-channel.ts
@@ -2,6 +2,7 @@ import { AlertChannel, AlertChannelProps } from './alert-channel'
 import { HttpHeader } from './http-header'
 import { HttpRequestMethod } from './api-check'
 import { QueryParam } from './query-param'
+import { Session } from './project'
 
 export interface WebhookAlertChannelProps extends AlertChannelProps {
   /**
@@ -63,7 +64,7 @@ export class WebhookAlertChannel extends AlertChannel {
     this.method = props.method
     this.headers = props.headers
     this.queryParameters = props.queryParameters
-    this.register(AlertChannel.__checklyType, logicalId, this.synthesize())
+    Session.registerConstruct(this)
   }
 
   synthesize () {

--- a/package/src/services/checkly-config-loader.ts
+++ b/package/src/services/checkly-config-loader.ts
@@ -5,11 +5,9 @@ import { CheckProps } from '../constructs/check'
 import { Session } from '../constructs'
 import type { Construct } from '../constructs/construct'
 
-// TODO: How would a user declare default alert channels?
-// We need some additional work before constructs can be created in checkly.config.js.
-// alertChannels?: Array<AlertChannel>,
 export type CheckConfigDefaults = Pick<CheckProps, 'activated' | 'muted' | 'doubleCheck'
-  | 'shouldFail' | 'runtimeId' | 'locations' | 'tags' | 'frequency' | 'environmentVariables'>
+  | 'shouldFail' | 'runtimeId' | 'locations' | 'tags' | 'frequency' | 'environmentVariables'
+  | 'alertChannels'>
 
 export type ChecklyConfig = {
   /**

--- a/package/src/services/checkly-config-loader.ts
+++ b/package/src/services/checkly-config-loader.ts
@@ -66,6 +66,6 @@ export async function loadChecklyConfig (dir: string): Promise<{ config: Checkly
   }
   const constructs = Session.checklyConfigConstructs
   // Overwrite `Session.checklyConfigConstructs` since the checkly cofnig is now parsed
-  Session.checklyConfigConstructs = undefined 
+  Session.checklyConfigConstructs = undefined
   return { config, constructs }
 }

--- a/package/src/services/project-parser.ts
+++ b/package/src/services/project-parser.ts
@@ -6,6 +6,7 @@ import * as path from 'path'
 import { CheckConfigDefaults } from './checkly-config-loader'
 
 import type { Runtime } from '../rest/runtimes'
+import type { Construct } from '../constructs/construct'
 
 const globPromise = promisify(glob)
 
@@ -19,7 +20,8 @@ type ProjectParseOpts = {
   ignoreDirectoriesMatch?: string[],
   checkDefaults?: CheckConfigDefaults,
   browserCheckDefaults?: CheckConfigDefaults,
-  availableRuntimes: Record<string, Runtime>
+  availableRuntimes: Record<string, Runtime>,
+  checklyConfigConstructs?: Construct[],
 }
 
 const BASE_CHECK_DEFAULTS = {
@@ -38,11 +40,15 @@ export async function parseProject (opts: ProjectParseOpts): Promise<Project> {
     checkDefaults = {},
     browserCheckDefaults = {},
     availableRuntimes,
+    checklyConfigConstructs,
   } = opts
   const project = new Project(projectLogicalId, {
     name: projectName,
     repoUrl,
   })
+  checklyConfigConstructs?.forEach(
+    (construct) => project.addResource(construct.type, construct.logicalId, construct.synthesize())
+  )
   Session.project = project
   Session.basePath = directory
   Session.checkDefaults = Object.assign({}, BASE_CHECK_DEFAULTS, checkDefaults)

--- a/package/src/services/project-parser.ts
+++ b/package/src/services/project-parser.ts
@@ -47,7 +47,7 @@ export async function parseProject (opts: ProjectParseOpts): Promise<Project> {
     repoUrl,
   })
   checklyConfigConstructs?.forEach(
-    (construct) => project.addResource(construct.type, construct.logicalId, construct.synthesize())
+    (construct) => project.addResource(construct.type, construct.logicalId, construct.synthesize()),
   )
   Session.project = project
   Session.basePath = directory


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

### Notes for the reviewer
Resolves https://github.com/checkly/checkly-cli/issues/408

Users might want to configure default alert channels which are applied to all checks. This currently isn't possible, though - mostly because users can't create constructs in the Checkly config file.

This PR allows users to create _any_ constructs in the Checkly config file [1]. Users can then add an `alertChannels` section to their config to be applied as a default. This works just like other check defaults.

In the implementation, I needed to make some changes to how constructs are registered. Previously, we would just register the constructs with the `Session.project`. The `Project` doesn't exist when the config file is being parsed, though. With this PR - we first try to register the constructs with the `Session.project`. If it doesn't exist, we try to register them with the `Session.checklyConfigConstructs` - an array that is only present when the Checkly config file is being parsed. After the Checkly config file is parsed and a project is created, all of the `checklyConfigConstructs` are registered with `Session.project`.

[1] Another option could be to only allow alert channels to be created in the config file