### PR TITLE
Feat/allow signup via cli

### DIFF
--- a/packages/cli/src/auth/index.ts
+++ b/packages/cli/src/auth/index.ts
@@ -1,34 +1,14 @@
-import axios, { type AxiosError } from 'axios'
+import axios, { Axios, type AxiosError } from 'axios'
 import * as os from 'os'
 import * as http from 'http'
 import * as crypto from 'crypto'
+import jwtDecode from 'jwt-decode'
+import { getDefaults as getApiDefaults } from '../rest/api'
 
 const AUTH0_CLIENT_ID = 'mBtwLFVm39GVZ1HpSRBSdRiLFucYxmMb'
-
-export const generateAuthenticationUrl = ({
-  codeChallenge,
-  scope,
-  state,
-}: {
-  codeChallenge: string,
-  scope: string,
-  state: string
-}) => {
-  const url = new URL('https://auth.checklyhq.com/authorize')
-
-  const params = new URLSearchParams({
-    client_id: AUTH0_CLIENT_ID,
-    code_challenge: codeChallenge,
-    code_challenge_method: 'S256',
-    response_type: 'code',
-    redirect_uri: 'http://localhost:4242',
-    scope,
-    state,
-  })
-
-  url.search = params.toString()
-  return url.toString()
-}
+const AUTH0_AUTHORIZATION_URL = 'https://auth.checklyhq.com/authorize'
+const AUTH0_SCOPES = 'openid profile email'
+const AUTH0_CALLBACK_URL = 'http://localhost:4242'
 
 export function generatePKCE () {
   const codeVerifier = crypto
@@ -52,135 +32,170 @@ export function generatePKCE () {
   }
 }
 
-export function startServer (codeVerifier: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const server = http.createServer()
-    server.on('request', (req, res) => {
-    // `req.url` has a '/' char at the beginning which needs removed to be valid searchParams input
-      if (!req.url?.includes('favicon.ico')) {
-        const responseParams = new URLSearchParams(req.url?.substring(1))
-        const code = responseParams.get('code')
-        const state = responseParams.get('state')
+export class AuthContext {
+  authenticationUrl: string
 
-        const error = responseParams.get('error')
-        const errorDescription = responseParams.get('error_description')
+  #codeChallenge: string
+  #codeVerifier: string
 
-        if (code && state === codeVerifier) {
-          res.write(`
-      <html>
-      <body>
-        <div style="height:100%;width:100%;inset:0;position:absolute;display:grid;place-items:center;background-color:#EFF2F7;text-align:center;font-family:Inter;">
-          <h3 style="font-weight: 200;"><strong style="color:#45C8F1;">@checkly/cli</strong> login success! </br></br>You can go back to your terminal</br></br>This window should close itself in 3 seconds.</h3>
-        </div>
-        <script>setTimeout(function() {window.close()}, 3000);</script>
-      </body>
-      </html>
-    `)
-          resolve(code)
-        } else {
-          res.write(`
-      <html>
-      <body>
-        <div style="height:100%;width:100%;inset:0;position:absolute;display:grid;place-items:center;background-color:#EFF2F7;text-align:center;font-family:Inter;">
-          <h3 style="font-weight:200;">Login failed, please try again!</h3>
-          <p>
-            <b>${error}</b>: ${errorDescription}
-          </p>
-        </div>
-      </body>
-      </html>
-    `)
-        }
+  #axiosInstance!: Axios
+  #accessToken!: string
 
-        res.end()
-      }
-    })
+  constructor () {
+    const { codeChallenge, codeVerifier } = generatePKCE()
+    this.#codeChallenge = codeChallenge
+    this.#codeVerifier = codeVerifier
 
-    server.listen(4242).on('error', (err: any) => {
-      if (err.code === 'EADDRINUSE') {
-        reject(new Error('Unable to start a local server on port 4242.' +
-          ' Please check that `checkly login` isn\'t already running in a separate tab.' +
-          ' On OS X and Linux, you can run `lsof -i :4242` to see which process is blocking the port.'))
-      } else {
-        reject(err)
-      }
-    })
-  })
-}
+    this.authenticationUrl = this.#generateAuthenticationUrl()
+  }
 
