### PR TITLE
chore: lint enum usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,3 +67,31 @@ To release the project to NPM:
 2. Create a new release in GitHub [here](https://github.com/checkly/checkly-cli/releases/new)
 
 The new version will then automatically be released by the corresponding GitHub action [here](https://github.com/checkly/checkly-cli/actions/workflows/release.yml).
+
+## Style Guide
+
+#### Enums vs. Union Types
+
+In general, prefer to use Union Types rather than Enums.
+
+Rather than:
+```
+enum BodyType {
+  JSON = 'JSON',
+  FORM = 'FORM',
+  RAW = 'RAW',
+}
+```
+
+use:
+```
+type BodyType = 'JSON' | 'FORM' | 'RAW'
+```
+
+This is especially important in public facing code (the `constructs` directory). The main goal is consistency for users. This rule is enforced by ESLint.
+
+If an enum makes sense for a particular use case (internal code), you can explicitly disable the ESLint rule by adding:
+```
+// eslint-disable-next-line no-restricted-syntax
+```
+

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -92,7 +92,14 @@
       "@typescript-eslint/type-annotation-spacing": 2,
       "@typescript-eslint/no-explicit-any": 0,
       "@typescript-eslint/ban-ts-comment": 0,
-      "no-console": 2
+      "no-console": 2,
+      "no-restricted-syntax": [
+        "error",
+        {
+          "selector": "TSEnumDeclaration",
+          "message": "Don't declare enums, use union types instead"
+        }
+      ]
     },
     "extends": [
       "@checkly/eslint-config",

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -12,6 +12,7 @@ import chalk = require('chalk')
 import { Check } from '../constructs/check'
 import { AlertChannel } from '../constructs/alert-channel'
 
+// eslint-disable-next-line no-restricted-syntax
 enum ResourceDeployStatus {
   UPDATE = 'UPDATE',
   CREATE = 'CREATE',

--- a/packages/cli/src/constructs/api-check.ts
+++ b/packages/cli/src/constructs/api-check.ts
@@ -3,6 +3,7 @@ import { HttpHeader } from './http-header'
 import { Session } from './project'
 import { QueryParam } from './query-param'
 
+// eslint-disable-next-line no-restricted-syntax
 enum AssertionSource {
   STATUS_CODE = 'STATUS_CODE',
   JSON_BODY = 'JSON_BODY',
@@ -11,6 +12,7 @@ enum AssertionSource {
   RESPONSE_TIME = 'RESPONSE_TIME',
 }
 
+// eslint-disable-next-line no-restricted-syntax
 enum AssertionComparison {
   EQUALS = 'EQUALS',
   NOT_EQUALS = 'NOT_EQUALS',

--- a/packages/cli/src/reporters/util.ts
+++ b/packages/cli/src/reporters/util.ts
@@ -5,6 +5,7 @@ import * as logSymbols from 'log-symbols'
 
 import { Assertion } from '../constructs/api-check'
 
+// eslint-disable-next-line no-restricted-syntax
 export enum CheckStatus {
   PENDING,
   FAILED,

--- a/packages/cli/src/rest/assets.ts
+++ b/packages/cli/src/rest/assets.ts
@@ -1,5 +1,6 @@
 import type { AxiosInstance } from 'axios'
 
+// eslint-disable-next-line no-restricted-syntax
 enum AssetType {
   LOG = 'log',
   CHECK_RUN_DATA = 'check-run-data',

--- a/packages/cli/src/services/check-runner.ts
+++ b/packages/cli/src/services/check-runner.ts
@@ -7,6 +7,7 @@ import { Check } from '../constructs/check'
 import { CheckGroup } from '../constructs'
 import type { Region } from '..'
 
+// eslint-disable-next-line no-restricted-syntax
 export enum Events {
   CHECK_REGISTERED = 'CHECK_REGISTERED',
   CHECK_INPROGRESS = 'CHECK_INPROGRESS',

--- a/packages/cli/src/services/checkly-config-loader.ts
+++ b/packages/cli/src/services/checkly-config-loader.ts
@@ -55,10 +55,10 @@ export type ChecklyConfig = {
   }
 }
 
+// eslint-disable-next-line no-restricted-syntax
 enum Extension {
   JS = '.js',
-  TS = '.ts'
-
+  TS = '.ts',
 }
 
 function loadFile (file: string) {

--- a/packages/cli/src/services/config.ts
+++ b/packages/cli/src/services/config.ts
@@ -11,6 +11,7 @@ const authSchema = {
 
 const projectSuffix = process.env.NODE_ENV === 'test' ? 'test' : ''
 
+// eslint-disable-next-line no-restricted-syntax
 enum Env {
   production = 'production',
   staging = 'staging',


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
We recently decided to prefer Union Types rather than Enums in publicly facing code. To make sure that we have a consistent code style, this PR adds an ESLint rule (from [here](https://github.com/typescript-eslint/typescript-eslint/issues/561#issuecomment-496664453)).

This PR also adds a small note in Contributing.md.

In cases where enums are already used, this PR just disables the lint rule.
