### PR TITLE
feat: make browser check testMatch optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ const config = {
     runtimeId: '2022.10',
     frequency: 5,
     locations: ['us-east-1', 'eu-west-1'],
+    browserChecks: {
+      testMatch: '**/*.spec.js',
+    },
   }
 }
 
@@ -112,7 +115,7 @@ const config = {
     browserChecks: {
       frequency: 10,
       testMatch: '**/*.spec.js',
-    }
+    },
   },
   cli: {
     verbose: false,

--- a/packages/cli/src/services/project-parser.ts
+++ b/packages/cli/src/services/project-parser.ts
@@ -32,7 +32,7 @@ export async function parseProject (opts: ProjectParseOpts): Promise<Project> {
   const {
     directory,
     checkMatch = '**/*.check.{js,ts}',
-    browserCheckMatch = '**/*.spec.{js,ts}',
+    browserCheckMatch,
     projectLogicalId,
     projectName,
     repoUrl,
@@ -88,10 +88,13 @@ async function loadAllCheckFiles (
 
 async function loadAllBrowserChecks (
   directory: string,
-  browserCheckFilePattern: string,
+  browserCheckFilePattern: string | undefined,
   ignorePattern: string[],
   project: Project,
 ): Promise<void> {
+  if (!browserCheckFilePattern) {
+    return
+  }
   const checkFiles = await findFilesWithPattern(directory, browserCheckFilePattern, ignorePattern)
   const preexistingCheckFiles = new Set<string>()
   Object.values(project.data.checks).forEach(({ scriptPath }) => {


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves https://github.com/checkly/checkly-cli/issues/485

`testMatch` in the Checkly config file allows users to automatically create browser checks from Playwright files. Users might not want this behavior at all, though.

Currently we set a default value for `testMatch`, so it isn't possible to disable the flag. With the new [clreate-cli](https://github.com/checkly/checkly-cli/tree/main/packages/create-cli) scaffolding, though, having a default is less important. 

This PR removes the default value for `testMatch` so that users can completely disable the feature.
