### PR TITLE
fix: transform all path to POSIX [sc-0]

### DIFF
--- a/packages/cli/e2e/__tests__/fixtures/test-project/src/__checks__/group.check.ts
+++ b/packages/cli/e2e/__tests__/fixtures/test-project/src/__checks__/group.check.ts
@@ -13,6 +13,10 @@ const group = new CheckGroup('check-group-1', {
   apiCheckDefaults: {},
   concurrency: 100,
   alertChannels,
+  browserChecks: {
+    // using .test.ts suffix (no .spec.ts) to avoid '@playwright/test not found error' when Jest transpile the spec.ts
+    testMatch: '**/*.test.ts',
+  },
 })
 
 const browserCheck = new BrowserCheck('group-browser-check-1', {

--- a/packages/cli/src/constructs/browser-check.ts
+++ b/packages/cli/src/constructs/browser-check.ts
@@ -3,6 +3,7 @@ import { Check, CheckProps } from './check'
 import { Session } from './project'
 import { Parser } from '../services/check-parser/parser'
 import { CheckConfigDefaults } from '../services/checkly-config-loader'
+import { pathToPosix } from '../services/util'
 
 export interface CheckDependency {
   path: string
@@ -96,13 +97,13 @@ export class BrowserCheck extends Check {
     const deps: CheckDependency[] = []
     for (const { filePath, content } of parsed.dependencies) {
       deps.push({
-        path: path.relative(Session.basePath!, filePath).split(path.sep).join(path.posix.sep),
+        path: pathToPosix(path.relative(Session.basePath!, filePath)),
         content,
       })
     }
     return {
       script: parsed.entrypoint.content,
-      scriptPath: path.relative(Session.basePath!, parsed.entrypoint.filePath).split(path.sep).join(path.posix.sep),
+      scriptPath: pathToPosix(path.relative(Session.basePath!, parsed.entrypoint.filePath)),
       dependencies: deps,
     }
   }

--- a/packages/cli/src/constructs/check-group.ts
+++ b/packages/cli/src/constructs/check-group.ts
@@ -9,7 +9,7 @@ import { EnvironmentVariable } from './environment-variable'
 import { AlertChannelSubscription } from './alert-channel-subscription'
 import { CheckConfigDefaults } from '../services/checkly-config-loader'
 import { ApiCheckDefaultConfig } from './api-check'
-import { pathToLogicalId } from '../services/util'
+import { pathToPosix } from '../services/util'
 import type { Region } from '..'
 
 const defaultApiCheckDefaults: ApiCheckDefaultConfig = {
@@ -158,7 +158,7 @@ export class CheckGroup extends Construct {
           entrypoint: filepath,
         },
       }
-      const checkLogicalId = pathToLogicalId(path.relative(Session.basePath!, filepath))
+      const checkLogicalId = pathToPosix(path.relative(Session.basePath!, filepath))
       const check = new BrowserCheck(checkLogicalId, props)
     }
   }

--- a/packages/cli/src/services/__tests__/util.spec.js
+++ b/packages/cli/src/services/__tests__/util.spec.js
@@ -1,12 +1,12 @@
 import path from 'path'
-import { pathToLogicalId } from '../util'
+import { pathToPosix } from '../util'
 
-describe('pathToLogicalId()', () => {
+describe('pathToPosix()', () => {
   it('should convert Windows paths', () => {
     const originalSep = path.sep
     try {
       path.sep = '\\'
-      expect(pathToLogicalId('src\\__checks__\\my_check.spec.ts'))
+      expect(pathToPosix('src\\__checks__\\my_check.spec.ts'))
         .toEqual('src/__checks__/my_check.spec.ts')
     } finally {
       path.sep = originalSep
@@ -17,7 +17,7 @@ describe('pathToLogicalId()', () => {
     const originalSep = path.sep
     try {
       path.sep = '/'
-      expect(pathToLogicalId('src/__checks__/my_check.spec.ts'))
+      expect(pathToPosix('src/__checks__/my_check.spec.ts'))
         .toEqual('src/__checks__/my_check.spec.ts')
     } finally {
       path.sep = originalSep

--- a/packages/cli/src/services/project-parser.ts
+++ b/packages/cli/src/services/project-parser.ts
@@ -1,7 +1,7 @@
 import { BrowserCheck, Project, Session } from '../constructs'
 import { promisify } from 'util'
 import * as glob from 'glob'
-import { loadJsFile, loadTsFile, pathToLogicalId } from './util'
+import { loadJsFile, loadTsFile, pathToPosix } from './util'
 import * as path from 'path'
 import { CheckConfigDefaults } from './checkly-config-loader'
 
@@ -72,7 +72,7 @@ async function loadAllCheckFiles (
   for (const checkFile of checkFiles) {
     // setting the checkFilePath is used for filtering by file name on the command line
     Session.checkFileAbsolutePath = checkFile
-    Session.checkFilePath = path.relative(directory, checkFile)
+    Session.checkFilePath = pathToPosix(path.relative(directory, checkFile))
     if (checkFile.endsWith('.js')) {
       await loadJsFile(checkFile)
     } else if (checkFile.endsWith('.ts')) {
@@ -104,12 +104,12 @@ async function loadAllBrowserChecks (
   })
 
   for (const checkFile of checkFiles) {
-    const relPath = path.relative(directory, checkFile)
+    const relPath = pathToPosix(path.relative(directory, checkFile))
     // Don't create an additional check if the checkFile was already added to a check in loadAllCheckFiles.
     if (preexistingCheckFiles.has(relPath)) {
       continue
     }
-    const browserCheck = new BrowserCheck(pathToLogicalId(relPath), {
+    const browserCheck = new BrowserCheck(pathToPosix(relPath), {
       name: path.basename(checkFile),
       code: {
         entrypoint: checkFile,

--- a/packages/cli/src/services/util.ts
+++ b/packages/cli/src/services/util.ts
@@ -69,7 +69,7 @@ async function getTsCompiler (): Promise<Service> {
   return tsCompiler
 }
 
-export function pathToLogicalId (relPath: string): string {
+export function pathToPosix (relPath: string): string {
   // Windows uses \ rather than / as a path separator.
   // It's important that logical ID's are consistent across platforms, though.
   // Otherwise, checks will be deleted and recreated when `npx checkly deploy` is run on different machines.


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [x] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
- fix duplicated `logicalId` error converting all path to POSIX. This fixes the problem checking if the check was already added with `preexistingCheckFiles.has(relPath)`.
- add checks into the `test-project` for the E2E test.
- `checkFileAbsolutePath` is not modified/covered by this PR.
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #572

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
