### PR TITLE
chore: add a timeout for check executions

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ between environments.
 - `--private-location <private location ID>`: Run checks against the specified private location.
 - `--env-file`: You can read variables from a `.env` file by passing the file path e.g. `--env-file="./.env"`
 - `--list`: Just list the checks in your project, but don't run them.
+- `--timeout`: A fallback timeout (in seconds) to wait for checks to complete.
 
 ### `npx checkly deploy`
 

--- a/packages/cli/src/reporters/util.ts
+++ b/packages/cli/src/reporters/util.ts
@@ -68,6 +68,12 @@ export function formatCheckResult (checkResult: any) {
       formatLogs(checkResult.logs),
     ])
   }
+  if (checkResult.runError) {
+    result.push([
+      formatSectionTitle('Execution Error'),
+      formatRunError(checkResult.runError),
+    ])
+  }
   return result.map(([title, body]) => title + '\n' + body).join('\n\n')
 }
 
@@ -160,6 +166,14 @@ function formatLogs (logs: Array<{ level: string, msg: string, time: number }>) 
       ...remainingLines.map((line) => format(line)),
     ]
   }).join('\n')
+}
+
+function formatRunError (err: string | Error): string {
+  if (typeof err === 'string') {
+    return err
+  } else {
+    return err.message
+  }
 }
 
 function formatSectionTitle (title: string): string {


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
> Resolves https://github.com/checkly/checkly-cli/issues/463

Normally, the CLI should always receive all check results when `checkly test` is executed. Even if a user's checks hang, there should be a result sent back to the CLI. Still, there might be some edge cases which cause results to never be sent back to the CLI. A websocket update might fail to be pushed, for example. With the current implementation, `checkly test` would just hang indefinitely.

As an extra fallback, this PR adds a timeout for `checkly test`. This way, the command won't hang indefinitely and block users' CI if there are ever any issues.

Rather than adding a timeout on the overall execution of `checkly test`, I added the timeout at the per-check level. I think that this will be more reliable if we ever start running checks one-at-a-time.

I set a default timeout of 240s. This is comfortably above our check runtime limit in the backend, so we should only ever reach it in exceptional cases. I think that users shouldn't really need to configure this, but I also added a `--timeout` argument for configuring this, just in case.

![Screenshot 2023-02-07 at 13 06 10](https://user-images.githubusercontent.com/10483186/217240572-e53cfbad-a7f7-418b-a5ad-2930dd83e6fa.png)
