### PR TITLE
fix: correctly configure dependabot directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
+    directory: "/"    
     versioning-strategy: increase
     # Runs at 9am CET only on weekdays
     schedule:


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [ ] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
The dependabot github action has started failing, but it's not clear what triggered this. To resolve this, we can set the required `directory` property ([docs here](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directory)).
