### PR TITLE
fix: remove name property for slack alert channel example [sc-00]

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,7 +656,6 @@ Sends a Slack message to an incoming Slack webhook address. You can specify the 
 const { SlackAlertChannel } = require('@checkly/cli/constructs')
 
 const slackChannel = new SlackAlertChannel('slack-channel-1', {
-  name: 'Slack channel',
   url: 'https://hooks.slack.com/services/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',
   channel: '#ops'
 })


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [ ] CLI
* [ ] Create CLI
* [ ] Test
* [X] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->
Updates the README to remove the misleading `name` property in the Slack Alert channel example.

See: https://checklyhq.slack.com/archives/C046VCZPBNH/p1676024249563939

