### PR TITLE
Chrislample/fix reporter flag

### DIFF
--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -70,7 +70,6 @@ export default class Test extends AuthCommand {
       char: 'r',
       description: 'A list of custom reporters for the test output.',
       options: ['list', 'dot', 'ci'],
-      default: 'list',
     }),
     config: Flags.string({
       char: 'c',

--- a/packages/cli/src/reporters/reporter.ts
+++ b/packages/cli/src/reporters/reporter.ts
@@ -24,7 +24,7 @@ export const createReporter = (
     case 'dot':
       return new DotReporter(runLocation, checks, verbose)
     case 'list':
-      return new CiReporter(runLocation, checks, verbose)
+      return new ListReporter(runLocation, checks, verbose)
     case 'ci':
       return new CiReporter(runLocation, checks, verbose)
     default:


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Currently `npx checkly test` always selects the CI reporter. Instead, we should select the List or CI reporter depending on whether the environment is a CI runner or local terminal.