### PR TITLE
feat: log scheduling errors

### DIFF
--- a/packages/cli/src/reporters/__tests__/__snapshots__/util.spec.ts.snap
+++ b/packages/cli/src/reporters/__tests__/__snapshots__/util.spec.ts.snap
@@ -42,6 +42,51 @@ Body:
 "
 `;
 
+exports[`formatCheckResult() API Check result formats an API Check result with a scheduleError: api-check-result-schedule-error-format 1`] = `
+"──HTTP Request────────────────────────────────────────────────────────────────────
+POST https://httpbin.org/post
+Headers:
+  User-Agent: Checkly/1.0 (https://www.checklyhq.com)
+  accept-encoding: gzip, deflate
+  content-length: 10
+Body:
+  {"data":1}
+
+──HTTP Response───────────────────────────────────────────────────────────────────
+Status Code: 200 OK
+Headers:
+  date: Fri, 24 Mar 2023 10:45:42 GMT
+  content-type: application/json
+  content-length: 422
+  connection: close
+  server: gunicorn/19.9.0
+  access-control-allow-origin: *
+  access-control-allow-credentials: true
+Body:
+  {
+    "args": {}, 
+    "data": "{\\"data\\":1}", 
+    "files": {}, 
+    "form": {}, 
+    "headers": {
+      "Accept-Encoding": "gzip, deflate", 
+      "Content-Length": "10", 
+      "Host": "httpbin.org", 
+      "User-Agent": "Checkly/1.0 (https://www.checklyhq.com)", 
+      "X-Amzn-Trace-Id": "Root=1-641d7f55-0b99ca310b7322250bd32d00"
+    }, 
+    "json": {
+      "data": 1
+    }, 
+    "origin": "3.251.180.115", 
+    "url": "https://httpbin.org/post"
+  }
+
+
+──Scheduling Error────────────────────────────────────────────────────────────────
+There was a scheduling error"
+`;
+
 exports[`formatCheckResult() API Check result formats an API Check result with assertions: api-check-result-assertions-format 1`] = `
 "──HTTP Request────────────────────────────────────────────────────────────────────
 POST https://httpbin.org/post
@@ -126,6 +171,25 @@ Body:
 "
 `;
 
+exports[`formatCheckResult() Browser Check result formats a Browser Check result with a scheduleError: browser-check-result-schedule-error-format 1`] = `
+"──Logs────────────────────────────────────────────────────────────────────────────
+10:53:15 DEBUG Starting job
+10:53:15 DEBUG Compiling environment variables
+10:53:15 DEBUG Creating runtime using version 2022.10
+10:53:15 DEBUG Running Playwright test script
+10:53:16 INFO  Running 1 test using 1 worker
+10:53:16 INFO  
+10:53:18 INFO  [1/1] [chromium] › ../../var/task/src/2022-10/node_modules/vm2/lib/bridge.js:479:11 › visit page and take screenshot
+10:53:22 INFO  
+10:53:22 INFO  
+10:53:22 INFO  1 passed (5s)
+10:53:22 DEBUG Run finished
+10:53:22 DEBUG Uploading log file
+
+──Scheduling Error────────────────────────────────────────────────────────────────
+There was a scheduling error"
+`;
+
 exports[`formatCheckResult() Browser Check result formats a Browser Check result with logs: browser-check-result-logs-format 1`] = `
 "──Logs────────────────────────────────────────────────────────────────────────────
 10:53:15 DEBUG Starting job
@@ -143,9 +207,3 @@ exports[`formatCheckResult() Browser Check result formats a Browser Check result
 `;
 
 exports[`formatCheckResult() Browser Check result formats a basic Browser Check result : browser-check-result-basic-format 1`] = `""`;
-
-exports[`formatCheckTitle() should print a failed check title: failed-check-title 1`] = `"✖ /test/test-file.check.ts > Test Check (11s)"`;
-
-exports[`formatCheckTitle() should print a passed check title: passed-check-title 1`] = `"✔ /test/test-file.check.ts > Test Check (11s)"`;
-
-exports[`formatCheckTitle() should print a pending check title: pending-check-title 1`] = `"- /test/test-file.check.ts > Test Check (11s)"`;

--- a/packages/cli/src/reporters/__tests__/__snapshots__/util.spec.ts.snap
+++ b/packages/cli/src/reporters/__tests__/__snapshots__/util.spec.ts.snap
@@ -207,3 +207,9 @@ exports[`formatCheckResult() Browser Check result formats a Browser Check result
 `;
 
 exports[`formatCheckResult() Browser Check result formats a basic Browser Check result : browser-check-result-basic-format 1`] = `""`;
+
+exports[`formatCheckTitle() should print a failed check title: failed-check-title 1`] = `"✖ /test/test-file.check.ts > Test Check (11s)"`;
+
+exports[`formatCheckTitle() should print a passed check title: passed-check-title 1`] = `"✔ /test/test-file.check.ts > Test Check (11s)"`;
+
+exports[`formatCheckTitle() should print a pending check title: pending-check-title 1`] = `"- /test/test-file.check.ts > Test Check (11s)"`;

--- a/packages/cli/src/reporters/__tests__/fixtures/api-check-result.ts
+++ b/packages/cli/src/reporters/__tests__/fixtures/api-check-result.ts
@@ -132,6 +132,7 @@ export const apiCheckResult = {
         "total": 1234.2094030000735
       }
     },
-    "requestError": null
-  }
+    "requestError": null,
+  },
+  "scheduleError" : ""
 }

