### PR TITLE
chore: increase timeout for flaky e2e test

### DIFF
--- a/packages/cli/e2e/__tests__/test.spec.ts
+++ b/packages/cli/e2e/__tests__/test.spec.ts
@@ -22,7 +22,6 @@ describe('test', () => {
       apiKey: config.get('apiKey'),
       accountId: config.get('accountId'),
       directory: path.join(__dirname, 'fixtures/test-project'),
-      timeout: 5000,
     })
     expect(result.status).toBe(0)
   })


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

### Notes for the reviewer
The `Should terminate when no checks are found` test is currently flaky. For example, [here](https://github.com/checkly/checkly-cli/pull/468) it failed on 1 out of 3 executions. After adding more logging, I saw that the failure is due to reaching the 5 second timeout.

As a quick fix, we can simply increase the timeout to the 10 second default. 

I'm not sure why the `checkly test does-not-exist.js` command is taking so long. Running locally, this integration test takes 1.7 seconds. I've also tried directly running `npx checkly test does-not-exist.js` which took 1.2s. In this case, I think that the normal command isn't so slow for users - this issue seems to be specific to our CI. It might make sense to do more investigation later on.