### PR TITLE
feat: enable default values for groups

### DIFF
--- a/packages/cli/src/constructs/check-group.ts
+++ b/packages/cli/src/constructs/check-group.ts
@@ -35,15 +35,15 @@ export interface CheckGroupProps {
   /**
    * Determines if the checks in the group are running or not.
    */
-  activated: boolean
+  activated?: boolean
   /**
    * Determines if any notifications will be send out when a check in this group fails and/or recovers.
    */
-  muted: boolean
+  muted?: boolean
   /**
    * The runtime version, i.e. fixed set of runtime dependencies, used to execute checks in this group.
    */
-  runtimeId: string
+  runtimeId?: string
   /**
    * An array of one or more data center locations where to run the checks.
    */
@@ -55,12 +55,12 @@ export interface CheckGroupProps {
   /**
    * Tags for organizing and filtering checks.
    */
-  tags: Array<string>
+  tags?: Array<string>
   /**
    * Determines how many checks are invoked concurrently when triggering a check group from CI/CD or through the API.
    */
-  concurrency: number
-  environmentVariables: Array<EnvironmentVariable>
+  concurrency?: number
+  environmentVariables?: Array<EnvironmentVariable>
   /**
    * List of alert channel subscriptions.
    */
@@ -74,8 +74,8 @@ export interface CheckGroupProps {
    * A valid piece of Node.js code to run in the teardown phase of an API check in this group.
    */
   localTearDownScript?: string
-  apiCheckDefaults: any
-  browserCheckDefaults: any
+  apiCheckDefaults?: any
+  browserCheckDefaults?: any
 }
 
 /**
@@ -87,14 +87,14 @@ export interface CheckGroupProps {
  */
 export class CheckGroup extends Construct {
   name: string
-  activated: boolean
-  muted: boolean
-  runtimeId: string
+  activated?: boolean
+  muted?: boolean
+  runtimeId?: string
   locations: Array<string>
   privateLocations?: Array<string>
-  tags: Array<string>
-  concurrency: number
-  environmentVariables: Array<EnvironmentVariable>
+  tags?: Array<string>
+  concurrency?: number
+  environmentVariables?: Array<EnvironmentVariable>
   alertChannels?: Array<AlertChannel>
   localSetupScript?: string
   localTearDownScript?: string


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Relates to https://github.com/checkly/checkly-cli/issues/472

We already have sensible defaults for check groups in the backend - added in the level Joi and DB level. With this PR, users can more easily create check groups with the default values:

`activated`: true
`muted`: false
`runtimeId`: `null`. In this case the runtimeId from the account will be used as a fallback.
`tags`: `[]`
`concurrency`: 3. This field wasn't mentioned in the GH issue, but I think that it makes sense to enable the default here as well.
`environmentVariables`: `[]`

`apiCheckDefaults` and `browserCheckDefaults` can also be skipped. This default comes from checkly-cli rather than the backend.