-export async function getAccessToken (code: string, codeVerifier: string) {
-  const tokenParams = new URLSearchParams({
-    grant_type: 'authorization_code',
-    client_id: AUTH0_CLIENT_ID,
-    code_verifier: codeVerifier,
-    code,
-    redirect_uri: 'http://localhost:4242',
-  })
+  async getAuth0Credentials () {
+    const { access_token: accessToken, id_token: idToken } = await this.#getAccessToken()
 
-  const tokenResponse = await axios.post(
-    'https://auth.checklyhq.com/oauth/token',
-    tokenParams,
-    {
+    this.#accessToken = accessToken
+    this.#axiosInstance = axios.create({
+      baseURL: getApiDefaults().baseURL,
       headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-        'Accept-Encoding': '*',
+        Accept: 'application/json, text/plain, */*',
+        Authorization: `Bearer ${this.#accessToken}`,
       },
-    },
-  )
-
-  return tokenResponse.data
-}
-
-// TODO: Move this to API SDK
-export async function getApiKey ({ accessToken, baseHost }: {accessToken: string, baseHost: string}) {
-  try {
-    await fetchUser({
-      accessToken,
-      baseHost,
     })
-  } catch (error: unknown) {
-    if ((error as AxiosError).response?.status === 401) {
-      await registerUser({ baseHost, accessToken })
-    } else {
-      throw error
+
+    const { name } = jwtDecode<any>(idToken)
+
+    const { key } = await this.#getApiKey()
+
+    return {
+      name,
+      key,
     }
   }
 
-  const { data } = await axios.post(
-      `${baseHost}/users/me/api-keys?name=${
-        'CLI User Key (' + os.hostname() + ')'
-      }`,
-      null,
+  #generateAuthenticationUrl () {
+    const url = new URL(AUTH0_AUTHORIZATION_URL)
+
+    const params = new URLSearchParams({
+      client_id: AUTH0_CLIENT_ID,
+      code_challenge: this.#codeChallenge,
+      code_challenge_method: 'S256',
+      response_type: 'code',
+      redirect_uri: AUTH0_CALLBACK_URL,
+      scope: AUTH0_SCOPES,
+      state: this.#codeVerifier,
+    })
+
+    url.search = params.toString()
+    return url.toString()
+  }
+
+  #startServer (): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const server = http.createServer()
+      server.on('request', (req, res) => {
+      // `req.url` has a '/' char at the beginning which needs removed to be valid searchParams input
+        if (!req.url?.includes('favicon.ico')) {
+          const responseParams = new URLSearchParams(req.url?.substring(1))
+          const code = responseParams.get('code')
+          const state = responseParams.get('state')
+
+          const error = responseParams.get('error')
+          const errorDescription = responseParams.get('error_description')
+
+          if (code && state === this.#codeVerifier) {
+            res.write(`
+        <html>
+        <body>
+          <div style="height:100%;width:100%;inset:0;position:absolute;display:grid;place-items:center;background-color:#EFF2F7;text-align:center;font-family:Inter;">
+            <h3 style="font-weight: 200;"><strong style="color:#45C8F1;">@checkly/cli</strong> login success! </br></br>You can go back to your terminal</br></br>This window should close itself in 3 seconds.</h3>
+          </div>
+          <script>setTimeout(function() {window.close()}, 3000);</script>
+        </body>
+        </html>
+      `)
+            resolve(code)
+          } else {
+            res.write(`
+        <html>
+        <body>
+          <div style="height:100%;width:100%;inset:0;position:absolute;display:grid;place-items:center;background-color:#EFF2F7;text-align:center;font-family:Inter;">
+            <h3 style="font-weight:200;">Login failed, please try again!</h3>
+            <p>
+              <b>${error}</b>: ${errorDescription}
+            </p>
+          </div>
+        </body>
+        </html>
+      `)
+          }
+
+          res.end()
+        }
+      })
+
+      server.listen(4242).on('error', (err: any) => {
+        if (err.code === 'EADDRINUSE') {
+          reject(new Error('Unable to start a local server on port 4242.' +
+            ' Please check that `checkly login` isn\'t already running in a separate tab.' +
+            ' On OS X and Linux, you can run `lsof -i :4242` to see which process is blocking the port.'))
+        } else {
+          reject(err)
+        }
+      })
+    })
+  }
+
+  async #getAccessToken () {
+    const code = await this.#startServer()
+
+    const tokenParams = new URLSearchParams({
+      grant_type: 'authorization_code',
+      client_id: AUTH0_CLIENT_ID,
+      code_verifier: this.#codeVerifier,
+      code,
+      redirect_uri: AUTH0_CALLBACK_URL,
+    })
+
+    const tokenResponse = await axios.post(
+      'https://auth.checklyhq.com/oauth/token',
+      tokenParams,
       {
         headers: {
-          Accept: 'application/json, text/plain, */*',
-          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Accept-Encoding': '*',
         },
       },
-  )
-  return data
-}
+    )
 
