### PR TITLE
login.ts: Fix help URL to API keys

### DIFF
--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -34,7 +34,7 @@ export default class Login extends BaseCommand {
       char: 'k',
       name: 'apiKey',
       description:
-      'Checkly User API Key. \nIf you did not have one, create it at: https://app.checklyhq.com/account/api-keys.',
+      'Checkly User API Key. \nIf you did not have one, create it at: https://app.checklyhq.com/settings/user/api-keys.',
     }),
 
     'account-id': Flags.string({


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI

## Notes for the Reviewer

Old URL was leading to the general Settings page. When clicking straight on `API keys` there (which is your mental mode since you came from `npx checkly login -h` telling you to go there finding API keys) then you get a deprecation warning that keys are based on users now. This is a fix to lead the user straight to the correct page.
