### PR TITLE
chore: add integration testing on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,11 @@ on:
 
 jobs:
   test_and_lint:
-    name: test&lint
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    name: test&lint - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [windows-latest]
     name: test - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [windows-latest]
+        os: [ubuntu-latest, windows-latest]
     name: test - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,8 @@ on:
       - main
 
 jobs:
-  test_and_lint:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-    name: test&lint - ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+  lint:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -24,6 +20,21 @@ jobs:
       # Test that the packaging works as well
       - run: npm pack --workspace packages/cli
       - run: npm run lint --workspace packages/cli
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    name: test - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+      - run: npm config set fund false && npm set audit false
+      - run: npm ci --workspaces
       - run: npm run test --workspace packages/cli
       - run: npm run test:e2e --workspace packages/cli
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -4144,6 +4144,24 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -11790,6 +11808,7 @@
         "@typescript-eslint/eslint-plugin": "5.46.1",
         "@typescript-eslint/parser": "5.46.1",
         "config": "3.3.8",
+        "cross-env": "7.0.3",
         "eslint": "8.30.0",
         "jest": "29.3.1",
         "ts-jest": "29.0.3",
@@ -12390,6 +12409,7 @@
         "ci-info": "3.7.1",
         "conf": "10.2.0",
         "config": "3.3.8",
+        "cross-env": "*",
         "dotenv": "16.0.3",
         "eslint": "8.30.0",
         "glob": "8.0.3",