-export async function fetchUser ({ accessToken, baseHost }: { accessToken: string, baseHost: string }) {
-  const { data } = await axios.get(`${baseHost}/users/me`, {
-    headers: {
-      Accept: 'application/json, text/plain, */*',
-      Authorization: `Bearer ${accessToken}`,
-    },
-  })
+    return tokenResponse.data
+  }
 
-  return data
-}
+  async #getApiKey () {
+    try {
+      await this.#fetchUser()
+    } catch (error: unknown) {
+      if ((error as AxiosError).response?.status === 401) {
+        await this.#registerUser()
+      } else {
+        throw error
+      }
+    }
 
-export async function registerUser ({ accessToken, baseHost }: { accessToken: string, baseHost: string }) {
-  const { data } = await axios.post(`${baseHost}/users/`, {
-    accessToken,
-  }, {
-    headers: {
-      Accept: 'application/json, text/plain, */*',
-      Authorization: `Bearer ${accessToken}`,
-    },
-  })
+    const apiKeyName = `CLI User Key (${os.hostname()})`
 
-  return data
+    const { data } = await this.#axiosInstance.post(`/users/me/api-keys?name=${apiKeyName}`)
+
+    return data
+  }
+
+  async #fetchUser () {
+    const { data } = await this.#axiosInstance.get('/users/me')
+
+    return data
+  }
+
+  async #registerUser () {
+    const { data } = await this.#axiosInstance.post('/users/', { accessToken: this.#accessToken })
+
+    return data
+  }
 }

--- a/packages/cli/src/auth/index.ts
+++ b/packages/cli/src/auth/index.ts
@@ -5,8 +5,17 @@ import * as crypto from 'crypto'
 
 const AUTH0_CLIENT_ID = 'mBtwLFVm39GVZ1HpSRBSdRiLFucYxmMb'
 
