### PR TITLE
fix: remove typo from `home.check.ts` description [sc-00]

### DIFF
--- a/examples/advanced-project/src/__checks__/home.check.ts
+++ b/examples/advanced-project/src/__checks__/home.check.ts
@@ -7,7 +7,7 @@ const alertChannels = [smsChannel, emailChannel]
 
 /*
 * In this example, we bundle all basic checks needed to check the Checkly homepage. We explicitly define the Browser
-* check here, instead of using generating a default based on a .spec.js file. This allows us to override the check configuration.
+* check here, instead of using a default based on a .spec.js file. This allows us to override the check configuration.
 * We can also add more checks into one file, in this case to cover a specific API call needed to hydrate the homepage.
 */
 


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [ ] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [x] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->
Fix the sentence:
> We explicitly define the Browser check here, instead of using ~generating~ a default based on a .spec.js file. 

Let me know if `generating` is the intended word.
