### PR TITLE
fix: use correct base path for CheckGroup testMatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5995,7 +5995,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -11749,6 +11748,7 @@
         "ci-info": "3.7.1",
         "conf": "10.2.0",
         "dotenv": "16.0.3",
+        "get-caller-file": "2.0.5",
         "glob": "8.0.3",
         "indent-string": "4.0.0",
         "inquirer": "8.2.3",
@@ -12376,6 +12376,7 @@
         "config": "3.3.8",
         "dotenv": "16.0.3",
         "eslint": "8.30.0",
+        "get-caller-file": "2.0.5",
         "glob": "8.0.3",
         "indent-string": "4.0.0",
         "inquirer": "8.2.3",
@@ -16810,8 +16811,7 @@
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-intrinsic": {
       "version": "1.2.0",

--- a/packages/cli/e2e/__tests__/deploy.spec.ts
+++ b/packages/cli/e2e/__tests__/deploy.spec.ts
@@ -64,4 +64,22 @@ describe('deploy', () => {
     expect(result.stdout).not.toContain('testonly-true-check')
     expect(result.status).toBe(0)
   })
+
+  /**
+  * `CheckGroup` supports loading *.spec.ts checks using `testMatch`, and `BrowserCheck` supports relative paths for *.spec.ts files.
+  * The base path for loading these extra files should be the file where `CheckGroup`/`BrowserCheck` are actually instantiated.
+  * This test checks the edge case where `CheckGroup` and `BrowserCheck` aren't instantiated directly in the *.check.ts file.
+  * Instead the objects are imported from helper files.
+  */
+  it('Should correctly detect files based on where constructs are stored', () => {
+    const result = runChecklyCli({
+      args: ['deploy', '--preview'],
+      apiKey: config.get('apiKey'),
+      accountId: config.get('accountId'),
+      directory: path.join(__dirname, 'fixtures/relative-path-edge-case'),
+    })
+    expect(result.stdout).toContain('BrowserCheck: group-dir/example.ts')
+    expect(result.stdout).toContain('BrowserCheck: example-check')
+    expect(result.status).toBe(0)
+  })
 })

--- a/packages/cli/e2e/__tests__/fixtures/relative-path-edge-case/check-dir/check-definition.ts
+++ b/packages/cli/e2e/__tests__/fixtures/relative-path-edge-case/check-dir/check-definition.ts
@@ -1,0 +1,8 @@
+// This file isn't actually a *.check.ts file. It simply exports the check object.
+// The `entrypoint` should be applied relative to this file (check-definition.ts), though, in order to import the file.
+import { BrowserCheck } from '@checkly/cli/constructs'
+
+export const check = new BrowserCheck('example-check', {
+  name: 'Browser Check',
+  code: { entrypoint: 'example.ts' },
+})

--- a/packages/cli/e2e/__tests__/fixtures/relative-path-edge-case/check-dir/example.ts
+++ b/packages/cli/e2e/__tests__/fixtures/relative-path-edge-case/check-dir/example.ts
@@ -1,0 +1,1 @@
+console.log('Executing the check')

--- a/packages/cli/e2e/__tests__/fixtures/relative-path-edge-case/checkly.config.ts
+++ b/packages/cli/e2e/__tests__/fixtures/relative-path-edge-case/checkly.config.ts
@@ -1,0 +1,7 @@
+const config = {
+  projectName: 'Relative Path Edge Case',
+  logicalId: 'relative-path-edge-case',
+  repoUrl: 'https://github.com/checkly/checkly-cli',
+}
+export default config
+

--- a/packages/cli/e2e/__tests__/fixtures/relative-path-edge-case/group-dir/example.ts
+++ b/packages/cli/e2e/__tests__/fixtures/relative-path-edge-case/group-dir/example.ts
@@ -1,0 +1,1 @@
+console.log('Example check')

--- a/packages/cli/e2e/__tests__/fixtures/relative-path-edge-case/group-dir/group-definition.ts
+++ b/packages/cli/e2e/__tests__/fixtures/relative-path-edge-case/group-dir/group-definition.ts
@@ -1,0 +1,9 @@
+// This file isn't actually a *.check.ts file. It simply exports the group.
+// The `testMatch` should be applied relative to this file (group-definition.ts), though, in order to import example.ts.
+import { CheckGroup } from '@checkly/cli/constructs'
+
+export const group = new CheckGroup('group', {
+  name: 'Check Group',
+  locations: [],
+  browserChecks: { testMatch: 'example.ts' },
+})

