### PR TITLE
fix: handle no cli option and push verbose config [sc-0]

### DIFF
--- a/packages/cli/e2e/__tests__/fixtures/test-project/checks.check.ts
+++ b/packages/cli/e2e/__tests__/fixtures/test-project/checks.check.ts
@@ -21,6 +21,6 @@ new BrowserCheck('browser-check', {
   activated: false,
   code: {
     // Remove the throw new Error when we support a verbose flag for check output
-    content: 'console.info(process.env.SECRET_ENV); throw new Error();'
+    content: 'console.info(process.env.SECRET_ENV);'
   }
 })

--- a/packages/cli/e2e/__tests__/test.spec.ts
+++ b/packages/cli/e2e/__tests__/test.spec.ts
@@ -13,7 +13,7 @@ describe('test', () => {
       directory: path.join(__dirname, 'fixtures/test-project'),
     })
     expect(result.stdout).toContain(secretEnv)
-    expect(result.status).toBe(0)
+    expect(result.status).toBeNull()
   })
 
   it('Should terminate when no checks are found', () => {

--- a/packages/cli/e2e/__tests__/test.spec.ts
+++ b/packages/cli/e2e/__tests__/test.spec.ts
@@ -7,13 +7,13 @@ describe('test', () => {
   it('Test project should run successfully', () => {
     const secretEnv = uuid.v4()
     const result = runChecklyCli({
-      args: ['test', '-e', `SECRET_ENV=${secretEnv}`],
+      args: ['test', '-e', `SECRET_ENV=${secretEnv}`, '--verbose'],
       apiKey: config.get('apiKey'),
       accountId: config.get('accountId'),
       directory: path.join(__dirname, 'fixtures/test-project'),
     })
     expect(result.stdout).toContain(secretEnv)
-    expect(result.status).not.toBe(0)
+    expect(result.status).toBe(0)
   })
 
   it('Should terminate when no checks are found', () => {

--- a/packages/cli/e2e/run-checkly.ts
+++ b/packages/cli/e2e/run-checkly.ts
@@ -26,7 +26,6 @@ export function runChecklyCli (options: {
       CHECKLY_ACCOUNT_ID: accountId,
       ...env,
     },
-    maxBuffer: 1024 * 1024,
     cwd: directory ?? process.cwd(),
     encoding: 'utf-8',
     timeout,

--- a/packages/cli/e2e/run-checkly.ts
+++ b/packages/cli/e2e/run-checkly.ts
@@ -24,8 +24,9 @@ export function runChecklyCli (options: {
       PATH: process.env.PATH,
       CHECKLY_API_KEY: apiKey,
       CHECKLY_ACCOUNT_ID: accountId,
-      ...env
+      ...env,
     },
+    maxBuffer: 1024 * 1024,
     cwd: directory ?? process.cwd(),
     encoding: 'utf-8',
     timeout,

--- a/packages/cli/src/commands/baseCommand.ts
+++ b/packages/cli/src/commands/baseCommand.ts
@@ -5,8 +5,6 @@ export abstract class BaseCommand extends Command {
   static hidden = true
 
   protected init (): Promise<void> {
-    // It is otherwise null
-    process.exitCode = 0
     api.defaults.headers['x-checkly-cli-version'] = this.config.version
     return super.init()
   }

--- a/packages/cli/src/commands/baseCommand.ts
+++ b/packages/cli/src/commands/baseCommand.ts
@@ -5,6 +5,8 @@ export abstract class BaseCommand extends Command {
   static hidden = true
 
   protected init (): Promise<void> {
+    // It is otherwise null
+    process.exitCode = 0
     api.defaults.headers['x-checkly-cli-version'] = this.config.version
     return super.init()
   }

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -63,8 +63,8 @@ export default class Test extends AuthCommand {
     }),
     verbose: Flags.boolean({
       char: 'v',
-      default: false,
       description: 'Always show the logs of the checks.',
+      allowNo: true,
     }),
   }
 
@@ -89,7 +89,7 @@ export default class Test extends AuthCommand {
       'env-file': envFile,
       list,
       timeout,
-      verbose,
+      verbose: verboseFlag,
     } = flags
     const cwd = process.cwd()
     const filePatterns = argv as string[]
@@ -97,6 +97,7 @@ export default class Test extends AuthCommand {
     const testEnvVars = await getEnvs(envFile, env)
     const { config: checklyConfig, constructs: checklyConfigConstructs } = await loadChecklyConfig(cwd)
     const location = await this.prepareRunLocation(checklyConfig.cli, { runLocation, privateRunLocation })
+    const verbose = this.prepareVerboseFlag(verboseFlag, checklyConfig.cli?.verbose)
     const { data: availableRuntimes } = await api.runtimes.getAll()
     const project = await parseProject({
       directory: cwd,
@@ -182,9 +183,13 @@ export default class Test extends AuthCommand {
     await runner.run()
   }
 
+  prepareVerboseFlag (verboseFlag?: boolean, cliVerboseFlag?: boolean) {
+    return verboseFlag ?? cliVerboseFlag ?? false
+  }
+
   async prepareRunLocation (
     configOptions: { runLocation?: string, privateRunLocation?: string } = {},
-    cliFlags: { runLocation?: string, privateRunLocation?: string },
+    cliFlags: { runLocation?: string, privateRunLocation?: string } = {},
   ): Promise<RunLocation> {
     // Command line options take precedence
     if (cliFlags.runLocation) {

--- a/packages/cli/src/services/checkly-config-loader.ts
+++ b/packages/cli/src/services/checkly-config-loader.ts
@@ -50,6 +50,7 @@ export type ChecklyConfig = {
   cli?: {
     runLocation?: string,
     privateRunLocation?: string,
+    verbose?: boolean
   }
 }
 


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
* Handle the missing cli field in the config
* Add the verbose flag support to the config as well
* Update the test to use the verbose flag as well to avoid false negatives

Tested the cases manually using the advanced-project