### PR TITLE
feat: add `locations` command [sc-00]

### DIFF
--- a/packages/cli/e2e/__tests__/locations.spec.ts
+++ b/packages/cli/e2e/__tests__/locations.spec.ts
@@ -2,13 +2,13 @@ import { runChecklyCli } from '../run-checkly'
 import * as config from 'config'
 import '../command-matchers'
 
-describe('whomai', () => {
-  it('should give correct user', () => {
+describe('locations', () => {
+  it('should give locations list', () => {
     const result = runChecklyCli({
-      args: ['whoami'],
+      args: ['locations'],
       apiKey: config.get('apiKey'),
       accountId: config.get('accountId'),
     })
-    expect(result).toHaveStdoutContaining(config.get('accountName'))
+    expect(result).toHaveStdoutContaining('us-east-1')
   })
 })

--- a/packages/cli/src/commands/locations.ts
+++ b/packages/cli/src/commands/locations.ts
@@ -1,0 +1,12 @@
+import * as api from '../rest/api'
+import { BaseCommand } from './baseCommand'
+
+export default class Locations extends BaseCommand {
+  static hidden = false
+  static description = 'List all supported locations'
+  async run (): Promise<void> {
+    const { data: locations } = await api.locations.getAll()
+    const output = locations.map(l => l.region)
+    this.log(JSON.stringify(output, null, 2))
+  }
+}


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Add a command to retrieve all available locations easily.  
I think it is very useful for a rapid locations settings on `checkly.config.ts`

``` bash
$ npx checkly locations
[
  "us-east-1",
  "us-east-2",
  "us-west-1",
  "us-west-2",
  "ca-central-1",
  "sa-east-1",
  "eu-west-1",
  "eu-central-1",
  "eu-west-2",
  "eu-west-3",
  "eu-north-1",
  "eu-south-1",
  "me-south-1",
  "ap-southeast-1",
  "ap-northeast-1",
  "ap-east-1",
  "ap-southeast-2",
  "ap-southeast-3",
  "ap-northeast-2",
  "ap-northeast-3",
  "ap-south-1",
  "af-south-1"
]
```
