### PR TITLE
fix: keep typescript as an optinal dependency [sc-0]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11469,7 +11469,7 @@
     },
     "packages/cli": {
       "name": "@checkly/cli",
-      "version": "0.3.12",
+      "version": "0.3.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@oclif/core": "2.0.7",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@checkly/cli",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "Checkly CLI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

### Notes for the reviewer
Keep typescript as an optinal dependency