### PR TITLE
fix: dependencies path separator in Windows [sc-0]

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,9 +5,10 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
+    "clean" : "rimraf ./dist",
     "test": "jest --selectProjects unit",
     "test:e2e": "npm run prepare && NODE_CONFIG_DIR=./e2e/config jest --selectProjects E2E",
-    "prepare": "rm -rf dist && tsc --build",
+    "prepare": "npm run clean && tsc --build",
     "prepack": "npx oclif manifest",
     "lint": "eslint src"
   },

--- a/packages/cli/src/constructs/browser-check.ts
+++ b/packages/cli/src/constructs/browser-check.ts
@@ -96,13 +96,13 @@ export class BrowserCheck extends Check {
     const deps: CheckDependency[] = []
     for (const { filePath, content } of parsed.dependencies) {
       deps.push({
-        path: path.relative(Session.basePath!, filePath),
+        path: path.relative(Session.basePath!, filePath).split(path.sep).join(path.posix.sep),
         content,
       })
     }
     return {
       script: parsed.entrypoint.content,
-      scriptPath: path.relative(Session.basePath!, parsed.entrypoint.filePath),
+      scriptPath: path.relative(Session.basePath!, parsed.entrypoint.filePath).split(path.sep).join(path.posix.sep),
       dependencies: deps,
     }
   }

--- a/packages/create-cli/package.json
+++ b/packages/create-cli/package.json
@@ -7,8 +7,9 @@
   "types": "dist/index.d.ts",
   "private": false,
   "scripts": {
+    "clean" : "rimraf ./dist",
     "test": "jest --selectProjects unit",
-    "prepare": "rm -rf dist && tsc --build",
+    "prepare": "npm run clean && tsc --build",
     "prepack": "npx oclif manifest",
     "lint": "eslint src",
     "start": "node ./index.mjs"


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [x] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
- fix browser checks dependencies path separator when executing `test` or `deploy` on Windows
- replace `rm -rf ./dist` with `rimfaf ./dist` allowing contributors running Windows
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #551

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