--- a/packages/cli/e2e/__tests__/fixtures/relative-path-edge-case/resources.check.ts
+++ b/packages/cli/e2e/__tests__/fixtures/relative-path-edge-case/resources.check.ts
@@ -1,0 +1,7 @@
+import * as groupResources from './group-dir/group-definition'
+import * as checkResources from './check-dir/check-definition'
+
+// This is needed to avoid the imports from being optimized away
+if (!groupResources || !checkResources) {
+  throw new Error('Failed to import resources')
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -57,6 +57,7 @@
     "ci-info": "3.7.1",
     "conf": "10.2.0",
     "dotenv": "16.0.3",
+    "get-caller-file": "2.0.5",
     "glob": "8.0.3",
     "indent-string": "4.0.0",
     "inquirer": "8.2.3",

--- a/packages/cli/src/constructs/browser-check.ts
+++ b/packages/cli/src/constructs/browser-check.ts
@@ -1,4 +1,5 @@
 import * as path from 'path'
+import * as getCallerFile from 'get-caller-file'
 import { Check, CheckProps } from './check'
 import { Session } from './project'
 import { Parser } from '../services/check-parser/parser'
@@ -56,10 +57,11 @@ export class BrowserCheck extends Check {
       if (path.isAbsolute(entrypoint)) {
         absoluteEntrypoint = entrypoint
       } else {
-        if (!Session.checkFileAbsolutePath) {
-          throw new Error('You cant use relative paths without the checkFileAbsolutePath in session')
-        }
-        absoluteEntrypoint = path.join(path.dirname(Session.checkFileAbsolutePath), entrypoint)
+        // getCallerFile() finds the exact file where the CheckGroup constructor was called.
+        // It does this by parsing the stack trace of an Error.
+        // This is a fragile hack, but it's nice to not require users to pass the base file explicitly.
+        const baseFileAbsolutePath = getCallerFile()
+        absoluteEntrypoint = path.join(path.dirname(baseFileAbsolutePath), entrypoint)
       }
       // runtimeId will always be set by check or browser check defaults so it is safe to use ! operator
       const bundle = BrowserCheck.bundle(absoluteEntrypoint, this.runtimeId!)

--- a/packages/cli/src/constructs/project.ts
+++ b/packages/cli/src/constructs/project.ts
@@ -100,7 +100,6 @@ export class Session {
   static checkDefaults?: CheckConfigDefaults
   static browserCheckDefaults?: CheckConfigDefaults
   static checkFilePath?: string
-  static checkFileAbsolutePath?: string
   static availableRuntimes: Record<string, Runtime>
   static loadingChecklyConfigFile: boolean
   static checklyConfigFileConstructs?: Construct[]

--- a/packages/cli/src/services/project-parser.ts
+++ b/packages/cli/src/services/project-parser.ts
@@ -71,7 +71,6 @@ async function loadAllCheckFiles (
   const checkFiles = await findFilesWithPattern(directory, checkFilePattern, ignorePattern)
   for (const checkFile of checkFiles) {
     // setting the checkFilePath is used for filtering by file name on the command line
-    Session.checkFileAbsolutePath = checkFile
     Session.checkFilePath = path.relative(directory, checkFile)
     if (checkFile.endsWith('.js')) {
       await loadJsFile(checkFile)
@@ -82,7 +81,6 @@ async function loadAllCheckFiles (
       `Please use a .js or .ts file instead.\n${checkFile}`)
     }
     Session.checkFilePath = undefined
-    Session.checkFileAbsolutePath = undefined
   }
 }
 


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #549

`CheckGroup` supports loading `*.spec.ts` checks using `testMatch`, and `BrowserCheck` supports relative paths for `*.spec.ts` files passed in `code: { entrypoint }`. Internally, these relative files are loaded using the `Session.checkFileAbsolutePath` as the base path. As mentioned in the linked GH issue - this doesn't always give the expected behavior. In particular, if the constructs are instantiated in a helper file then imported in a `*.check.ts` file - then the extra files will be loaded relative to the `*.check.ts` file. For a more clear illustration, see the test in this PR (which fails for `main`).

It's hard to detect the file where the `CheckGroup` constructor is actually called. One possible solution is to require the user to pass the base path explicitly:
```
new CheckGroup('my-group', { basePath: __filename })
```

This adds extra boilerplate for users, though. Instead, this PR uses a library [get-caller-file](https://github.com/stefanpenner/get-caller-file). This library parses the file name of the caller from the `Error` stack trace. This is a bit of a hack, but it works fine and the library is widely used. This let's us correctly detect which file the `CheckGroup` is actually instantiated in.

This will be a bit of a breaking change in case any users were importing `CheckGroup`'s and `Check`'s to other files. I think that it's unlikely that users are doing this, though, so I think it's OK to merge this. Maybe we should consider making the next release `0.5.x`, though.

