### PR TITLE
feat: use latest checkly/cli version in examples

### DIFF
--- a/examples/advanced-project/package.json
+++ b/examples/advanced-project/package.json
@@ -10,7 +10,7 @@
     "checkly:test": "npx checkly test"
   },
   "dependencies": {
-    "@checkly/cli": "^0.3.13"
+    "@checkly/cli": "latest"
   },
   "author": "",
   "license": "ISC",

--- a/examples/boilerplate-project/package.json
+++ b/examples/boilerplate-project/package.json
@@ -8,7 +8,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@checkly/cli": "^0.3.13"
+    "@checkly/cli": "latest"
   },
   "author": "",
   "license": "ISC",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@checkly/cli": "^0.3.13"
+        "@checkly/cli": "latest"
       },
       "devDependencies": {
         "ts-node": "10.9.1",
@@ -24,9 +24,9 @@
       }
     },
     "examples/advanced-project/node_modules/@checkly/cli": {
-      "version": "0.3.15",
-      "resolved": "https://registry.npmjs.org/@checkly/cli/-/cli-0.3.15.tgz",
-      "integrity": "sha512-iBZugDXwXgLvlyveG8he9rG3i1XuC2uR5oXAx9sbf4uvSattODeD3YbkhC/lvhecIGNH+rfJsQu+r3VDaJbRcA==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@checkly/cli/-/cli-0.4.2.tgz",
+      "integrity": "sha512-ZDb5aoZnf85TdAxelTMm08Z4uJFg63k549vvRtJsxZT+IkSW9Ug+7lsgGmDpUHCnYDC3ClOBgc9gSDhpWv0uog==",
       "dependencies": {
         "@oclif/core": "2.0.7",
         "@oclif/plugin-help": "5.1.20",
@@ -46,7 +46,7 @@
         "inquirer": "8.2.3",
         "jwt-decode": "3.1.2",
         "log-symbols": "4.1.0",
-        "luxon": "3.2.0",
+        "luxon": "3.2.1",
         "open": "8.4.0",
         "uuid": "9.0.0"
       },
@@ -173,7 +173,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@checkly/cli": "^0.3.13"
+        "@checkly/cli": "latest"
       },
       "devDependencies": {
         "ts-node": "10.9.1",
@@ -181,9 +181,9 @@
       }
     },
     "examples/boilerplate-project/node_modules/@checkly/cli": {
-      "version": "0.3.15",
-      "resolved": "https://registry.npmjs.org/@checkly/cli/-/cli-0.3.15.tgz",
-      "integrity": "sha512-iBZugDXwXgLvlyveG8he9rG3i1XuC2uR5oXAx9sbf4uvSattODeD3YbkhC/lvhecIGNH+rfJsQu+r3VDaJbRcA==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@checkly/cli/-/cli-0.4.2.tgz",
+      "integrity": "sha512-ZDb5aoZnf85TdAxelTMm08Z4uJFg63k549vvRtJsxZT+IkSW9Ug+7lsgGmDpUHCnYDC3ClOBgc9gSDhpWv0uog==",
       "dependencies": {
         "@oclif/core": "2.0.7",
         "@oclif/plugin-help": "5.1.20",
@@ -203,7 +203,7 @@
         "inquirer": "8.2.3",
         "jwt-decode": "3.1.2",
         "log-symbols": "4.1.0",
-        "luxon": "3.2.0",
+        "luxon": "3.2.1",
         "open": "8.4.0",
         "uuid": "9.0.0"
       },
@@ -9191,9 +9191,9 @@
       }
     },
     "node_modules/luxon": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.0.tgz",
-      "integrity": "sha512-Namj3XqoJjFekq/JHQEaaAv4zyE/fyyDBrMEBnIL2s/X54SC8W5Ea0uej1TRXUArWec8OojsAVsGBYhNRjpMVw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
+      "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg==",
       "engines": {
         "node": ">=12"
       }
@@ -11860,14 +11860,6 @@
         "node": ">=8"
       }
     },