@@ -15503,6 +15523,15 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
     },
     "cross-spawn": {
       "version": "7.0.3",

--- a/packages/cli/e2e/__tests__/deploy.spec.ts
+++ b/packages/cli/e2e/__tests__/deploy.spec.ts
@@ -45,7 +45,7 @@ describe('deploy', () => {
       args: ['deploy', '--force'],
       apiKey: config.get('apiKey'),
       accountId: config.get('accountId'),
-      directory: path.join(__dirname, 'fixtures/deploy-project'),
+      directory: path.join(__dirname, 'fixtures', 'deploy-project'),
       env: { PROJECT_LOGICAL_ID: projectLogicalId },
     })
     expect(result.stderr).toBe('')
@@ -56,7 +56,7 @@ describe('deploy', () => {
       args: ['deploy', '--preview'],
       apiKey: config.get('apiKey'),
       accountId: config.get('accountId'),
-      directory: path.join(__dirname, 'fixtures/test-only-project'),
+      directory: path.join(__dirname, 'fixtures', 'test-only-project'),
       env: { PROJECT_LOGICAL_ID: projectLogicalId },
     })
     expect(result.stdout).toContain('not-testonly-default-check')

--- a/packages/cli/e2e/__tests__/test.spec.ts
+++ b/packages/cli/e2e/__tests__/test.spec.ts
@@ -24,7 +24,6 @@ describe('test', () => {
       accountId: config.get('accountId'),
       directory: path.join(__dirname, 'fixtures', 'test-project'),
     })
-    console.log('GOT ', result)
     expect(result.status).toBe(0)
     expect(result.stdout).toContain('Show SECRET_ENV value')
     expect(result.stdout).toContain('1 passed, 1 total')

--- a/packages/cli/e2e/__tests__/test.spec.ts
+++ b/packages/cli/e2e/__tests__/test.spec.ts
@@ -10,7 +10,7 @@ describe('test', () => {
       args: ['test', '-e', `SECRET_ENV=${secretEnv}`, '--verbose'],
       apiKey: config.get('apiKey'),
       accountId: config.get('accountId'),
-      directory: path.join(__dirname, 'fixtures/test-project'),
+      directory: path.join(__dirname, 'fixtures', 'test-project'),
     })
     expect(result.status).toBe(0)
     expect(result.stdout).not.toContain('File extension type example')
@@ -22,7 +22,7 @@ describe('test', () => {
       args: ['test', 'secret.check.ts'],
       apiKey: config.get('apiKey'),
       accountId: config.get('accountId'),
-      directory: path.join(__dirname, 'fixtures/test-project'),
+      directory: path.join(__dirname, 'fixtures', 'test-project'),
     })
     expect(result.status).toBe(0)
     expect(result.stdout).toContain('Show SECRET_ENV value')
@@ -34,7 +34,7 @@ describe('test', () => {
       args: ['test', 'does-not-exist.js'],
       apiKey: config.get('apiKey'),
       accountId: config.get('accountId'),
-      directory: path.join(__dirname, 'fixtures/test-project'),
+      directory: path.join(__dirname, 'fixtures', 'test-project'),
     })
     expect(result.status).toBe(0)
     expect(result.stdout).toContain('0 total')
@@ -45,7 +45,7 @@ describe('test', () => {
       args: ['test'],
       apiKey: config.get('apiKey'),
       accountId: config.get('accountId'),
-      directory: path.join(__dirname, 'fixtures/test-parse-error'),
+      directory: path.join(__dirname, 'fixtures', 'test-parse-error'),
     })
     expect(result.stderr).toContain('Error loading file')
     expect(result.stderr).toContain('Error: Big bang!')
@@ -57,7 +57,7 @@ describe('test', () => {
       args: ['test'],
       apiKey: config.get('apiKey'),
       accountId: config.get('accountId'),
-      directory: path.join(__dirname, 'fixtures/test-duplicated-groups'),
+      directory: path.join(__dirname, 'fixtures', 'test-duplicated-groups'),
     })
     expect(result.stderr.replace(/(\n {4})/gm, ''))
       .toContain("Error: Resource of type 'groups' with logical id 'my-check-group' already exists.")
@@ -69,7 +69,7 @@ describe('test', () => {
       args: ['test'],
       apiKey: config.get('apiKey'),
       accountId: config.get('accountId'),
-      directory: path.join(__dirname, 'fixtures/test-only-project'),
+      directory: path.join(__dirname, 'fixtures', 'test-only-project'),
     })
     expect(result.stdout).toContain('TestOnly=false (default) Check')
     expect(result.stdout).toContain('TestOnly=false Check')

--- a/packages/cli/e2e/__tests__/test.spec.ts
+++ b/packages/cli/e2e/__tests__/test.spec.ts
@@ -12,6 +12,7 @@ describe('test', () => {
       accountId: config.get('accountId'),
       directory: path.join(__dirname, 'fixtures', 'test-project'),
     })
+    expect(result).toEqual({ abc: 'test' })
     expect(result.status).toBe(0)
     expect(result.stdout).not.toContain('File extension type example')
     expect(result.stdout).toContain(secretEnv)

--- a/packages/cli/e2e/__tests__/test.spec.ts
+++ b/packages/cli/e2e/__tests__/test.spec.ts
@@ -24,6 +24,7 @@ describe('test', () => {
       accountId: config.get('accountId'),
       directory: path.join(__dirname, 'fixtures', 'test-project'),
     })
+    console.log('GOT ', result)
     expect(result.status).toBe(0)
     expect(result.stdout).toContain('Show SECRET_ENV value')
     expect(result.stdout).toContain('1 passed, 1 total')

--- a/packages/cli/e2e/__tests__/test.spec.ts
+++ b/packages/cli/e2e/__tests__/test.spec.ts
@@ -12,7 +12,6 @@ describe('test', () => {
       accountId: config.get('accountId'),
       directory: path.join(__dirname, 'fixtures', 'test-project'),
     })
-    expect(result).toEqual({ abc: 'test' })
     expect(result.status).toBe(0)
     expect(result.stdout).not.toContain('File extension type example')
     expect(result.stdout).toContain(secretEnv)

--- a/packages/cli/e2e/run-checkly.ts
+++ b/packages/cli/e2e/run-checkly.ts
@@ -1,7 +1,7 @@
 import * as path from 'path'
 import * as childProcess from 'node:child_process'
 
-const CHECKLY_PATH = path.resolve(path.dirname(__filename), '../bin/run')
+const CHECKLY_PATH = path.resolve(path.dirname(__filename), '..', 'bin', 'run')
 
 export function runChecklyCli (options: {
   directory?: string,

--- a/packages/cli/e2e/run-checkly.ts
+++ b/packages/cli/e2e/run-checkly.ts
@@ -29,5 +29,6 @@ export function runChecklyCli (options: {
     cwd: directory ?? process.cwd(),
     encoding: 'utf-8',
     timeout,
+    shell: process.platform === "win32",
   })
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "clean" : "rimraf ./dist",
+    "clean": "rimraf ./dist",
     "test": "jest --selectProjects unit",
     "test:e2e": "npm run prepare && cross-env NODE_CONFIG_DIR=./e2e/config jest --selectProjects E2E",
     "prepare": "npm run clean && tsc --build",
@@ -80,6 +80,7 @@
     "@typescript-eslint/eslint-plugin": "5.46.1",
     "@typescript-eslint/parser": "5.46.1",
     "config": "3.3.8",
+    "cross-env": "7.0.3",
     "eslint": "8.30.0",
     "jest": "29.3.1",
     "ts-jest": "29.0.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "clean" : "rimraf ./dist",
     "test": "jest --selectProjects unit",
-    "test:e2e": "npm run prepare && NODE_CONFIG_DIR=./e2e/config jest --selectProjects E2E",
+    "test:e2e": "npm run prepare && cross-env NODE_CONFIG_DIR=./e2e/config jest --selectProjects E2E",
     "prepare": "npm run clean && tsc --build",
     "prepack": "npx oclif manifest",
     "lint": "eslint src"

--- a/packages/cli/src/constructs/__tests__/browser-check.spec.ts
+++ b/packages/cli/src/constructs/__tests__/browser-check.spec.ts
@@ -1,6 +1,7 @@
 import { BrowserCheck, CheckGroup } from '../index'
 import { Project, Session } from '../project'
 import * as path from 'path'
+import * as fs from 'fs'
 
 const runtimes = {
   '2022.10': { name: '2022.10', default: false, stage: 'CURRENT', description: 'Main updates are Playwright 1.28.0, Node.js 16.x and Typescript support. We are also dropping support for Puppeteer', dependencies: { '@playwright/test': '1.28.0', '@opentelemetry/api': '1.0.4', '@opentelemetry/sdk-trace-base': '1.0.1', '@faker-js/faker': '5.5.3', aws4: '1.11.0', axios: '0.27.2', btoa: '1.2.1', chai: '4.3.7', 'chai-string': '1.5.0', 'crypto-js': '4.1.1', expect: '29.3.1', 'form-data': '4.0.0', jsonwebtoken: '8.5.1', lodash: '4.17.21', mocha: '10.1.0', moment: '2.29.2', node: '16.x', otpauth: '9.0.2', playwright: '1.28.0', typescript: '4.8.4', uuid: '9.0.0' } },
@@ -10,20 +11,21 @@ describe('BrowserCheck', () => {
   it('should correctly load file dependencies', () => {
     Session.basePath = __dirname
     Session.availableRuntimes = runtimes
-    const bundle = BrowserCheck.bundle(path.join(__dirname, 'fixtures', 'browser-check', 'entrypoint.js'), '2022.10')
+    const getFilePath = (filename: string) => path.join(__dirname, 'fixtures', 'browser-check', filename)
+    const bundle = BrowserCheck.bundle(getFilePath('entrypoint.js'), '2022.10')
     delete Session.basePath
 
     expect(bundle).toEqual({
-      script: 'require("./dep1")\nrequire("./dep2")\n',
+      script: fs.readFileSync(getFilePath('entrypoint.js')),
       scriptPath: 'fixtures/browser-check/entrypoint.js',
       dependencies: [
         {
           path: 'fixtures/browser-check/dep1.js',
-          content: 'module.exports = "dependency 1"\n',
+          content: fs.readFileSync(getFilePath('dep1.js')),
         },
         {
           path: 'fixtures/browser-check/dep2.js',
-          content: 'module.exports = "dependency 2"\n',
+          content: fs.readFileSync(getFilePath('dep2.js')),
         },
       ],
     })

--- a/packages/cli/src/constructs/__tests__/browser-check.spec.ts
+++ b/packages/cli/src/constructs/__tests__/browser-check.spec.ts
@@ -16,16 +16,16 @@ describe('BrowserCheck', () => {
     delete Session.basePath
 
     expect(bundle).toEqual({
-      script: fs.readFileSync(getFilePath('entrypoint.js')),
+      script: fs.readFileSync(getFilePath('entrypoint.js')).toString(),
       scriptPath: 'fixtures/browser-check/entrypoint.js',
       dependencies: [
         {
           path: 'fixtures/browser-check/dep1.js',
-          content: fs.readFileSync(getFilePath('dep1.js')),
+          content: fs.readFileSync(getFilePath('dep1.js')).toString(),
         },
         {
           path: 'fixtures/browser-check/dep2.js',
-          content: fs.readFileSync(getFilePath('dep2.js')),
+          content: fs.readFileSync(getFilePath('dep2.js')).toString(),
         },
       ],
     })

--- a/packages/cli/src/services/check-parser/__tests__/check-parser.spec.ts
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser.spec.ts
@@ -15,16 +15,16 @@ describe('dependency-parser - parser()', () => {
   })
 
   it('should handle JS file with dependencies', () => {
-    const toAbsolutePath = (filename: string) => path.join(__dirname, 'check-parser-fixtures', 'simple-example', filename)
+    const toAbsolutePath = (...filepath: string[]) => path.join(__dirname, 'check-parser-fixtures', 'simple-example', ...filepath)
     const parser = new Parser(defaultNpmModules)
     const { dependencies } = parser.parse(toAbsolutePath('entrypoint.js'))
     expect(dependencies.map(d => d.filePath).sort()).toEqual([
       toAbsolutePath('dep1.js'),
       toAbsolutePath('dep2.js'),
       toAbsolutePath('dep3.js'),
-      toAbsolutePath('module-package/main.js'),
-      toAbsolutePath('module-package/package.json'),
-      toAbsolutePath('module/index.js'),
+      toAbsolutePath('module-package', 'main.js'),
+      toAbsolutePath('module-package', 'package.json'),
+      toAbsolutePath('module', 'index.js'),
     ])
   })
 
@@ -39,7 +39,7 @@ describe('dependency-parser - parser()', () => {
   })
 
   it('should report missing check dependencies', () => {
-    const toAbsolutePath = (filename: string) => path.join(__dirname, 'check-parser-fixtures', filename)
+    const toAbsolutePath = (...filepath: string[]) => path.join(__dirname, 'check-parser-fixtures', ...filepath)
     try {
       const parser = new Parser(defaultNpmModules)
       parser.parse(toAbsolutePath('missing-dependencies.js'))
@@ -69,7 +69,7 @@ describe('dependency-parser - parser()', () => {
   })
 
   it('should handle circular dependencies', () => {
-    const toAbsolutePath = (filename: string) => path.join(__dirname, 'check-parser-fixtures', 'circular-dependencies', filename)
+    const toAbsolutePath = (...filepath: string[]) => path.join(__dirname, 'check-parser-fixtures', 'circular-dependencies', ...filepath)
     const parser = new Parser(defaultNpmModules)
     const { dependencies } = parser.parse(toAbsolutePath('entrypoint.js'))
 
@@ -83,7 +83,7 @@ describe('dependency-parser - parser()', () => {
   })
 
   it('should parse typescript dependencies', () => {
-    const toAbsolutePath = (filename: string) => path.join(__dirname, 'check-parser-fixtures', 'typescript-example', filename)
+    const toAbsolutePath = (...filepath: string[]) => path.join(__dirname, 'check-parser-fixtures', 'typescript-example', ...filepath)
     const parser = new Parser(defaultNpmModules)
     const { dependencies } = parser.parse(toAbsolutePath('entrypoint.ts'))
     expect(dependencies.map(d => d.filePath).sort()).toEqual([
@@ -91,15 +91,15 @@ describe('dependency-parser - parser()', () => {
       toAbsolutePath('dep2.ts'),
       toAbsolutePath('dep3.ts'),
       toAbsolutePath('dep4.js'),
-      toAbsolutePath('module-package/main.js'),
-      toAbsolutePath('module-package/package.json'),
-      toAbsolutePath('module/index.ts'),
+      toAbsolutePath('module-package', 'main.js'),
+      toAbsolutePath('module-package', 'package.json'),
+      toAbsolutePath('module', 'index.ts'),
       toAbsolutePath('type.ts'),
     ])
   })
 
   it('should handle ES Modules', () => {
-    const toAbsolutePath = (filename: string) => path.join(__dirname, 'check-parser-fixtures', 'esmodules-example', filename)
+    const toAbsolutePath = (...filepath: string[]) => path.join(__dirname, 'check-parser-fixtures', 'esmodules-example', ...filepath)
     const parser = new Parser(defaultNpmModules)
     const { dependencies } = parser.parse(toAbsolutePath('entrypoint.js'))
     expect(dependencies.map(d => d.filePath).sort()).toEqual([

--- a/packages/cli/src/services/check-parser/parser.ts
+++ b/packages/cli/src/services/check-parser/parser.ts
@@ -16,45 +16,33 @@ type Module = {
   npmDependencies: Array<string>
 }
 
-enum FileExtensions {
-  JS = '.js',
-  TS = '.ts',
-  PACKAGE = '/package.json',
-  INDEX_JS = '/index.js',
-  INDEX_TS = '/index.ts'
-}
+type SupportedFileExtension = '.js' | '.ts'
+
+const PACKAGE_EXTENSION = `${path.sep}package.json`
 
 const JS_RESOLVE_ORDER = [
-  FileExtensions.JS,
-  FileExtensions.PACKAGE,
-  FileExtensions.INDEX_JS,
-]
-const TS_RESOLVE_ORDER = [
-  FileExtensions.TS,
-  FileExtensions.JS,
-  FileExtensions.PACKAGE,
-  FileExtensions.INDEX_TS,
-  FileExtensions.INDEX_JS,
+  '.js',
+  PACKAGE_EXTENSION,
+  `${path.sep}index.js`,
 ]
 
-type SupportedExtensions = FileExtensions.JS | FileExtensions.TS
+const TS_RESOLVE_ORDER = [
+  '.ts',
+  '.js',
+  PACKAGE_EXTENSION,
+  `${path.sep}index.ts`,
+  `${path.sep}index.js`,
+]
 
 const supportedBuiltinModules = [
   'assert', 'buffer', 'crypto', 'dns', 'fs', 'path', 'querystring', 'readline ', 'stream', 'string_decoder',
   'timers', 'tls', 'url', 'util', 'zlib',
 ]
 
-function validateEntrypoint (entrypoint: string): {extension: SupportedExtensions, content: string} {
-  let extension: SupportedExtensions
-  switch (path.extname(entrypoint)) {
-    case FileExtensions.JS:
-      extension = FileExtensions.JS
-      break
-    case FileExtensions.TS:
-      extension = FileExtensions.TS
-      break
-    default:
-      throw new Error(`Unsupported file extension for ${entrypoint}`)
+function validateEntrypoint (entrypoint: string): {extension: SupportedFileExtension, content: string} {
+  const extension = path.extname(entrypoint)
+  if (extension !== '.js' && extension !== '.ts') {
+    throw new Error(`Unsupported file extension for ${entrypoint}`)
   }
   try {
     const content = fs.readFileSync(entrypoint, { encoding: 'utf-8' })
@@ -117,7 +105,7 @@ export class Parser {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const item = bfsQueue.shift()!
 
-      if (item.filePath.endsWith(FileExtensions.PACKAGE)) {
+      if (item.filePath.endsWith(PACKAGE_EXTENSION)) {
         // Holds info about the main file and doesn't need to be parsed
         continue
       }
@@ -154,13 +142,13 @@ export class Parser {
     return collector.getItems()
   }
 
-  static readDependency (filePath: string, preferedExtenstion: SupportedExtensions) {
+  static readDependency (filePath: string, preferedExtenstion: SupportedFileExtension) {
     // Read the specific file if it has an extension
     if (path.extname(filePath).length) {
       const content = fs.readFileSync(filePath, { encoding: 'utf-8' })
       return [{ filePath, content }]
     } else {
-      if (preferedExtenstion === FileExtensions.JS) {
+      if (preferedExtenstion === '.js') {
         return Parser.tryReadFileExt(filePath, JS_RESOLVE_ORDER)
       } else {
         return Parser.tryReadFileExt(filePath, TS_RESOLVE_ORDER)
@@ -168,14 +156,14 @@ export class Parser {
     }
   }
 
-  static tryReadFileExt (filePath: string, exts: Array<FileExtensions>) {
+  static tryReadFileExt (filePath: string, exts: typeof JS_RESOLVE_ORDER | typeof TS_RESOLVE_ORDER) {
     for (const extension of exts) {
       try {
         const deps = []
         const fullPath = filePath + extension
         const content = fs.readFileSync(fullPath, { encoding: 'utf-8' })
         deps.push({ filePath: fullPath, content })
-        if (extension === FileExtensions.PACKAGE) {
+        if (extension === PACKAGE_EXTENSION) {
           const { main } = JSON.parse(content)
           if (!main || !main.length) {
             // No main is defined. This means package.json doesn't have a specific entry
@@ -199,14 +187,14 @@ export class Parser {
 
     const extension = path.extname(filePath)
     try {
-      if (extension === FileExtensions.JS) {
+      if (extension === '.js') {
         const ast = acorn.parse(contents, {
           allowReturnOutsideFunction: true,
           ecmaVersion: 'latest',
           allowImportExportEverywhere: true,
         })
         walk.simple(ast, Parser.jsNodeVisitor(localDependencies, npmDependencies))
-      } else if (extension === FileExtensions.TS) {
+      } else if (extension === '.ts') {
         const tsParser = getTsParser()
         const ast = tsParser.parse(contents, {})
         // The AST from typescript-estree is slightly different from the type used by acorn-walk.


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [ ] CLI
* [ ] Create CLI
* [x] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
We seem to have a decent number of users on Windows. With this PR we'll also run the integration tests on Windows. That should help us avoid regressions.

If this PR is accepted, we should update the branch protection rules to match the new jobs.

#### New Dependencies
[cross-env](https://www.npmjs.com/package/cross-env) is added as a dev dependency. This lets us set env vars for the integration tests in a cross platform way.