### PR TITLE
feat: log error message when no resources in deploy preview

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -155,6 +155,9 @@ export default class Deploy extends AuthCommand {
       }
       output.push('')
     }
+    if (!creating.length && !deleting.length && !updating.length) {
+      output.push('\nNo checks were detected. More information on how to set up a Checkly CLI project is available at https://checklyhq.com/docs/cli/.\n')
+    }
     return output.join('\n')
   }
 }

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -120,6 +120,11 @@ export default class Deploy extends AuthCommand {
         }
       }
     }
+
+    if (!creating.length && !deleting.length && !updating.length) {
+      return '\nNo checks were detected. More information on how to set up a Checkly CLI project is available at https://checklyhq.com/docs/cli/.\n'
+    }
+
     // Having some order will make the output easier to read.
     const compareEntries = (a: any, b: any) =>
       a.resourceType.localeCompare(b.resourceType) ||
@@ -154,9 +159,6 @@ export default class Deploy extends AuthCommand {
         output.push(`    ${construct.constructor.name}: ${logicalId}`)
       }
       output.push('')
-    }
-    if (!creating.length && !deleting.length && !updating.length) {
-      output.push('\nNo checks were detected. More information on how to set up a Checkly CLI project is available at https://checklyhq.com/docs/cli/.\n')
     }
     return output.join('\n')
   }


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->
Currently `npx checkly deploy --preview` has no output at all when no checks or other resources are detected. This output could be a bit misleading for new users.

This PR adds some output for this case:
```
$ npx checkly deploy --preview

No checks were detected. More information on how to set up a Checkly CLI project is available at https://checklyhq.com/docs/cli/.

```

This issue could happen for a number of reasons, so I'm not sure if it makes sense to give any other info in the output for now.