### PR TITLE
refactor: move filename filter before project rendering

### DIFF
--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -133,6 +133,7 @@ export default class Test extends AuthCommand {
       checkMatch: checklyConfig.checks?.checkMatch,
       browserCheckMatch: checklyConfig.checks?.browserChecks?.testMatch,
       ignoreDirectoriesMatch: checklyConfig.checks?.ignoreDirectoriesMatch,
+      fileNameFilters: filePatterns,
       checkDefaults: checklyConfig.checks,
       browserCheckDefaults: checklyConfig.checks?.browserChecks,
       availableRuntimes: availableRuntimes.reduce((acc, runtime) => {
@@ -142,14 +143,6 @@ export default class Test extends AuthCommand {
       checklyConfigConstructs,
     })
     const checks = Object.entries(project.data.checks)
-      .filter(([, check]) => {
-        if (check instanceof BrowserCheck) {
-          return filterByFileNamePattern(filePatterns, check.scriptPath) ||
-            filterByFileNamePattern(filePatterns, check.__checkFilePath)
-        } else {
-          return filterByFileNamePattern(filePatterns, check.__checkFilePath)
-        }
-      })
       .filter(([, check]) => {
         return filterByCheckNamePattern(grep, check.name)
       })

--- a/packages/cli/src/services/__tests__/project-parser.spec.ts
+++ b/packages/cli/src/services/__tests__/project-parser.spec.ts
@@ -48,4 +48,28 @@ describe('parseProject()', () => {
       },
     })
   })
+
+  it('filter on file name', async () => {
+    const simpleProjectPath = path.join(__dirname, 'project-parser-fixtures', 'simple-project')
+    const project = await parseProject({
+      directory: simpleProjectPath,
+      projectLogicalId: 'project-id',
+      projectName: 'project name',
+      fileNameFilters: ['login'],
+      repoUrl: 'https://github.com/checkly/checkly-cli',
+      availableRuntimes: runtimes,
+    })
+    const synthesizedProject = project.synthesize()
+    expect(synthesizedProject).toMatchObject({
+      project: {
+        logicalId: 'project-id',
+        name: 'project name',
+        repoUrl: 'https://github.com/checkly/checkly-cli',
+      },
+      checks: {
+        'check-1': {},
+      },
+    })
+    expect(Object.keys(synthesizedProject.checks)).toHaveLength(1)
+  })
 })


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [x] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

## Notes for the Reviewer
- shuffles file name filtering, e.g. `npx checkly test my-file` just before the files are required, enabling having "broken" checks in your code base but still being able to run specific checks.

- note: still has one broken test that works when running individually, but not as a suite. Probably due to scope polution.

> Resolves #441 


