### PR TITLE
fix: log clear error in case of internet connection issues

### DIFF
--- a/packages/cli/src/commands/authCommand.ts
+++ b/packages/cli/src/commands/authCommand.ts
@@ -6,6 +6,6 @@ export abstract class AuthCommand extends BaseCommand {
 
   protected async init (): Promise<any> {
     super.init()
-    await api.isAuthenticated()
+    await api.validateAuthentication()
   }
 }

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -73,7 +73,7 @@ export default class Login extends BaseCommand {
   }
 
   private _isLoginSuccess = async () => {
-    await api.isAuthenticated()
+    await api.validateAuthentication()
     this.log('Welcome to @checkly/cli 🦝')
   }
 

--- a/packages/cli/src/rest/api.ts
+++ b/packages/cli/src/rest/api.ts
@@ -37,7 +37,7 @@ export function getDefaults () {
   return { baseURL, accountId, Authorization, apiKey }
 }
 
-export async function isAuthenticated (): Promise<boolean> {
+export async function validateAuthentication (): Promise<void> {
   if (!config.hasValidCredentials()) {
     throw new Error('Run `npx checkly login` or manually set `CHECKLY_API_KEY` ' +
       '& `CHECKLY_ACCOUNT_ID` environment variables to setup authentication.')
@@ -49,15 +49,17 @@ export async function isAuthenticated (): Promise<boolean> {
   try {
     // check if credentials works
     await accounts.get(accountId)
-    return true
   } catch (err: any) {
-    const { status } = err.response
-    if (status === 401) {
+    if (err.response?.status === 401) {
       throw new Error(`Authentication failed with Account ID "${accountId}" ` +
         `and API key "...${apiKey?.slice(-4)}"`)
+    } else if (!err.response) {
+      // The request was made but no response was received. This may be due to an internet connection issue.
+      throw new Error(`Encountered an error connecting to Checkly. Please check that the internet conenction is working.\nCause: ${err.message}`)
+    } else {
+      throw new Error(`Encountered an unexpected error connecting to Checkly: ${err.message}`)
     }
   }
-  return false
 }
 
 function init (): AxiosInstance {


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #545 

When there's no internet connection, the CLI fails with an unclear error. This can be reproduced by disabling WIFI.
```
$ npx checkly test
    TypeError: Cannot destructure property 'status' of 'err.response' as it is undefined.
```

This PR detects this case by checking whether `err.response` is defined, and returns a more specific error message. The error messages returned are now: 

Incorrect API key (unchanged):
```
$ npx checkly test
    Error: Authentication failed with Account ID "bf7babe3-0589-4cc9-9358-f706b3b11362"
    and API key "...8b0f"
```

Wifi Disabled:
```
$ npx checkly test
    Error: Encountered an error connecting to Checkly. Please check that the internet
    conenction is working.
    Error: getaddrinfo ENOTFOUND api.checklyhq.com
```

Unexpected error (for example, a 404 from Checkly):
```
$ npx checkly test
    Error: Encountered an unexpected error connecting to Checkly: Request failed with
    status code 404
```

Implementing this, I referred to [Axios error handling docs](https://axios-http.com/docs/handling_errors)

I also made some small changes to `isAuthenticated`. The boolean return value is never used, so I changed it to `validateAuthentication`. It throws an error if there's an issue, otherwise it returns.

