### PR TITLE
chore: change GH issue template labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,8 +1,7 @@
 name: "Bug report"
 description: Create a report to help us improve
 title: 'bug: '
-labels:
-  - 'type: bug'
+labels: ['bug']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/docs_request.yml
+++ b/.github/ISSUE_TEMPLATE/docs_request.yml
@@ -1,8 +1,7 @@
 name: 'New docs request/improvement'
 description: A request to update or improve provider documentation
 title: 'docs: '
-labels:
-  - 'type: documentation'
+labels: ['documentation']
 body:
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,8 +1,7 @@
 name: " New feature request"
 description: Suggest an idea for this project
 title: 'feat: '
-labels:
-  - 'type: feature request'
+labels: ['enhancement']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/story.yml
+++ b/.github/ISSUE_TEMPLATE/story.yml
@@ -1,8 +1,7 @@
 name: "New Story"
 description: Create a new working ticket (maintainers only)
 title: 'story: '
-labels:
-  - 'type: epic'
+labels: []
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [ ] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [x] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
It appears that labels aren't automatically being added to new issues when using the GH issue templates. This PR changes the syntax to follow [this doc](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms) and changes the label names to match our current labels. I'm not sure that it's possible to test this without merging, but I think that it should fix auto-labeling.
