### PR TITLE
chore: call synthesize() later on

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -68,19 +68,6 @@ export default class Deploy extends AuthCommand {
 
     try {
       const projectPayload = project.synthesize()
-
-      // TODO: refactor Check construct to handle internal attributes properly
-      projectPayload.checks = Object.keys(projectPayload.checks).reduce((acc, checkLogicalId) => {
-        const check = projectPayload.checks[checkLogicalId]
-        delete check.__checkFilePath
-        delete check.sourceFile
-        acc = {
-          ...acc,
-          [checkLogicalId]: check,
-        }
-        return acc
-      }, {})
-
       const { data } = await api.projects.deploy(projectPayload, { dryRun: preview })
       if (preview || output) {
         this.log(data)

--- a/packages/cli/src/constructs/browser-check.ts
+++ b/packages/cli/src/constructs/browser-check.ts
@@ -106,6 +106,10 @@ export class BrowserCheck extends Check {
     }
   }
 
+  getSourceFile () {
+    return this.__checkFilePath ?? this.scriptPath
+  }
+
   synthesize () {
     return {
       ...super.synthesize(),
@@ -113,7 +117,6 @@ export class BrowserCheck extends Check {
       script: this.script,
       scriptPath: this.scriptPath,
       dependencies: this.dependencies,
-      sourceFile: this.__checkFilePath ?? this.scriptPath,
     }
   }
 }

--- a/packages/cli/src/constructs/check.ts
+++ b/packages/cli/src/constructs/check.ts
@@ -141,6 +141,10 @@ export abstract class Check extends Construct {
     }
   }
 
+  getSourceFile () {
+    return this.__checkFilePath
+  }
+
   synthesize () {
     return {
       name: this.name,
@@ -155,8 +159,6 @@ export abstract class Check extends Construct {
       frequency: this.frequency,
       groupId: this.groupId,
       environmentVariables: this.environmentVariables,
-      __checkFilePath: this.__checkFilePath,
-      sourceFile: this.__checkFilePath,
     }
   }
 }

--- a/packages/cli/src/constructs/construct.ts
+++ b/packages/cli/src/constructs/construct.ts
@@ -1,6 +1,5 @@
 import { Session } from './project'
 import { Ref } from './ref'
-import { ValidationError } from './validator-error'
 
 export abstract class Construct {
   type: string

--- a/packages/cli/src/services/project-parser.ts
+++ b/packages/cli/src/services/project-parser.ts
@@ -47,7 +47,7 @@ export async function parseProject (opts: ProjectParseOpts): Promise<Project> {
     repoUrl,
   })
   checklyConfigConstructs?.forEach(
-    (construct) => project.addResource(construct.type, construct.logicalId, construct.synthesize()),
+    (construct) => project.addResource(construct.type, construct.logicalId, construct),
   )
   Session.project = project
   Session.basePath = directory
@@ -97,9 +97,9 @@ async function loadAllBrowserChecks (
   }
   const checkFiles = await findFilesWithPattern(directory, browserCheckFilePattern, ignorePattern)
   const preexistingCheckFiles = new Set<string>()
-  Object.values(project.data.checks).forEach(({ scriptPath }) => {
-    if (scriptPath) {
-      preexistingCheckFiles.add(scriptPath)
+  Object.values(project.data.checks).forEach((check) => {
+    if (check instanceof BrowserCheck && check.scriptPath) {
+      preexistingCheckFiles.add(check.scriptPath)
     }
   })
 

--- a/packages/cli/src/services/test-filters.ts
+++ b/packages/cli/src/services/test-filters.ts
@@ -3,9 +3,9 @@ export function filterByCheckNamePattern (checkNamePattern = '', checkName: stri
   return re.test(checkName)
 }
 
-export function filterByFileNamePattern (filePatterns: Array<string> = [], path: string) {
+export function filterByFileNamePattern (filePatterns: Array<string> = [], path: string|undefined) {
   return !!filePatterns.find(filePattern => {
     const re = new RegExp(filePattern)
-    return re.test(path)
+    return re.test(path as any)
   })
 }


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Currently the `Project` tracks all of the `synthesize()` result of checks, groups, and alert channels rather than tracking the original construct. This means that after parsing the project, we only have access to the results of `synthesize()`.

This has worked OK so far, but it also has a few small issues. In particular, we need to put internal properties in the `synthesize()` result. These internal properties need to be removed later on in `checkly deploy`  before messaging the backend https://github.com/checkly/checkly-cli/blob/f2ab503c5997de1fa9b1f5565bd3872395e1b48e/packages/cli/src/commands/deploy.ts#L72-L82

In this PR, I make `Project` track the original construct objects. We can then access the construct method and any internal properties throughout the CLI codebase. `synthesize()` is only called at the last moment - when serializing a request before sending to the backend.