-export const generateAuthenticationUrl = (codeChallenge: string, scope: string, state: string) => {
+export const generateAuthenticationUrl = ({
+  codeChallenge,
+  scope,
+  state,
+}: {
+  codeChallenge: string,
+  scope: string,
+  state: string
+}) => {
   const url = new URL('https://auth.checklyhq.com/authorize')
+
   const params = new URLSearchParams({
     client_id: AUTH0_CLIENT_ID,
     code_challenge: codeChallenge,
@@ -131,7 +140,6 @@ export async function getApiKey ({ accessToken, baseHost }: {accessToken: string
     })
   } catch (error: unknown) {
     if ((error as AxiosError).response?.status === 401) {
-      console.log(error)
       await registerUser({ baseHost, accessToken })
     } else {
       throw error
@@ -165,18 +173,14 @@ export async function fetchUser ({ accessToken, baseHost }: { accessToken: strin
 }
 
 export async function registerUser ({ accessToken, baseHost }: { accessToken: string, baseHost: string }) {
-  try {
-    const { data } = await axios.post(`${baseHost}/users/`, {
-      accessToken,
-    }, {
-      headers: {
-        Accept: 'application/json, text/plain, */*',
-        Authorization: `Bearer ${accessToken}`,
-      },
-    })
+  const { data } = await axios.post(`${baseHost}/users/`, {
+    accessToken,
+  }, {
+    headers: {
+      Accept: 'application/json, text/plain, */*',
+      Authorization: `Bearer ${accessToken}`,
+    },
+  })
 
-    return data
-  } catch (error) {
-    console.log(error)
-  }
+  return data
 }

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -123,7 +123,9 @@ export default class Login extends BaseCommand {
     const code = await startServer(codeVerifier)
 
     const { access_token: accessToken, id_token: idToken } = await getAccessToken(code, codeVerifier)
+
     const { name } = jwtDecode<any>(idToken)
+
     const { key } = await getApiKey({
       accessToken,
       baseHost: api.getDefaults().baseURL,

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -96,11 +96,12 @@ export default class Login extends BaseCommand {
     }
 
     const { codeChallenge, codeVerifier } = generatePKCE()
-    const authServerUrl = generateAuthenticationUrl(
+
+    const authServerUrl = generateAuthenticationUrl({
       codeChallenge,
-      'openid profile',
-      codeVerifier,
-    )
+      scope: 'openid profile email',
+      state: codeVerifier,
+    })
 
     const { openUrl } = await inquirer.prompt([
       {

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -3,17 +3,10 @@ import * as chalk from 'chalk'
 import { Flags } from '@oclif/core'
 import { BaseCommand } from './baseCommand'
 import * as inquirer from 'inquirer'
-import jwtDecode from 'jwt-decode'
 import config from '../services/config'
 import * as api from '../rest/api'
 import type { Account } from '../rest/accounts'
-import {
-  generateAuthenticationUrl,
-  getAccessToken,
-  generatePKCE,
-  startServer,
-  getApiKey,
-} from '../auth'
+import { AuthContext } from '../auth'
 
 const selectAccount = async (accounts: Array<Account>): Promise<Account> => {
   if (accounts.length === 1) {
@@ -95,13 +88,7 @@ export default class Login extends BaseCommand {
       this.exit(0)
     }
 
-    const { codeChallenge, codeVerifier } = generatePKCE()
-
-    const authServerUrl = generateAuthenticationUrl({
-      codeChallenge,
-      scope: 'openid profile email',
-      state: codeVerifier,
-    })
+    const authContext = new AuthContext()
 
     const { openUrl } = await inquirer.prompt([
       {
@@ -114,23 +101,14 @@ export default class Login extends BaseCommand {
     if (!openUrl) {
       this.log(
         `Please open the following URL in your browser: \n\n${chalk.blueBright(
-          authServerUrl,
+          authContext.authenticationUrl,
         )}`,
       )
     } else {
-      await open(authServerUrl)
+      await open(authContext.authenticationUrl)
     }
 
-    const code = await startServer(codeVerifier)
-
-    const { access_token: accessToken, id_token: idToken } = await getAccessToken(code, codeVerifier)
-
-    const { name } = jwtDecode<any>(idToken)
-
-    const { key } = await getApiKey({
-      accessToken,
-      baseHost: api.getDefaults().baseURL,
-    })
+    const { key, name } = await authContext.getAuth0Credentials()
 
     config.auth.set('apiKey', key)
 


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Consolidates all the code related to the auth context in `auth/index.ts` so we can clean up `LoginCommand`.

When retrieving the API key, it will try first to fetch the user, and if it gets a 401 back, it will then register a new one.

> Resolves #574

