### PR TITLE
fix: clean up TS warnings if PWT types are available

### DIFF
--- a/examples/advanced-project/src/__checks__/404.spec.ts
+++ b/examples/advanced-project/src/__checks__/404.spec.ts
@@ -6,7 +6,7 @@ test('Checkly 404 page', async ({ page }) => {
   await page.setViewportSize(defaults.playwright.viewportSize)
   const response = await page.goto(`${defaults.pageUrl}/does-not-exist`)
 
-  expect(response.status()).toBe(404)
+  expect(response?.status()).toBe(404)
   expect(await page.title()).toEqual('404 Page not found | Checkly')
   expect(await page.locator('.main h1').innerText()).toContain('404')
   expect(await page.locator('.main h3').innerText()).toContain('Whoops, that page does not exist!')

--- a/examples/advanced-project/src/__checks__/homepage.spec.ts
+++ b/examples/advanced-project/src/__checks__/homepage.spec.ts
@@ -6,7 +6,7 @@ test('Checkly Homepage', async ({ page }) => {
   await page.setViewportSize(defaults.playwright.viewportSize)
   const response = await page.goto(defaults.pageUrl)
 
-  expect(response.status()).toBeLessThan(400)
+  expect(response?.status()).toBeLessThan(400)
   await expect(page).toHaveTitle(/Build and Run Synthetics That Scale/)
   await page.screenshot({ path: 'homepage.jpg' })
 })

--- a/examples/advanced-project/src/services/docs/__checks__/docs-search.spec.ts
+++ b/examples/advanced-project/src/services/docs/__checks__/docs-search.spec.ts
@@ -12,7 +12,7 @@ test.describe('Docs', () => {
     await page.setViewportSize(defaults.playwright.viewportSize)
     const response = await page.goto(`${defaults.pageUrl}/docs`)
 
-    expect(response.status()).toBeLessThan(400)
+    expect(response?.status()).toBeLessThan(400)
     await expect(page).toHaveTitle(/documentation/)
     await page.screenshot({ path: 'docs_landing.jpg' })
   })
@@ -21,7 +21,7 @@ test.describe('Docs', () => {
     await page.setViewportSize(defaults.playwright.viewportSize)
     const response = await page.goto(`${defaults.pageUrl}/docs`)
 
-    expect(response.status()).toBeLessThan(400)
+    expect(response?.status()).toBeLessThan(400)
     await expect(page).toHaveTitle(/documentation/)
 
     await page.getByPlaceholder('Press / to search').fill('browser')

--- a/examples/boilerplate-project/__checks__/homepage.spec.ts
+++ b/examples/boilerplate-project/__checks__/homepage.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test'
 
 test('Checkly Homepage', async ({ page }) => {
   const response = await page.goto('https://checklyhq.com')
-  expect(response.status()).toBeLessThan(400)
+  expect(response?.status()).toBeLessThan(400)
   await expect(page).toHaveTitle(/Build and Run Synthetics That Scale/)
   await page.screenshot({ path: 'homepage.jpg' })
 })


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [ ] CLI
* [x] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

If PWT is installed in the same project TS complains about our example code. This PR doesn't change functionality and only makes TS happy.

<img width="947" alt="image" src="https://user-images.githubusercontent.com/962099/225268721-1771536b-ed4f-43d0-a848-3ed3770d2ff2.png">

