### PR TITLE
fix: dont create alert subscriptions when testOnly is true [gh-655]

### DIFF
--- a/packages/cli/src/constructs/check.ts
+++ b/packages/cli/src/constructs/check.ts
@@ -133,7 +133,7 @@ export abstract class Check extends Construct {
   }
 
   addSubscriptions () {
-    if (!this.alertChannels) {
+    if (!this.alertChannels || this.testOnly) {
       return
     }
     for (const alertChannel of this.alertChannels) {


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Dont create alert subscriptions if `testOnly=true`

> Resolves #655 
