### PR TITLE
feat: allow setting check group without calling ref()

### DIFF
--- a/examples/advanced-project/src/__checks__/group.check.ts
+++ b/examples/advanced-project/src/__checks__/group.check.ts
@@ -3,7 +3,7 @@ import { smsChannel, emailChannel } from '../alert-channels'
 const alertChannels = [smsChannel, emailChannel]
 /*
 * In this example, we bundle checks using a Check Group. We add checks to this group in two ways:
-* 1. By calling the ref() method for the groupId property of the check.
+* 1. By passing the `CheckGroup` object for the `group` property of the check.
 * 2. By defining a glob pattern that matches browser checks using *.spec.js.
 *
 * You can use either or both.
@@ -29,7 +29,7 @@ const group = new CheckGroup('check-group-1', {
 
 new ApiCheck('check-group-api-check-1', {
   name: 'Homepage - fetch stats',
-  groupId: group.ref(),
+  group,
   degradedResponseTime: 10000,
   maxResponseTime: 20000,
   request: {

--- a/packages/cli/e2e/__tests__/fixtures/test-duplicated-groups/group1.check.ts
+++ b/packages/cli/e2e/__tests__/fixtures/test-duplicated-groups/group1.check.ts
@@ -13,5 +13,5 @@ new BrowserCheck('browser-check', {
     // Remove the throw new Error when we support a verbose flag for check output
     content: 'console.info(process.env.SECRET_ENV);'
   },
-  groupId: group2.ref()
+  group: group2,
 })

--- a/packages/cli/e2e/__tests__/fixtures/test-duplicated-groups/group2.check.ts
+++ b/packages/cli/e2e/__tests__/fixtures/test-duplicated-groups/group2.check.ts
@@ -9,7 +9,7 @@ const group1 = new CheckGroup('my-check-group', {
 new ApiCheck('api-check', {
   name: 'Api Check',
   activated: false,
-  groupId: group1.ref(),
+  group: group1,
   request: {
     url: 'https://www.google.com',
     method: 'GET',

--- a/packages/cli/src/constructs/__tests__/browser-check.spec.ts
+++ b/packages/cli/src/constructs/__tests__/browser-check.spec.ts
@@ -1,4 +1,4 @@
-import { BrowserCheck } from '../index'
+import { BrowserCheck, CheckGroup } from '../index'
 import { Project, Session } from '../project'
 import * as path from 'path'
 
@@ -72,5 +72,33 @@ describe('BrowserCheck', () => {
     delete Session.checkDefaults
     delete Session.browserCheckDefaults
     expect(browserCheck).toMatchObject({ tags: ['browser check default'] })
+  })
+
+  it('should support setting groups with `groupId`', () => {
+    Session.project = new Project('project-id', {
+      name: 'Test Project',
+      repoUrl: 'https://github.com/checkly/checkly-cli',
+    })
+    const group = new CheckGroup('main-group', { name: 'Main Group', locations: [] })
+    const check = new BrowserCheck('main-check', {
+      name: 'Main Check',
+      code: { content: '' },
+      groupId: group.ref(),
+    })
+    expect(check.synthesize()).toMatchObject({ groupId: { ref: 'main-group' } })
+  })
+
+  it('should support setting groups with `group`', () => {
+    Session.project = new Project('project-id', {
+      name: 'Test Project',
+      repoUrl: 'https://github.com/checkly/checkly-cli',
+    })
+    const group = new CheckGroup('main-group', { name: 'Main Group', locations: [] })
+    const check = new BrowserCheck('main-check', {
+      name: 'Main Check',
+      code: { content: '' },
+      group,
+    })
+    expect(check.synthesize()).toMatchObject({ groupId: { ref: 'main-group' } })
   })
 })

--- a/packages/cli/src/constructs/check-group.ts
+++ b/packages/cli/src/constructs/check-group.ts
@@ -155,7 +155,7 @@ export class CheckGroup extends Construct {
       }
       const filepath = path.join(parent, match)
       const props = {
-        groupId: this.ref(),
+        group: this,
         name: match,
         ...defaults,
         code: {

--- a/packages/cli/src/constructs/check.ts
+++ b/packages/cli/src/constructs/check.ts
@@ -6,6 +6,7 @@ import { AlertChannelSubscription } from './alert-channel-subscription'
 import { Session } from './project'
 import { CheckConfigDefaults } from '../services/checkly-config-loader'
 import type { Region } from '..'
+import { CheckGroup } from './check-group'
 
 export interface CheckProps {
   /**
@@ -57,8 +58,13 @@ export interface CheckProps {
   environmentVariables?: Array<EnvironmentVariable>
   /**
    * The id of the check group this check is part of. Set this by calling `someGroup.ref()`
+   * @deprecated Use {@link CheckProps.group} instead.
    */
   groupId?: Ref
+  /**
+   * The CheckGroup that this check is part of.
+   */
+  group?: CheckGroup
   /**
    * List of alert channels to notify when the check fails or recovers.
    */
@@ -107,7 +113,8 @@ export abstract class Check extends Construct {
     // Alert channel subscriptions will be synthesized separately in the Project construct.
     // This is due to the way things are organized on the BE.
     this.alertChannels = props.alertChannels ?? []
-    this.groupId = props.groupId
+    // Prefer the `group` parameter, but support groupId for backwards compatibility.
+    this.groupId = props.group?.ref() ?? props.groupId
     // alertSettings, useGlobalAlertSettings, groupId, groupOrder
 
     this.testOnly = props.testOnly ?? false


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
The `Check` construct already accepts `alertChannels` as actual `AlertChannel` constructs, but for `groupId` it accepts a `Ref` rather than a `CheckGroup`. This is a bit inconsistent, and it would be nice to follow one pattern for linking constructs. 

https://github.com/checkly/checkly-cli/blob/d1a1bed14d68fba64103b916bc8f90fedbec37d3/packages/cli/src/constructs/check.ts#L62-L65

This PR updates the preferred method of assigning a check to a group from passing a ref:
```
new BrowserCheck('logicalId', { groupId: group.ref() })
```

to passing the group construct:
```
new BrowserCheck('logicalId', { group })
```

This is done in a backwards compatible way. The old `groupId` property is marked as deprecated.
<img width="651" alt="Screenshot 2023-02-22 at 15 34 03" src="https://user-images.githubusercontent.com/10483186/220658473-7781ff5c-7b52-443d-84c4-04a946fed73a.png">


This PR also updates the examples since it's just one line. To avoid a race condition, a release should be made right after this is merged. Docs are updated in https://github.com/checkly/checklyhq.com/pull/683.