### PR TITLE
feat: allow Region type augmentation [sc-0]

### DIFF
--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -13,6 +13,7 @@ import { filterByFileNamePattern, filterByCheckNamePattern } from '../services/t
 import type { Runtime } from '../rest/runtimes'
 import { AuthCommand } from './authCommand'
 import { BrowserCheck } from '../constructs'
+import type { Region } from '..'
 
 const DEFAULT_REGION = 'eu-central-1'
 
@@ -96,7 +97,10 @@ export default class Test extends AuthCommand {
 
     const testEnvVars = await getEnvs(envFile, env)
     const { config: checklyConfig, constructs: checklyConfigConstructs } = await loadChecklyConfig(cwd)
-    const location = await this.prepareRunLocation(checklyConfig.cli, { runLocation, privateRunLocation })
+    const location = await this.prepareRunLocation(checklyConfig.cli, {
+      runLocation: runLocation as keyof Region,
+      privateRunLocation,
+    })
     const verbose = this.prepareVerboseFlag(verboseFlag, checklyConfig.cli?.verbose)
     const { data: availableRuntimes } = await api.runtimes.getAll()
     const project = await parseProject({
@@ -188,8 +192,8 @@ export default class Test extends AuthCommand {
   }
 
   async prepareRunLocation (
-    configOptions: { runLocation?: string, privateRunLocation?: string } = {},
-    cliFlags: { runLocation?: string, privateRunLocation?: string } = {},
+    configOptions: { runLocation?: keyof Region, privateRunLocation?: string } = {},
+    cliFlags: { runLocation?: keyof Region, privateRunLocation?: string } = {},
   ): Promise<RunLocation> {
     // Command line options take precedence
     if (cliFlags.runLocation) {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,5 +1,36 @@
 import type { ChecklyConfig } from './services/checkly-config-loader'
 
+/**
+ *  Supported regions
+ */
+
+declare module './' {
+  export interface Region {
+    'us-east-1': string
+    'us-east-2': string
+    'us-west-1': string
+    'us-west-2': string
+    'ca-central-1': string
+    'sa-east-1': string
+    'eu-west-1': string
+    'eu-central-1': string
+    'eu-west-2': string
+    'eu-west-3': string
+    'eu-north-1': string
+    'eu-south-1': string
+    'me-south-1': string
+    'ap-southeast-1': string
+    'ap-northeast-1': string
+    'ap-east-1': string
+    'ap-southeast-2': string
+    'ap-southeast-3': string
+    'ap-northeast-2': string
+    'ap-northeast-3': string
+    'ap-south-1': string
+    'af-south-1': string
+  }
+}
+
 export function defineConfig (config: ChecklyConfig): ChecklyConfig {
   return config
 }

--- a/packages/cli/src/constructs/check-group.ts
+++ b/packages/cli/src/constructs/check-group.ts
@@ -48,7 +48,7 @@ export interface CheckGroupProps {
   /**
    * An array of one or more data center locations where to run the checks.
    */
-  locations: Array<Region>
+  locations: Array<keyof Region>
   /**
    * An array of one or more private locations where to run the checks.
    */
@@ -91,7 +91,7 @@ export class CheckGroup extends Construct {
   activated?: boolean
   muted?: boolean
   runtimeId?: string
-  locations: Array<Region>
+  locations: Array<keyof Region>
   privateLocations?: Array<string>
   tags?: Array<string>
   concurrency?: number

--- a/packages/cli/src/constructs/check-group.ts
+++ b/packages/cli/src/constructs/check-group.ts
@@ -8,7 +8,7 @@ import { AlertChannel } from './alert-channel'
 import { EnvironmentVariable } from './environment-variable'
 import { AlertChannelSubscription } from './alert-channel-subscription'
 import { CheckConfigDefaults } from '../services/checkly-config-loader'
-import type { Region } from './check'
+import type { Region } from '..'
 
 // TODO: turn this into type
 const defaultApiCheckDefaults = {

--- a/packages/cli/src/constructs/check.ts
+++ b/packages/cli/src/constructs/check.ts
@@ -5,17 +5,7 @@ import { EnvironmentVariable } from './environment-variable'
 import { AlertChannelSubscription } from './alert-channel-subscription'
 import { Session } from './project'
 import { CheckConfigDefaults } from '../services/checkly-config-loader'
-
-/**
- *  Supported regions
- */
-export type Region = 'us-east-1' | 'us-east-2' | 'us-west-1' | 'us-west-2'
-  | 'ca-central-1' | 'sa-east-1'
-  | 'eu-west-1' | 'eu-central-1' | 'eu-west-2' | 'eu-west-3' | 'eu-north-1' | 'eu-south-1'
-  | 'me-south-1'
-  | 'ap-southeast-1' | 'ap-northeast-1' | 'ap-east-1'
-  | 'ap-southeast-2' | 'ap-southeast-3' | 'ap-northeast-2' | 'ap-northeast-3'
-  | 'ap-south-1' | 'af-south-1'
+import type { Region } from '..'
 
 export interface CheckProps {
   /**
@@ -50,7 +40,7 @@ export interface CheckProps {
    * ap-southeast-1, ap-northeast-1, ap-east-1, ap-southeast-2, ap-southeast-3, ap-northeast-2, ap-northeast-3,
    * ap-south-1, af-south-1
    */
-  locations?: Array<Region>
+  locations?: Array<keyof Region>
   /**
    * An array of one or more private locations where to run the check.
    */
@@ -86,7 +76,7 @@ export abstract class Check extends Construct {
   doubleCheck?: boolean
   shouldFail?: boolean
   runtimeId?: string
-  locations?: Array<Region>
+  locations?: Array<keyof Region>
   privateLocations?: Array<string>
   tags?: Array<string>
   frequency?: number

--- a/packages/cli/src/services/check-runner.ts
+++ b/packages/cli/src/services/check-runner.ts
@@ -5,6 +5,7 @@ import { EventEmitter } from 'node:events'
 import type { AsyncMqttClient } from 'async-mqtt'
 import { Check } from '../constructs/check'
 import { CheckGroup } from '../constructs'
+import type { Region } from '..'
 
 export enum Events {
   CHECK_REGISTERED = 'CHECK_REGISTERED',
@@ -23,7 +24,7 @@ export type PrivateRunLocation = {
 }
 export type PublicRunLocation = {
   type: 'PUBLIC',
-  region: string,
+  region: keyof Region,
 }
 export type RunLocation = PublicRunLocation | PrivateRunLocation
 

--- a/packages/cli/src/services/checkly-config-loader.ts
+++ b/packages/cli/src/services/checkly-config-loader.ts
@@ -4,6 +4,7 @@ import { loadJsFile, loadTsFile } from './util'
 import { CheckProps } from '../constructs/check'
 import { Session } from '../constructs'
 import { Construct } from '../constructs/construct'
+import type { Region } from '..'
 
 export type CheckConfigDefaults = Pick<CheckProps, 'activated' | 'muted' | 'doubleCheck'
   | 'shouldFail' | 'runtimeId' | 'locations' | 'tags' | 'frequency' | 'environmentVariables'
@@ -48,7 +49,7 @@ export type ChecklyConfig = {
    * CLI default configuration properties.
    */
   cli?: {
-    runLocation?: string,
+    runLocation?: keyof Region,
     privateRunLocation?: string,
     verbose?: boolean
   }


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
- add typed `runLocation` attribute
- allow user to augment the `Region` type with missing new locations, example:
```ts
import { defineConfig, type Region } from '@checkly/cli'

declare module '@checkly/cli' {
  export interface Region {
    'ar-east-1': string
    'ar-central-1': string
    'ar-west-1': string
  }
}

export default defineConfig({
  projectName: 'Advanced Example Project',
  logicalId: 'advanced-example-project',
  repoUrl: 'https://github.com/checkly/checkly-cli',
  checks: {
    locations: ['us-east-1', 'ar-central-1'],
    tags: ['mac'],
    runtimeId: '2022.10',
    checkMatch: '**/*.check.ts',
    browserChecks: {
      testMatch: '**/__checks__/*.spec.ts', // this matches any Playwright spec-files and automagically creates a Browser check
    },
  },
  cli: {
    runLocation: 'ar-central-1',
  },
})
```
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #517 (not totally related)

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
