### PR TITLE
fix: export BodyType and migrate enums to string literals [sc-0]

### DIFF
--- a/packages/cli/src/constructs/api-check.ts
+++ b/packages/cli/src/constructs/api-check.ts
@@ -164,13 +164,7 @@ class GeneralAssertionBuilder {
   }
 }
 
-enum BodyType {
-  JSON = 'JSON',
-  FORM = 'FORM',
-  RAW = 'RAW',
-  GRAPHQL = 'GRAPHQL',
-  NONE = 'NONE'
-}
+export type BodyType = 'JSON' | 'FORM' | 'RAW' | 'GRAPHQL' | 'NONE'
 
 export type HttpRequestMethod =
   | 'get' | 'GET'

--- a/packages/cli/src/constructs/opsgenie-alert-channel.ts
+++ b/packages/cli/src/constructs/opsgenie-alert-channel.ts
@@ -1,18 +1,9 @@
 import { AlertChannel, AlertChannelProps } from './alert-channel'
 import { Session } from './project'
 
-export enum OpsgeniePriority {
-  P1 = 'P1',
-  P2 = 'P2',
-  P3 = 'P3',
-  P4 = 'P4',
-  P5 = 'P5',
-}
+export type OpsgeniePriority = 'P1' | 'P2' | 'P3' | 'P4' | 'P5'
 
-export enum OpsgenieRegion {
-  EU = 'EU',
-  US = 'US',
-}
+export type OpsgenieRegion = 'EU' | 'US'
 
 export interface OpsgenieAlertChannelProps extends AlertChannelProps {
   /**


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
* export BodyType and migrate it to a type
* turn opsgenie region and priority to types