### PR TITLE
docs: use defineConfig in examples

### DIFF
--- a/examples/advanced-project/checkly.config.ts
+++ b/examples/advanced-project/checkly.config.ts
@@ -1,4 +1,6 @@
-const config = {
+import { defineConfig } from '@checkly/cli'
+
+const config = defineConfig({
   projectName: 'Advanced Example Project',
   logicalId: 'advanced-example-project',
   repoUrl: 'https://github.com/checkly/checkly-cli',
@@ -14,6 +16,6 @@ const config = {
   cli: {
     runLocation: 'eu-west-1',
   },
-}
+})
 
 export default config

--- a/examples/boilerplate-project/checkly.config.ts
+++ b/examples/boilerplate-project/checkly.config.ts
@@ -1,4 +1,6 @@
-const config = {
+import { defineConfig } from '@checkly/cli'
+
+const config = defineConfig({
   projectName: 'Boilerplate Project',
   logicalId: 'boilerplate-project',
   repoUrl: 'https://github.com/checkly/checkly-cli',
@@ -14,6 +16,6 @@ const config = {
   cli: {
     runLocation: 'eu-west-1',
   },
-}
+})
 
 export default config


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [ ] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [x] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Having type checking and Intellisense completion for the Checkly config is quite useful ([docs here](https://www.checklyhq.com/docs/cli/project-structure/#config-intellisense)). We should consider making this the suggested setup in the examples, so that users don't need to search for it in the docs.

(Good idea @stefanjudis 🥳  )