### PR TITLE
fix: handle Windows path separator for logical IDs

### DIFF
--- a/packages/cli/src/constructs/check-group.ts
+++ b/packages/cli/src/constructs/check-group.ts
@@ -8,6 +8,7 @@ import { AlertChannel } from './alert-channel'
 import { EnvironmentVariable } from './environment-variable'
 import { AlertChannelSubscription } from './alert-channel-subscription'
 import { CheckConfigDefaults } from '../services/checkly-config-loader'
+import { pathToLogicalId } from '../services/util'
 import type { Region } from '..'
 
 // TODO: turn this into type
@@ -161,7 +162,7 @@ export class CheckGroup extends Construct {
           entrypoint: filepath,
         },
       }
-      const checkLogicalId = path.relative(Session.basePath!, filepath)
+      const checkLogicalId = pathToLogicalId(path.relative(Session.basePath!, filepath))
       const check = new BrowserCheck(checkLogicalId, props)
     }
   }

--- a/packages/cli/src/services/__tests__/util.spec.js
+++ b/packages/cli/src/services/__tests__/util.spec.js
@@ -1,0 +1,26 @@
+import path from 'path'
+import { pathToLogicalId } from '../util'
+
+describe('pathToLogicalId()', () => {
+  it('should convert Windows paths', () => {
+    const originalSep = path.sep
+    try {
+      path.sep = '\\'
+      expect(pathToLogicalId('src\\__checks__\\my_check.spec.ts'))
+        .toEqual('src/__checks__/my_check.spec.ts')
+    } finally {
+      path.sep = originalSep
+    }
+  })
+
+  it('should have no effect on linux paths', () => {
+    const originalSep = path.sep
+    try {
+      path.sep = '/'
+      expect(pathToLogicalId('src/__checks__/my_check.spec.ts'))
+        .toEqual('src/__checks__/my_check.spec.ts')
+    } finally {
+      path.sep = originalSep
+    }
+  })
+})

--- a/packages/cli/src/services/project-parser.ts
+++ b/packages/cli/src/services/project-parser.ts
@@ -1,7 +1,7 @@
 import { BrowserCheck, Project, Session } from '../constructs'
 import { promisify } from 'util'
 import * as glob from 'glob'
-import { loadJsFile, loadTsFile } from './util'
+import { loadJsFile, loadTsFile, pathToLogicalId } from './util'
 import * as path from 'path'
 import { CheckConfigDefaults } from './checkly-config-loader'
 
@@ -109,7 +109,7 @@ async function loadAllBrowserChecks (
     if (preexistingCheckFiles.has(relPath)) {
       continue
     }
-    const browserCheck = new BrowserCheck(relPath, {
+    const browserCheck = new BrowserCheck(pathToLogicalId(relPath), {
       name: path.basename(checkFile),
       code: {
         entrypoint: checkFile,

--- a/packages/cli/src/services/util.ts
+++ b/packages/cli/src/services/util.ts
@@ -68,3 +68,10 @@ async function getTsCompiler (): Promise<Service> {
   }
   return tsCompiler
 }
+
+export function pathToLogicalId (relPath: string): string {
+  // Windows uses \ rather than / as a path separator.
+  // It's important that logical ID's are consistent across platforms, though.
+  // Otherwise, checks will be deleted and recreated when `npx checkly deploy` is run on different machines.
+  return relPath.split(path.sep).join(path.posix.sep)
+}


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #539 

On Windows, the path separator is `\` rather than `/`. The relative path of `testMatch` files is used in the logical ID. This causes problems, though, since `\` isn't an allowed character in logical IDs. Users on Windows will receive the following error:
```
  Error: The 'logicalId' must includes only allowed characters [A-Za-z0-9_-/#.]. (logicalId='src\__checks__\check.spec.ts')
```

Additionally, logical ID's should be consistent across platforms. If `npx checkly deploy` produces different logical IDs in Linux CI vs a Windows developer laptop, then users would constantly see checks being deleted and recreated with each `npx checkly deploy`.

This PR resolves the issue by normalizing the logical IDs for `testMatch` files.

#### Test Plan

I've added a simple unit test to check that this works. 

I've also checked that this doesn't cause any breaking changes in logical ID's on macOS / Linux by running `npx checkly deploy` first with CLI version 0.4.0, then with this version. I've confirmed that the checks aren't recreated.
