### PR TITLE
feat: enable default values for API checks

### DIFF
--- a/packages/cli/src/constructs/api-check.ts
+++ b/packages/cli/src/constructs/api-check.ts
@@ -35,13 +35,13 @@ interface BasicAuth {
 export interface Request {
   url: string,
   method: HttpRequestMethod,
-  followRedirects: boolean,
-  skipSsl: boolean,
+  followRedirects?: boolean,
+  skipSsl?: boolean,
   /**
    * Check the main Checkly documentation on assertions for specific values like regular expressions
    * and JSON path descriptors you can use in the "property" field.
    */
-  assertions: Array<Assertion>
+  assertions?: Array<Assertion>
   body?: string
   bodyType?: BodyType
   headers?: Array<HttpHeader>
@@ -64,11 +64,11 @@ export interface ApiCheckProps extends CheckProps {
   /**
    * The response time in milliseconds where a check should be considered degraded.
    */
-  degradedResponseTime: number
+  degradedResponseTime?: number
   /**
    * The response time in milliseconds where a check should be considered failing.
    */
-  maxResponseTime: number
+  maxResponseTime?: number
 }
 
 /**
@@ -82,8 +82,8 @@ export class ApiCheck extends Check {
   request: Request
   localSetupScript?: string
   localTearDownScript?: string
-  degradedResponseTime: number
-  maxResponseTime: number
+  degradedResponseTime?: number
+  maxResponseTime?: number
 
   /**
    * Constructs the API Check instance


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

### Notes for the reviewer
Relates to https://github.com/checkly/checkly-cli/issues/472

We already have sensible defaults for API check values in the backend. These are added via Joi and the DB (in the case of `followRedirects`). This PR makes some fields optional - the defaults will be used in this case.

* `degradedResponseTime`: 10000 (higher than the one mentioned in the issue, but it's worth the consistency with the public API + TF)
* `maxResponseTime`: 20000
* `followRedirects`: true
* `skipSsl`: false
* `assertions`: []

