### PR TITLE
fix: add correct skipSSL property [gh-597]

### DIFF
--- a/examples/advanced-project/src/services/api/api.check.ts
+++ b/examples/advanced-project/src/services/api/api.check.ts
@@ -10,7 +10,7 @@ new ApiCheck('homepage-api-check-1', {
     url: 'https://api.checklyhq.com/public-stats',
     method: 'GET',
     followRedirects: true,
-    skipSsl: false,
+    skipSSL: false,
     assertions: [
       AssertionBuilder.statusCode().equals(200),
       AssertionBuilder.jsonBody('$.apiCheckResults').greaterThan(0),

--- a/examples/boilerplate-project/__checks__/api.check.ts
+++ b/examples/boilerplate-project/__checks__/api.check.ts
@@ -9,7 +9,7 @@ new ApiCheck('homepage-api-check-1', {
     url: 'https://api.checklyhq.com/public-stats',
     method: 'GET',
     followRedirects: true,
-    skipSsl: false,
+    skipSSL: false,
     assertions: [
       AssertionBuilder.statusCode().equals(200),
       AssertionBuilder.jsonBody('$.apiCheckResults').greaterThan(0),

--- a/packages/cli/e2e/__tests__/fixtures/deploy-project/api.check.ts
+++ b/packages/cli/e2e/__tests__/fixtures/deploy-project/api.check.ts
@@ -7,7 +7,7 @@ new ApiCheck('api-check', {
     url: 'https://www.google.com',
     method: 'GET',
     followRedirects: false,
-    skipSsl: false,
+    skipSSL: false,
     assertions: []
   },
   localSetupScript: "console.log('hi from setup')",

--- a/packages/cli/e2e/__tests__/fixtures/test-duplicated-groups/group2.check.ts
+++ b/packages/cli/e2e/__tests__/fixtures/test-duplicated-groups/group2.check.ts
@@ -14,7 +14,7 @@ new ApiCheck('api-check', {
     url: 'https://www.google.com',
     method: 'GET',
     followRedirects: false,
-    skipSsl: false,
+    skipSSL: false,
     assertions: []
   },
   localSetupScript: "console.log('hi from setup')",

--- a/packages/cli/src/constructs/api-check.ts
+++ b/packages/cli/src/constructs/api-check.ts
@@ -193,7 +193,11 @@ export interface Request {
   url: string,
   method: HttpRequestMethod,
   followRedirects?: boolean,
+  /**
+   * To be deprecated, use `skipSSL`
+   */
   skipSsl?: boolean,
+  skipSSL?: boolean,
   /**
    * Check the main Checkly documentation on assertions for specific values like regular expressions
    * and JSON path descriptors you can use in the "property" field.
@@ -252,7 +256,12 @@ export class ApiCheck extends Check {
 
   constructor (logicalId: string, props: ApiCheckProps) {
     super(logicalId, props)
-    this.request = props.request
+    this.request = {
+      ...props.request,
+      // TODO: remove the `skipSsl` property after deprecate it
+      skipSSL: props.request.skipSSL ?? props.request.skipSsl,
+      skipSsl: undefined,
+    }
     this.localSetupScript = props.localSetupScript
     this.localTearDownScript = props.localTearDownScript
     this.degradedResponseTime = props.degradedResponseTime

--- a/packages/cli/src/reporters/util.ts
+++ b/packages/cli/src/reporters/util.ts
@@ -50,17 +50,24 @@ export function formatCheckResult (checkResult: any) {
   const result = []
   if (checkResult.checkType === 'API') {
     // Order should follow the check lifecycle (response, then assertions)
-    if (checkResult.checkRunData?.response) {
+    if (checkResult.checkRunData?.requestError) {
       result.push([
-        formatSectionTitle('HTTP Response'),
-        formatHttpResponse(checkResult.checkRunData.response),
+        formatSectionTitle(checkResult.checkRunData?.requestError),
+        '',
       ])
-    }
-    if (checkResult.checkRunData?.assertions?.length) {
-      result.push([
-        formatSectionTitle('Assertions'),
-        formatAssertions(checkResult.checkRunData.assertions),
-      ])
+    } else {
+      if (checkResult.checkRunData?.response) {
+        result.push([
+          formatSectionTitle('HTTP Response'),
+          formatHttpResponse(checkResult.checkRunData.response),
+        ])
+      }
+      if (checkResult.checkRunData?.assertions?.length) {
+        result.push([
+          formatSectionTitle('Assertions'),
+          formatAssertions(checkResult.checkRunData.assertions),
+        ])
+      }
     }
   }
   if (checkResult.logs?.length) {


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [x] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
- add `skipSSL` request property for API Checks (the `skipSsl` has wrong case)
- set `skipSsl` as to-be-deprecated
- rename property in the example projects.
- handle certificate issues in `formatCheckResult()`.

<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #597

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