-    "packages/cli/node_modules/luxon": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
-      "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "packages/cli/node_modules/minimatch": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
@@ -12452,11 +12444,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "luxon": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
-          "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg=="
         },
         "minimatch": {
           "version": "5.1.6",
@@ -14524,15 +14511,15 @@
     "advanced-project": {
       "version": "file:examples/advanced-project",
       "requires": {
-        "@checkly/cli": "^0.3.13",
+        "@checkly/cli": "latest",
         "ts-node": "10.9.1",
         "typescript": "4.9.5"
       },
       "dependencies": {
         "@checkly/cli": {
-          "version": "0.3.15",
-          "resolved": "https://registry.npmjs.org/@checkly/cli/-/cli-0.3.15.tgz",
-          "integrity": "sha512-iBZugDXwXgLvlyveG8he9rG3i1XuC2uR5oXAx9sbf4uvSattODeD3YbkhC/lvhecIGNH+rfJsQu+r3VDaJbRcA==",
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/@checkly/cli/-/cli-0.4.2.tgz",
+          "integrity": "sha512-ZDb5aoZnf85TdAxelTMm08Z4uJFg63k549vvRtJsxZT+IkSW9Ug+7lsgGmDpUHCnYDC3ClOBgc9gSDhpWv0uog==",
           "requires": {
             "@oclif/core": "2.0.7",
             "@oclif/plugin-help": "5.1.20",
@@ -14552,7 +14539,7 @@
             "inquirer": "8.2.3",
             "jwt-decode": "3.1.2",
             "log-symbols": "4.1.0",
-            "luxon": "3.2.0",
+            "luxon": "3.2.1",
             "open": "8.4.0",
             "uuid": "9.0.0"
           }
@@ -14986,15 +14973,15 @@
     "boilerlate-project": {
       "version": "file:examples/boilerplate-project",
       "requires": {
-        "@checkly/cli": "^0.3.13",
+        "@checkly/cli": "latest",
         "ts-node": "10.9.1",
         "typescript": "4.9.5"
       },
       "dependencies": {
         "@checkly/cli": {
-          "version": "0.3.15",
-          "resolved": "https://registry.npmjs.org/@checkly/cli/-/cli-0.3.15.tgz",
-          "integrity": "sha512-iBZugDXwXgLvlyveG8he9rG3i1XuC2uR5oXAx9sbf4uvSattODeD3YbkhC/lvhecIGNH+rfJsQu+r3VDaJbRcA==",
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/@checkly/cli/-/cli-0.4.2.tgz",
+          "integrity": "sha512-ZDb5aoZnf85TdAxelTMm08Z4uJFg63k549vvRtJsxZT+IkSW9Ug+7lsgGmDpUHCnYDC3ClOBgc9gSDhpWv0uog==",
           "requires": {
             "@oclif/core": "2.0.7",
             "@oclif/plugin-help": "5.1.20",
@@ -15014,7 +15001,7 @@
             "inquirer": "8.2.3",
             "jwt-decode": "3.1.2",
             "log-symbols": "4.1.0",
-            "luxon": "3.2.0",
+            "luxon": "3.2.1",
             "open": "8.4.0",
             "uuid": "9.0.0"
           }
@@ -19185,9 +19172,9 @@
       }
     },
     "luxon": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.0.tgz",
-      "integrity": "sha512-Namj3XqoJjFekq/JHQEaaAv4zyE/fyyDBrMEBnIL2s/X54SC8W5Ea0uej1TRXUArWec8OojsAVsGBYhNRjpMVw=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
+      "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg=="
     },
     "make-dir": {
       "version": "3.1.0",


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [ ] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [x] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Currently the examples are set to use version `^0.3.13` of `@checkly/cli`. Since there isn't yet a `1.0.0` release, though, this will enforce that the version `0.3.x` is used ([more info](https://michaelsoolee.com/npm-pre-1-caret-rules/)). Users of `npx create @checkly/cli` will end up using the alpha version `0.3.15` rather than the latest version of `@checkly/cli`.

One fix would simply be to update the exampels to use `^0.4.0`. I think that we may have trouble forgetting to keep this up-to-date, though, when `0.5.0` is released. To make sure that the examples are always using the latest CLI version, this PR simply updates them to `latest` for `@checkly/cli`.
