### PR TITLE
feat: add git info into project [sc-14207]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6082,6 +6082,14 @@
         "giget": "dist/cli.mjs"
       }
     },
+    "node_modules/git-repo-info": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/git-repo-info/-/git-repo-info-2.1.1.tgz",
+      "integrity": "sha512-8aCohiDo4jwjOwma4FmYFd3i97urZulL8XL24nIPxuE+GZnfsAyy/g2Shqx6OjUiFKUXZM+Yy+KHnOmmA3FVcg==",
+      "engines": {
+        "node": ">= 4.0"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -11765,6 +11773,7 @@
         "ci-info": "3.7.1",
         "conf": "10.2.0",
         "dotenv": "16.0.3",
+        "git-repo-info": "2.1.1",
         "glob": "8.0.3",
         "indent-string": "4.0.0",
         "inquirer": "8.2.3",
@@ -12392,6 +12401,7 @@
         "config": "3.3.8",
         "dotenv": "16.0.3",
         "eslint": "8.30.0",
+        "git-repo-info": "*",
         "glob": "8.0.3",
         "indent-string": "4.0.0",
         "inquirer": "8.2.3",
@@ -16893,6 +16903,11 @@
         "pathe": "^1.0.0",
         "tar": "^6.1.12"
       }
+    },
+    "git-repo-info": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/git-repo-info/-/git-repo-info-2.1.1.tgz",
+      "integrity": "sha512-8aCohiDo4jwjOwma4FmYFd3i97urZulL8XL24nIPxuE+GZnfsAyy/g2Shqx6OjUiFKUXZM+Yy+KHnOmmA3FVcg=="
     },
     "glob": {
       "version": "7.2.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "clean" : "rimraf ./dist",
+    "clean": "rimraf ./dist",
     "test": "jest --selectProjects unit",
     "test:e2e": "npm run prepare && NODE_CONFIG_DIR=./e2e/config jest --selectProjects E2E",
     "prepare": "npm run clean && tsc --build",
@@ -58,6 +58,7 @@
     "ci-info": "3.7.1",
     "conf": "10.2.0",
     "dotenv": "16.0.3",
+    "git-repo-info": "2.1.1",
     "glob": "8.0.3",
     "indent-string": "4.0.0",
     "inquirer": "8.2.3",

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -11,6 +11,7 @@ import { AlertChannelSubscription, CheckGroup, Project, ProjectData } from '../c
 import chalk = require('chalk')
 import { Check } from '../constructs/check'
 import { AlertChannel } from '../constructs/alert-channel'
+import { getGitInformation } from '../services/util'
 
 enum ResourceDeployStatus {
   UPDATE = 'UPDATE',
@@ -46,11 +47,13 @@ export default class Deploy extends AuthCommand {
     const cwd = process.cwd()
     const { config: checklyConfig, constructs: checklyConfigConstructs } = await loadChecklyConfig(cwd)
     const { data: avilableRuntimes } = await runtimes.getAll()
+    const gitInfo = getGitInformation()
     const project = await parseProject({
       directory: cwd,
       projectLogicalId: checklyConfig.logicalId,
       projectName: checklyConfig.projectName,
       repoUrl: checklyConfig.repoUrl,
+      repoInfo: gitInfo ?? undefined,
       checkMatch: checklyConfig.checks?.checkMatch,
       browserCheckMatch: checklyConfig.checks?.browserChecks?.testMatch,
       ignoreDirectoriesMatch: checklyConfig.checks?.ignoreDirectoriesMatch,

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -14,6 +14,7 @@ import type { Runtime } from '../rest/runtimes'
 import { AuthCommand } from './authCommand'
 import { BrowserCheck } from '../constructs'
 import type { Region } from '..'
+import { getGitInformation } from '../services/util'
 
 const DEFAULT_REGION = 'eu-central-1'
 
@@ -103,11 +104,13 @@ export default class Test extends AuthCommand {
     })
     const verbose = this.prepareVerboseFlag(verboseFlag, checklyConfig.cli?.verbose)
     const { data: availableRuntimes } = await api.runtimes.getAll()
+    const gitInfo = getGitInformation()
     const project = await parseProject({
       directory: cwd,
       projectLogicalId: checklyConfig.logicalId,
       projectName: checklyConfig.projectName,
       repoUrl: checklyConfig.repoUrl,
+      repoInfo: gitInfo ?? undefined,
       checkMatch: checklyConfig.checks?.checkMatch,
       browserCheckMatch: checklyConfig.checks?.browserChecks?.testMatch,
       ignoreDirectoriesMatch: checklyConfig.checks?.ignoreDirectoriesMatch,

--- a/packages/cli/src/constructs/project.ts
+++ b/packages/cli/src/constructs/project.ts
@@ -7,6 +7,7 @@ import { Check } from './check'
 import { CheckGroup } from './check-group'
 import { AlertChannel } from './alert-channel'
 import { AlertChannelSubscription } from './alert-channel-subscription'
+import { GitInformation } from '../services/util'
 
 export interface ProjectProps {
   /**
@@ -17,6 +18,10 @@ export interface ProjectProps {
    * Git repository URL.
    */
   repoUrl?: string
+  /**
+   * Git repository information.
+   */
+  repoInfo?: GitInformation
 }
 
 export interface ProjectData {
@@ -29,6 +34,7 @@ export interface ProjectData {
 export class Project extends Construct {
   name: string
   repoUrl?: string
+  repoInfo?: GitInformation
   logicalId: string
   data: ProjectData = {
     checks: {},
@@ -54,6 +60,7 @@ export class Project extends Construct {
 
     this.name = props.name
     this.repoUrl = props.repoUrl
+    this.repoInfo = props.repoInfo
     this.logicalId = logicalId
   }
 
@@ -75,6 +82,7 @@ export class Project extends Construct {
       logicalId: this.logicalId,
       name: this.name,
       repoUrl: this.repoUrl,
+      repoInfo: this.repoInfo,
     }
     return {
       project,

--- a/packages/cli/src/services/project-parser.ts
+++ b/packages/cli/src/services/project-parser.ts
@@ -1,7 +1,7 @@
 import { BrowserCheck, Project, Session } from '../constructs'
 import { promisify } from 'util'
 import * as glob from 'glob'
-import { loadJsFile, loadTsFile, pathToLogicalId } from './util'
+import { GitInformation, loadJsFile, loadTsFile, pathToLogicalId } from './util'
 import * as path from 'path'
 import { CheckConfigDefaults } from './checkly-config-loader'
 
@@ -15,6 +15,7 @@ type ProjectParseOpts = {
   projectLogicalId: string,
   projectName: string,
   repoUrl?: string,
+  repoInfo?: GitInformation,
   checkMatch?: string,
   browserCheckMatch?: string,
   ignoreDirectoriesMatch?: string[],
@@ -36,6 +37,7 @@ export async function parseProject (opts: ProjectParseOpts): Promise<Project> {
     projectLogicalId,
     projectName,
     repoUrl,
+    repoInfo,
     ignoreDirectoriesMatch = [],
     checkDefaults = {},
     browserCheckDefaults = {},
@@ -45,6 +47,7 @@ export async function parseProject (opts: ProjectParseOpts): Promise<Project> {
   const project = new Project(projectLogicalId, {
     name: projectName,
     repoUrl,
+    repoInfo,
   })
   checklyConfigConstructs?.forEach(
     (construct) => project.addResource(construct.type, construct.logicalId, construct),


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
- gather git repository information using `git-repo-info` package
- (to be discussed) get the git remote origin URL using the `node:child_process.spawnSync` command
- add a new `project` property (`repoInfo`) to be sent when `test` and `deploy` command
<!-- Anything the reviewer should pay extra attention to. -->

**Important**: https://github.com/checkly/checkly-backend/pull/3924 must be merged first.

> Resolves [[sc-14207](https://app.shortcut.com/checkly/story/14207/as-a-user-i-want-the-cli-to-gather-data-about-the-ci-git-info)]

## New Dependency Submission
- Add `git-repo-info` to get Git repository information
<!-- Please explain here why we need the new dependency. -->
