### PR TITLE
fix: default reporter value [gh-0]

### DIFF
--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs/promises'
 import { Flags, Args } from '@oclif/core'
 import { parse } from 'dotenv'
+import { isCI } from 'ci-info'
 import * as api from '../rest/api'
 import config from '../services/config'
 import { parseProject } from '../services/project-parser'
@@ -70,7 +71,6 @@ export default class Test extends AuthCommand {
       char: 'r',
       description: 'A list of custom reporters for the test output.',
       options: ['list', 'dot', 'ci', 'github'],
-      default: 'list',
     }),
     config: Flags.string({
       char: 'c',
@@ -104,7 +104,7 @@ export default class Test extends AuthCommand {
       list,
       timeout,
       verbose: verboseFlag,
-      reporter: reporterType,
+      reporter: reporterType = isCI ? 'ci' : 'list',
       config: configFilename,
       record: shouldRecord,
     } = flags

--- a/packages/cli/src/reporters/reporter.ts
+++ b/packages/cli/src/reporters/reporter.ts
@@ -1,4 +1,3 @@
-import { isCI } from 'ci-info'
 import { Check } from '../constructs/check'
 import { RunLocation } from '../services/check-runner'
 import CiReporter from './ci'
@@ -32,6 +31,6 @@ export const createReporter = (
     case 'github':
       return new GithubReporter(runLocation, checks, verbose)
     default:
-      return isCI ? new CiReporter(runLocation, checks, verbose) : new ListReporter(runLocation, checks, verbose)
+      return new ListReporter(runLocation, checks, verbose)
   }
 }


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
- remove the `--reporter` default value to fix the `ci` output when CLI is executed from a CI task.
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
