### PR TITLE
feat: introduce checkly trigger command [sc-14206]

### DIFF
--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -1,6 +1,4 @@
-import * as fs from 'node:fs/promises'
 import { Flags, Args, ux } from '@oclif/core'
-import { parse } from 'dotenv'
 import { isCI } from 'ci-info'
 import * as api from '../rest/api'
 import config from '../services/config'
@@ -13,20 +11,11 @@ import type { Runtime } from '../rest/runtimes'
 import { AuthCommand } from './authCommand'
 import { BrowserCheck } from '../constructs'
 import type { Region } from '..'
-import { splitConfigFilePath, getGitInformation, getCiInformation } from '../services/util'
+import { splitConfigFilePath, getGitInformation, getCiInformation, getEnvs } from '../services/util'
 import { createReporters, ReporterType } from '../reporters/reporter'
 import commonMessages from '../messages/common-messages'
 
 const DEFAULT_REGION = 'eu-central-1'
-
-async function getEnvs (envFile: string|undefined, envArgs: Array<string>) {
-  if (envFile) {
-    const envsString = await fs.readFile(envFile, { encoding: 'utf8' })
-    return parse(envsString)
-  }
-  const envsString = `${envArgs.join('\n')}`
-  return parse(envsString)
-}
 
 export default class Test extends AuthCommand {
   static hidden = false

--- a/packages/cli/src/commands/trigger.ts
+++ b/packages/cli/src/commands/trigger.ts
@@ -28,7 +28,7 @@ export default class Trigger extends AuthCommand {
     tags: Flags.string({
       char: 't',
       description: 'Filter the checks to be run using a comma separated list of tags.' +
-        ' Checks will only be run if the contain all of the specified tags.' +
+        ' Checks will only be run if they contain all of the specified tags.' +
         ' Multiple --tags flags can be passed, in which case checks will be run if they match any of the --tags filters.' +
         ' F.ex. `--tags production,webapp --tags production,backend` will run checks with tags (production AND webapp) OR (production AND backend).',
       multiple: true,

--- a/packages/cli/src/commands/trigger.ts
+++ b/packages/cli/src/commands/trigger.ts
@@ -1,0 +1,201 @@
+import { Flags } from '@oclif/core'
+import { isCI } from 'ci-info'
+
+import * as api from '../rest/api'
+import { AuthCommand } from './authCommand'
+import { loadChecklyConfig } from '../services/checkly-config-loader'
+import { splitConfigFilePath, getEnvs, getGitInformation, getCiInformation } from '../services/util'
+import type { Region } from '..'
+import TriggerRunner from '../services/trigger-runner'
+import { RunLocation, Events, PrivateRunLocation, CheckRunId } from '../services/abstract-check-runner'
+import config from '../services/config'
+import { createReporters, ReporterType } from '../reporters/reporter'
+
+const DEFAULT_REGION = 'eu-central-1'
+
+export default class Trigger extends AuthCommand {
+  static hidden = false
+  static description = 'Trigger checks on Checkly'
+  static flags = {
+    location: Flags.string({
+      char: 'l',
+      description: 'The location to run the checks at.',
+    }),
+    'private-location': Flags.string({
+      description: 'The private location to run checks at.',
+      exclusive: ['location'],
+    }),
+    tags: Flags.string({
+      char: 't',
+      description: 'Filter the checks to be run using a comma separated list of tags.' +
+        ' Checks will only be run if the contain all of the specified tags.' +
+        ' Multiple --tags flags can be passed, in which case checks will be run if they match any of the --tags filters.' +
+        ' F.ex. `--tags production,webapp --tags production,backend` will run checks with tags (production AND webapp) OR (production AND backend).',
+      multiple: true,
+      required: false,
+    }),
+    config: Flags.string({
+      char: 'c',
+      description: 'The Checkly CLI config filename.',
+    }),
+    timeout: Flags.integer({
+      default: 240,
+      description: 'A timeout (in seconds) to wait for checks to complete.',
+    }),
+    verbose: Flags.boolean({
+      char: 'v',
+      description: 'Always show the full logs of the checks.',
+      allowNo: true,
+    }),
+    reporter: Flags.string({
+      char: 'r',
+      description: 'A list of custom reporters for the test output.',
+      options: ['list', 'dot', 'ci', 'github'],
+    }),
+    env: Flags.string({
+      char: 'e',
+      description: 'Env vars to be passed to the check run.',
+      exclusive: ['env-file'],
+      multiple: true,
+      default: [],
+    }),
+    'env-file': Flags.string({
+      description: 'dotenv file path to be passed. For example --env-file="./.env"',
+      exclusive: ['env'],
+    }),
+    record: Flags.boolean({
+      description: 'Record check results in Checkly as a test session with full logs, traces and videos.',
+      default: false,
+    }),
+    'test-session-name': Flags.string({
+      char: 'n',
+      description: 'A name to use when storing results in Checkly with --record.',
+    }),
+  }
+
+  async run (): Promise<void> {
+    const { flags } = await this.parse(Trigger)
+    const {
+      location: runLocation,
+      'private-location': privateRunLocation,
+      config: configFilename,
+      tags: targetTags,
+      timeout,
+      verbose: verboseFlag,
+      record: shouldRecord,
+      reporter: reporterFlag,
+      env,
+      'env-file': envFile,
+      'test-session-name': testSessionName,
+    } = flags
+    const envVars = await getEnvs(envFile, env)
+    const { configDirectory, configFilenames } = splitConfigFilePath(configFilename)
+
+    let checklyConfig
+    try {
+      const { config } = await loadChecklyConfig(configDirectory, configFilenames)
+      checklyConfig = config
+    } catch (err) {} // Don't throw an error if the config file is missing
+    const location = await this.prepareRunLocation(checklyConfig?.cli, {
+      runLocation: runLocation as keyof Region,
+      privateRunLocation,
+    })
+    const verbose = this.prepareVerboseFlag(verboseFlag, checklyConfig?.cli?.verbose)
+    const reporterTypes = this.prepareReportersTypes(reporterFlag as ReporterType, checklyConfig?.cli?.reporters)
+    const reporters = createReporters(reporterTypes, location, verbose)
+
+    const repoInfo = getGitInformation()
+    const ciInfo = getCiInformation()
+
+    const runner = new TriggerRunner(
+      config.getAccountId(),
+      timeout,
+      verbose,
+      shouldRecord,
+      location,
+      targetTags?.map((tags: string) => tags.split(',')) ?? [],
+      Object.entries(envVars).map(([key, value]) => ({ key, value })),
+      repoInfo,
+      ciInfo.environment,
+      testSessionName,
+    )
+    // TODO: This is essentially the same for `checkly test`. Maybe reuse code.
+    runner.on(Events.RUN_STARTED,
+      (checks: Array<{ check: any, checkRunId: CheckRunId, testResultId?: string }>, testSessionId: string) =>
+        reporters.forEach(r => r.onBegin(checks, testSessionId)))
+    runner.on(Events.CHECK_SUCCESSFUL, (checkRunId, _, result) => {
+      if (result.hasFailures) {
+        process.exitCode = 1
+      }
+      reporters.forEach(r => r.onCheckEnd(checkRunId, result))
+    })
+    runner.on(Events.CHECK_FAILED, (checkRunId, check, message: string) => {
+      reporters.forEach(r => r.onCheckEnd(checkRunId, {
+        ...check,
+        hasFailures: true,
+        runError: message,
+      }))
+      process.exitCode = 1
+    })
+    runner.on(Events.RUN_FINISHED, () => reporters.forEach(r => r.onEnd()),
+    )
+    runner.on(Events.ERROR, (err) => {
+      reporters.forEach(r => r.onError(err))
+      process.exitCode = 1
+    })
+    await runner.run()
+  }
+
+  // TODO: Reuse prepare* methods from the `checkly test command`
+  async prepareRunLocation (
+    configOptions: { runLocation?: keyof Region, privateRunLocation?: string } = {},
+    cliFlags: { runLocation?: keyof Region, privateRunLocation?: string } = {},
+  ): Promise<RunLocation> {
+    // Command line options take precedence
+    if (cliFlags.runLocation) {
+      const { data: availableLocations } = await api.locations.getAll()
+      if (availableLocations.some(l => l.region === cliFlags.runLocation)) {
+        return { type: 'PUBLIC', region: cliFlags.runLocation }
+      }
+      throw new Error(`Unable to run checks on unsupported location "${cliFlags.runLocation}". ` +
+        `Supported locations are:\n${availableLocations.map(l => `${l.region}`).join('\n')}`)
+    } else if (cliFlags.privateRunLocation) {
+      return this.preparePrivateRunLocation(cliFlags.privateRunLocation)
+    } else if (configOptions.runLocation && configOptions.privateRunLocation) {
+      throw new Error('Both runLocation and privateRunLocation fields were set in the Checkly config file.' +
+        ` Please only specify one run location. The configured locations were' + 
+        ' "${configOptions.runLocation}" and "${configOptions.privateRunLocation}"`)
+    } else if (configOptions.runLocation) {
+      return { type: 'PUBLIC', region: configOptions.runLocation }
+    } else if (configOptions.privateRunLocation) {
+      return this.preparePrivateRunLocation(configOptions.privateRunLocation)
+    } else {
+      return { type: 'PUBLIC', region: DEFAULT_REGION }
+    }
+  }
+
+  async preparePrivateRunLocation (privateLocationSlugName: string): Promise<PrivateRunLocation> {
+    try {
+      const { data: privateLocations } = await api.privateLocations.getAll()
+      const privateLocation = privateLocations.find(({ slugName }) => slugName === privateLocationSlugName)
+      if (privateLocation) {
+        return { type: 'PRIVATE', id: privateLocation.id, slugName: privateLocationSlugName }
+      }
+      const { data: account } = await api.accounts.get(config.getAccountId())
+      throw new Error(`The specified private location "${privateLocationSlugName}" was not found on account "${account.name}".`)
+    } catch (err: any) {
+      throw new Error(`Failed to get private locations. ${err.message}.`)
+    }
+  }
+
+  prepareVerboseFlag (verboseFlag?: boolean, cliVerboseFlag?: boolean) {
+    return verboseFlag ?? cliVerboseFlag ?? false
+  }
+
+  prepareReportersTypes (reporterFlag: ReporterType, cliReporters: ReporterType[] = []): ReporterType[] {
+    if (!reporterFlag && !cliReporters.length) {
+      return [isCI ? 'ci' : 'list']
+    }
+    return reporterFlag ? [reporterFlag] : cliReporters
+  }
+}

--- a/packages/cli/src/reporters/github.ts
+++ b/packages/cli/src/reporters/github.ts
@@ -14,6 +14,10 @@ type GithubMdBuilderOptions = {
   checkFilesMap: checkFilesMap
 }
 
+function nonNullable<T> (value: T): value is NonNullable<T> {
+  return value !== null && value !== undefined
+}
+
 export class GithubMdBuilder {
   testSessionId?: string
   numChecks: number
@@ -23,6 +27,7 @@ export class GithubMdBuilder {
   tableHeaders: Array<string>
   extraTableHeadersWithLinks: Array<string>
   tableRows: Array<string> = []
+  hasFilenames: boolean
 
   readonly header: string = '# Checkly Test Session Summary'
   readonly tableSeparatorFiller: string = '|:-'
@@ -34,7 +39,14 @@ export class GithubMdBuilder {
     this.checkFilesMap = options.checkFilesMap
 
     this.subHeader = []
-    this.tableHeaders = ['Result', 'Name', 'Check Type', 'Filename', 'Duration']
+    this.hasFilenames = !(options.checkFilesMap.size === 1 && options.checkFilesMap.has(undefined))
+    this.tableHeaders = [
+      'Result',
+      'Name',
+      'Check Type',
+      this.hasFilenames ? 'Filename' : undefined,
+      'Duration',
+    ].filter(nonNullable)
     this.extraTableHeadersWithLinks = ['Assets', 'Link']
     this.tableRows = []
   }
@@ -56,9 +68,9 @@ export class GithubMdBuilder {
           `${result.hasFailures ? '❌ Fail' : '✅ Pass'}`,
           `${result.name}`,
           `${result.checkType}`,
-          `\`${result.sourceFile}\``,
+          this.hasFilenames ? `\`${result.sourceFile}\`` : undefined,
           `${formatDuration(result.responseTime)} `,
-        ]
+        ].filter(nonNullable)
 
         if (this.testSessionId && testResultId) {
           const assets: Array<string> = []

--- a/packages/cli/src/rest/test-sessions.ts
+++ b/packages/cli/src/rest/test-sessions.ts
@@ -11,6 +11,17 @@ type RunTestSessionRequest = {
   shouldRecord: boolean,
 }
 
+type TriggerTestSessionRequest = {
+  name: string,
+  runLocation: string|{ type: 'PUBLIC', region: string }|{ type: 'PRIVATE', slugName: string, id: string },
+  shouldRecord: boolean,
+  targetTags: string[][],
+  checkRunSuiteId: string,
+  environmentVariables: Array<{ key: string, value: string }>,
+  repoInfo: GitInformation | null,
+  environment: string | null,
+}
+
 class TestSessions {
   api: AxiosInstance
   constructor (api: AxiosInstance) {
@@ -19,6 +30,10 @@ class TestSessions {
 
   run (payload: RunTestSessionRequest) {
     return this.api.post('/next/test-sessions/run', payload)
+  }
+
+  trigger (payload: TriggerTestSessionRequest) {
+    return this.api.post('/next/test-sessions/trigger', payload)
   }
 }
 

--- a/packages/cli/src/services/trigger-runner.ts
+++ b/packages/cli/src/services/trigger-runner.ts
@@ -1,0 +1,78 @@
+import { testSessions } from '../rest/api'
+import AbstractCheckRunner, { RunLocation, CheckRunId } from './abstract-check-runner'
+import { GitInformation } from './util'
+
+export default class TriggerRunner extends AbstractCheckRunner {
+  shouldRecord: boolean
+  location: RunLocation
+  targetTags: string[][]
+  envVars: Array<{ key: string, value: string }>
+  repoInfo: GitInformation | null
+  environment: string | null
+  testSessionName: string | undefined
+
+  constructor (
+    accountId: string,
+    timeout: number,
+    verbose: boolean,
+    shouldRecord: boolean,
+    location: RunLocation,
+    targetTags: string[][],
+    envVars: Array<{ key: string, value: string }>,
+    repoInfo: GitInformation | null,
+    environment: string | null,
+    testSessionName: string | undefined,
+  ) {
+    super(accountId, timeout, verbose)
+    this.shouldRecord = shouldRecord
+    this.location = location
+    this.targetTags = targetTags
+    this.envVars = envVars
+    this.repoInfo = repoInfo
+    this.environment = environment
+    this.testSessionName = testSessionName
+  }
+
+  async scheduleChecks (
+    checkRunSuiteId: string,
+  ): Promise<{
+    testSessionId?: string,
+    checks: Array<{ check: any, checkRunId: CheckRunId, testSessionId?: string }>,
+  }> {
+    try {
+      const { data } = await testSessions.trigger({
+        name: this.testSessionName ?? 'Triggered Session',
+        shouldRecord: this.shouldRecord,
+        runLocation: this.location,
+        checkRunSuiteId,
+        targetTags: this.targetTags,
+        environmentVariables: this.envVars,
+        repoInfo: this.repoInfo,
+        environment: this.environment,
+      })
+      const {
+        checks,
+        checkRunIds,
+        testSessionId,
+        testResultIds,
+      }: {
+        checks: Array<any>,
+        checkRunIds: Record<string, CheckRunId>,
+        testSessionId: string,
+        testResultIds: Record<string, string>,
+      } = data
+      const checksMap: Record<string, any> = checks.reduce((acc: Record<string, any>, check: any) => {
+        acc[check.id] = check
+        return acc
+      }, {})
+      const augmentedChecks = Object.entries(checkRunIds).map(([checkId, checkRunId]) => ({
+        checkRunId,
+        check: checksMap[checkId],
+        testResultId: testResultIds?.[checkId],
+      }))
+      return { checks: augmentedChecks, testSessionId }
+    } catch (err: any) {
+      throw new Error(err.response?.data?.message ?? err.message)
+    }
+  }
+}

--- a/packages/cli/src/services/util.ts
+++ b/packages/cli/src/services/util.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs/promises'
 import * as fsSync from 'fs'
 import { Service } from 'ts-node'
 import * as gitRepoInfo from 'git-repo-info'
+import { parse } from 'dotenv'
 
 export interface GitInformation {
   commitId: string
@@ -151,4 +152,13 @@ export function escapeValue (value: string | undefined) {
       .replace(/\n/g, '\\n') // combine newlines (unix) into one line
       .replace(/\r/g, '\\r') // combine newlines (windows) into one line
     : ''
+}
+
+export async function getEnvs (envFile: string|undefined, envArgs: Array<string>) {
+  if (envFile) {
+    const envsString = await fs.readFile(envFile, { encoding: 'utf8' })
+    return parse(envsString)
+  }
+  const envsString = `${envArgs.join('\n')}`
+  return parse(envsString)
 }


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
This PR introduces a new command for running checks, `npx checkly trigger`.  Unlike `npx checkly test`, this lets you run checks that are stored on your Checkly account and not necessarily managed with MaC. It's possible to specify checks to run using tags: `npx checkly trigger -t target-tag`. For the most part, `npx checkly trigger` aims to be as similar as possible to `npx checkly test`.

```
$ npx checkly trigger --help
Trigger checks on Checkly

USAGE
  $ checkly trigger [--private-location <value> | -l <value>] [-t <value>] [-c <value>] [--timeout <value>] [-v] [-r list|dot|ci|github] [-e <value> | --env-file <value>] [--record] [-n <value>]

FLAGS
  -c, --config=<value>             The Checkly CLI config filename.
  -e, --env=<value>...             [default: ] Env vars to be passed to the check run.
  -l, --location=<value>           The location to run the checks at.
  -n, --test-session-name=<value>  A name to use when storing results in Checkly with --record.
  -r, --reporter=<option>          A list of custom reporters for the test output.
                                   <options: list|dot|ci|github>
  -t, --tags=<value>...            Filter the checks to be run using a comma separated list of tags. Checks will only be run if the contain all of the specified tags. Multiple --tags flags can be passed, in which case checks will be run if they match any of the --tags
                                   filters. F.ex. `--tags production,webapp --tags production,backend` will run checks with tags (production AND webapp) OR (staging AND backend).
  -v, --[no-]verbose               Always show the full logs of the checks.
  --env-file=<value>               dotenv file path to be passed. For example --env-file="./.env"
  --private-location=<value>       The private location to run checks at.
  --record                         Record check results in Checkly as a test session with full logs, traces and videos.
  --timeout=<value>                [default: 240] A timeout (in seconds) to wait for checks to complete.

DESCRIPTION
  Trigger checks on Checkly
```