### PR TITLE
feat: enable default values for alert channels

### DIFF
--- a/packages/cli/src/constructs/alert-channel.ts
+++ b/packages/cli/src/constructs/alert-channel.ts
@@ -4,23 +4,23 @@ export interface AlertChannelProps {
   /**
    * Determines if an alert should be send for check recoveries.
    */
-  sendRecovery: boolean
+  sendRecovery?: boolean
   /**
    * Determines if an alert should be send for check failures.
    */
-  sendFailure: boolean
+  sendFailure?: boolean
   /**
    * Determines if an alert should be send when a check is degraded.
    */
-  sendDegraded: boolean
+  sendDegraded?: boolean
   /**
    * Determines if an alert should be send for expiring SSL certificates.
    */
-  sslExpiry: boolean
+  sslExpiry?: boolean
   /**
    * At what moment in time to start alerting on SSL certificates.
    */
-  sslExpiryThreshold: number
+  sslExpiryThreshold?: number
 }
 
 /**
@@ -31,11 +31,11 @@ export interface AlertChannelProps {
  * This class make use of the Alert Channels endpoints.
  */
 export abstract class AlertChannel extends Construct {
-  sendRecovery: boolean
-  sendFailure: boolean
-  sendDegraded: boolean
-  sslExpiry: boolean
-  sslExpiryThreshold: number
+  sendRecovery?: boolean
+  sendFailure?: boolean
+  sendDegraded?: boolean
+  sslExpiry?: boolean
+  sslExpiryThreshold?: number
 
   static readonly __checklyType = 'alertChannels'
 


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

### Notes for the reviewer
Relates to https://github.com/checkly/checkly-cli/issues/472

We already have sensible defaults for API check values in the backend - added in the level Joi and DB level. With this PR, users can more easily create alert channels with the default values:

* `sendRecovery`: true 
* `sendFailure`: true
* `sendDegraded`: false
* `sendExpiry`: false
* `sslExpiryThreshold`: 30

It might make sense to update the default values for `sendDegraded` and `sendExpiry` in the backend to `true`.
