### PR TITLE
chore: add account id to `whoami` output [sc-00]

### DIFF
--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -8,6 +8,6 @@ export default class Whoami extends AuthCommand {
   async run (): Promise<void> {
     const { data: account } = await api.accounts.get(config.getAccountId())
     const { data: user } = await api.user.get()
-    this.log(`You are currently on account "${account.name}" as ${user.name}.`)
+    this.log(`You are currently on account "${account.name}" (${account.id}) as ${user.name}.`)
   }
 }


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
- Add `accountId` when running `whoami` command

```bash
> You are currently on account "nacho@checklyhq.com" (111ac7a7-466b-4d15-b07d-8b051626f754) as Ignacio Anaya.
```