### PR TITLE
refactor: dont export project from constructs [sc-0]

### DIFF
--- a/packages/cli/src/constructs/index.ts
+++ b/packages/cli/src/constructs/index.ts
@@ -1,4 +1,3 @@
-export * from './project'
 export * from './sms-alert-channel'
 export * from './email-alert-channel'
 export * from './slack-alert-channel'

--- a/packages/cli/src/services/checkly-config-loader.ts
+++ b/packages/cli/src/services/checkly-config-loader.ts
@@ -2,7 +2,7 @@ import * as path from 'path'
 import { existsSync } from 'fs'
 import { loadJsFile, loadTsFile } from './util'
 import { CheckProps } from '../constructs/check'
-import { Session } from '../constructs'
+import { Session } from '../constructs/project'
 import { Construct } from '../constructs/construct'
 
 export type CheckConfigDefaults = Pick<CheckProps, 'activated' | 'muted' | 'doubleCheck'

--- a/packages/cli/src/services/project-parser.ts
+++ b/packages/cli/src/services/project-parser.ts
@@ -1,4 +1,5 @@
-import { BrowserCheck, Project, Session } from '../constructs'
+import { Project, Session } from '../constructs/project'
+import { BrowserCheck } from '../constructs'
 import { promisify } from 'util'
 import * as glob from 'glob'
 import { loadJsFile, loadTsFile } from './util'


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Don't export Project from the constructs module to avoid users make mistakes by trying to do something with the exported class