--- a/packages/cli/src/reporters/__tests__/fixtures/browser-check-result.ts
+++ b/packages/cli/src/reporters/__tests__/fixtures/browser-check-result.ts
@@ -157,5 +157,6 @@ export const browserCheckResult = {
       "msg": "Uploading log file",
       "level": "DEBUG"
     }
-  ]
+  ],
+  "scheduleError" : ''
 }

--- a/packages/cli/src/reporters/__tests__/util.spec.ts
+++ b/packages/cli/src/reporters/__tests__/util.spec.ts
@@ -52,6 +52,15 @@ describe('formatCheckResult()', () => {
       expect(stripAnsi(formatCheckResult(apiCheckResult)))
         .toMatchSnapshot('api-check-result-logs-format')
     })
+    it('formats an API Check result with a scheduleError', () => {
+      const basicApiCheckResult = { ...apiCheckResult }
+      basicApiCheckResult.checkRunData.assertions = []
+      basicApiCheckResult.logs.setup = []
+      basicApiCheckResult.logs.teardown = []
+      basicApiCheckResult.scheduleError = 'There was a scheduling error'
+      expect(stripAnsi(formatCheckResult(basicApiCheckResult)))
+        .toMatchSnapshot('api-check-result-schedule-error-format')
+    })
   })
   describe('Browser Check result', () => {
     it('formats a basic Browser Check result ', () => {
@@ -63,6 +72,12 @@ describe('formatCheckResult()', () => {
     it('formats a Browser Check result with logs', () => {
       expect(stripAnsi(formatCheckResult(browserCheckResult)))
         .toMatchSnapshot('browser-check-result-logs-format')
+    })
+    it('formats a Browser Check result with a scheduleError', () => {
+      const basicBrowserCheckResult = { ...browserCheckResult }
+      basicBrowserCheckResult.scheduleError = 'There was a scheduling error'
+      expect(stripAnsi(formatCheckResult(basicBrowserCheckResult)))
+        .toMatchSnapshot('browser-check-result-schedule-error-format')
     })
   })
 })

--- a/packages/cli/src/reporters/util.ts
+++ b/packages/cli/src/reporters/util.ts
@@ -100,6 +100,12 @@ export function formatCheckResult (checkResult: any) {
       formatRunError(checkResult.runError),
     ])
   }
+  if (checkResult.scheduleError) {
+    result.push([
+      formatSectionTitle('Scheduling Error'),
+      formatRunError(checkResult.scheduleError),
+    ])
+  }
   return result.map(([title, body]) => title + '\n' + body).join('\n\n')
 }
 


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [x] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

## Notes for the Reviewer
Logs scheduling errors to the logs.

Example:

```
Running 1 checks in eu-west-1.

✖ Test API check (0ms)

    ──Scheduling Error────────
    Your setup script timed out after 23010 milliseconds

src/__checks__/api-3.check.ts
  ✖ Test API check (0ms)
```

> Resolves #617 
