### PR TITLE
feat: release CLI v0.4.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11767,7 +11767,7 @@
     },
     "packages/cli": {
       "name": "@checkly/cli",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@oclif/core": "2.0.7",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@checkly/cli",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "Checkly CLI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Currently the latest CLI release is out of sync with the examples. The latest CLI release expects `skipSsl`, but the examples use `skipSSL`. This causes an error for users going through the `npm create @checkly/checkly-cli` flow.

To resolve this, we can make a new release of the CLI.