### PR TITLE
chore: add engines property to cli package.json

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,6 +4,9 @@
   "description": "Checkly CLI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "engines": {
+    "node": ">=16.0.0"
+  },
   "scripts": {
     "clean": "rimraf ./dist",
     "test": "jest --selectProjects unit",


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->
Add `engines` property to CLI `package.json` to warn folks when they're using the wrong Node.js version


## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
