### PR TITLE
chore: provide better error message for EADDRINUSE

### DIFF
--- a/packages/cli/src/auth/index.ts
+++ b/packages/cli/src/auth/index.ts
@@ -87,11 +87,14 @@ export function startServer (codeVerifier: string): Promise<string> {
       }
     })
 
-    server.listen(4242).on('error', err => {
-      // TODO: Update error handling to not have a console.log here.
-      // eslint-disable-next-line no-console
-      console.log('Unable to start an HTTP server on port 4242.', err)
-      reject(err)
+    server.listen(4242).on('error', (err: any) => {
+      if (err.code === 'EADDRINUSE') {
+        reject(new Error('Unable to start a local server on port 4242.' +
+          ' Please check that `checkly login` isn\'t already running in a separate tab.' +
+          ' On OS X and Linux, you can run `lsof -i :4242` to see which process is blocking the port.'))
+      } else {
+        reject(err)
+      }
     })
   })
 }


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

### Notes for the reviewer
Resolves https://github.com/checkly/checkly-cli/issues/445

Running `npx checkly login` may fail if port 4242 is already in use. As a simple improvement, this PR gives a more clear error message in this case. If users continue running into this error, we can invest more effort into removing the error case altogether.


![Screenshot 2023-02-03 at 14 03 17](https://user-images.githubusercontent.com/10483186/216610214-a1e9ceae-b8c7-4e17-b0c0-ab83049c45cd.png)

