### PR TITLE
refactor: prepare reporters for checkly trigger command [sc-14206]

### DIFF
--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -5,7 +5,7 @@ import { isCI } from 'ci-info'
 import * as api from '../rest/api'
 import config from '../services/config'
 import { parseProject } from '../services/project-parser'
-import { Events, RunLocation, PrivateRunLocation } from '../services/abstract-check-runner'
+import { Events, RunLocation, PrivateRunLocation, CheckRunId } from '../services/abstract-check-runner'
 import TestRunner from '../services/test-runner'
 import { loadChecklyConfig } from '../services/checkly-config-loader'
 import { filterByFileNamePattern, filterByCheckNamePattern } from '../services/test-filters'
@@ -179,7 +179,7 @@ export default class Test extends AuthCommand {
       return
     }
 
-    const reporters = createReporters(reporterTypes, location, checks, verbose)
+    const reporters = createReporters(reporterTypes, location, verbose)
     if (list) {
       reporters.forEach(r => r.onBeginStatic())
       return
@@ -200,20 +200,20 @@ export default class Test extends AuthCommand {
       ciInfo.environment,
     )
     runner.on(Events.RUN_STARTED,
-      (testSessionId: string, testResultIds: { [key: string]: string }) =>
-        reporters.forEach(r => r.onBegin(testSessionId, testResultIds)))
-    runner.on(Events.CHECK_SUCCESSFUL, (check, result) => {
+      (checks: Array<{ check: any, checkRunId: CheckRunId, testResultId?: string }>, testSessionId: string) =>
+        reporters.forEach(r => r.onBegin(checks, testSessionId)))
+    runner.on(Events.CHECK_SUCCESSFUL, (checkRunId, check, result) => {
       if (result.hasFailures) {
         process.exitCode = 1
       }
-      reporters.forEach(r => r.onCheckEnd({
+      reporters.forEach(r => r.onCheckEnd(checkRunId, {
         logicalId: check.logicalId,
         sourceFile: check.getSourceFile(),
         ...result,
       }))
     })
-    runner.on(Events.CHECK_FAILED, (check, message: string) => {
-      reporters.forEach(r => r.onCheckEnd({
+    runner.on(Events.CHECK_FAILED, (checkRunId, check, message: string) => {
+      reporters.forEach(r => r.onCheckEnd(checkRunId, {
         ...check,
         logicalId: check.logicalId,
         sourceFile: check.getSourceFile(),

--- a/packages/cli/src/reporters/__tests__/github-md-builder.spec.ts
+++ b/packages/cli/src/reporters/__tests__/github-md-builder.spec.ts
@@ -5,10 +5,9 @@ const testSessionId = '0c4c64b3-79c5-44a6-ae07-b580ce73f328'
 const runLocation = 'eu-west-1'
 describe('GithubMdBuilder', () => {
   test('renders basic markdown output with no assets & links', () => {
-    const { checkFilesMap } = generateMapAndTestResultIds()
+    const checkFilesMap = generateMapAndTestResultIds({ includeTestResultIds: false })
     const markdown = new GithubMdBuilder({
       testSessionId: undefined,
-      testResultIds: {},
       numChecks: checkFilesMap.size,
       runLocation,
       checkFilesMap,
@@ -16,10 +15,9 @@ describe('GithubMdBuilder', () => {
     expect(markdown).toMatchSnapshot('github-basic-markdown')
   })
   test('renders basic markdown output with assets & links', () => {
-    const { checkFilesMap, testResultIds } = generateMapAndTestResultIds()
+    const checkFilesMap = generateMapAndTestResultIds({ includeTestResultIds: true })
     const markdown = new GithubMdBuilder({
       testSessionId,
-      testResultIds,
       numChecks: checkFilesMap.size,
       runLocation,
       checkFilesMap,

--- a/packages/cli/src/reporters/__tests__/helpers.ts
+++ b/packages/cli/src/reporters/__tests__/helpers.ts
@@ -2,22 +2,24 @@ import { checkFilesMap } from '../abstract-list'
 import { browserCheckResult } from './fixtures/browser-check-result'
 import { apiCheckResult } from './fixtures/api-check-result'
 
-export function generateMapAndTestResultIds () {
+export function generateMapAndTestResultIds ({ includeTestResultIds = true }) {
   const checkFilesMapFixture: checkFilesMap = new Map([
     ['folder/browser.check.ts', new Map([
-      [browserCheckResult.logicalId, { result: browserCheckResult as any, titleString: browserCheckResult.name }],
+      [browserCheckResult.checkRunId, {
+        result: browserCheckResult as any,
+        titleString: browserCheckResult.name,
+        // TODO: We shouldn't reuse the checkRunId as the testResultId in the test. This isn't how it actually works.
+        testResultId: includeTestResultIds ? browserCheckResult.checkRunId : undefined,
+      }],
     ])],
     ['folder/api.check.ts', new Map([
-      [apiCheckResult.logicalId, { result: apiCheckResult as any, titleString: apiCheckResult.name }],
+      [apiCheckResult.checkRunId, {
+        result: apiCheckResult as any,
+        titleString: apiCheckResult.name,
+        testResultId: includeTestResultIds ? apiCheckResult.checkRunId : undefined,
+      }],
     ])],
   ])
 
-  const testResultIdsFixture = {
-    [browserCheckResult.logicalId]: browserCheckResult.checkRunId,
-    [apiCheckResult.logicalId]: apiCheckResult.checkRunId,
-  }
-  return {
-    checkFilesMap: checkFilesMapFixture,
-    testResultIds: testResultIdsFixture,
-  }
+  return checkFilesMapFixture
 }

--- a/packages/cli/src/reporters/ci.ts
+++ b/packages/cli/src/reporters/ci.ts
@@ -2,6 +2,7 @@ import * as indentString from 'indent-string'
 
 import AbstractListReporter from './abstract-list'
 import { formatCheckTitle, formatCheckResult, CheckStatus, printLn } from './util'
+import { CheckRunId } from '../services/abstract-check-runner'
 
 export default class CiReporter extends AbstractListReporter {
   onBeginStatic () {
@@ -9,7 +10,8 @@ export default class CiReporter extends AbstractListReporter {
     this._printSummary({ skipCheckCount: true })
   }
 
-  onBegin () {
+  onBegin (checks: Array<{ check: any, checkRunId: CheckRunId, testResultId?: string }>, testSessionId?: string) {
+    super.onBegin(checks, testSessionId)
     printLn(`Running ${this.numChecks} checks in ${this._runLocationString()}:`, 2, 1)
     this._printSummary({ skipCheckCount: true })
   }
@@ -19,8 +21,8 @@ export default class CiReporter extends AbstractListReporter {
     this._printSummary()
   }
 
-  onCheckEnd (checkResult: any) {
-    super.onCheckEnd(checkResult)
+  onCheckEnd (checkRunId: CheckRunId, checkResult: any) {
+    super.onCheckEnd(checkRunId, checkResult)
     printLn(formatCheckTitle(checkResult.hasFailures ? CheckStatus.FAILED : CheckStatus.SUCCESSFUL, checkResult))
 
     if (this.verbose || checkResult.hasFailures) {

--- a/packages/cli/src/reporters/dot.ts
+++ b/packages/cli/src/reporters/dot.ts
@@ -1,5 +1,6 @@
 import * as chalk from 'chalk'
 import AbstractListReporter from './abstract-list'
+import { CheckRunId } from '../services/abstract-check-runner'
 import { print, printLn } from './util'
 
 export default class DotReporter extends AbstractListReporter {
@@ -7,7 +8,8 @@ export default class DotReporter extends AbstractListReporter {
     printLn(`Running ${this.numChecks} checks in ${this._runLocationString()}.`, 2, 1)
   }
 
-  onBegin () {
+  onBegin (checks: Array<{ check: any, checkRunId: CheckRunId, testResultId?: string }>, testSessionId?: string) {
+    super.onBegin(checks, testSessionId)
     this.onBeginStatic()
   }
 
@@ -15,8 +17,8 @@ export default class DotReporter extends AbstractListReporter {
     this._printBriefSummary()
   }
 
-  onCheckEnd (checkResult: any) {
-    super.onCheckEnd(checkResult)
+  onCheckEnd (checkRunId: CheckRunId, checkResult: any) {
+    super.onCheckEnd(checkRunId, checkResult)
     if (checkResult.hasFailures) {
       print(`${chalk.red('F')}`)
     } else {

--- a/packages/cli/src/reporters/list.ts
+++ b/packages/cli/src/reporters/list.ts
@@ -2,6 +2,7 @@ import * as indentString from 'indent-string'
 import * as chalk from 'chalk'
 
 import AbstractListReporter from './abstract-list'
+import { CheckRunId } from '../services/abstract-check-runner'
 import { formatCheckTitle, formatCheckResult, CheckStatus, printLn, getTestSessionUrl, getTraceUrl } from './util'
 
 export default class ListReporter extends AbstractListReporter {
@@ -10,9 +11,8 @@ export default class ListReporter extends AbstractListReporter {
     this._printSummary({ skipCheckCount: true })
   }
 
-  onBegin (testSessionId?: string, testResultIds?: { [key: string]: string }) {
-    this._setTestSessionId(testSessionId)
-    this._setTestResultIds(testResultIds)
+  onBegin (checks: Array<{ check: any, checkRunId: CheckRunId, testResultId?: string }>, testSessionId?: string) {
+    super.onBegin(checks, testSessionId)
     printLn(`Running ${this.numChecks} checks in ${this._runLocationString()}.`, 2, 1)
     this._printSummary()
   }
@@ -23,8 +23,9 @@ export default class ListReporter extends AbstractListReporter {
     this._printTestSessionsUrl()
   }
 
-  onCheckEnd (checkResult: any) {
-    super.onCheckEnd(checkResult)
+  onCheckEnd (checkRunId: CheckRunId, checkResult: any) {
+    super.onCheckEnd(checkRunId, checkResult)
+    const { testResultId } = this.checkFilesMap!.get(checkResult.sourceFile)!.get(checkRunId)!
     this._clearSummary()
 
     if (this.verbose) {
@@ -54,9 +55,9 @@ export default class ListReporter extends AbstractListReporter {
           , 4,
         ))
       }
-      if (this.testResultIds && this.testSessionId) {
+      if (testResultId && this.testSessionId) {
         printLn(indentString(
-          'View result: ' + chalk.underline.cyan(`${getTestSessionUrl(this.testSessionId)}/results/${this.testResultIds[checkResult.logicalId]}`)
+          'View result: ' + chalk.underline.cyan(`${getTestSessionUrl(this.testSessionId)}/results/${testResultId}`)
           , 4,
         ), 2)
       }

--- a/packages/cli/src/reporters/reporter.ts
+++ b/packages/cli/src/reporters/reporter.ts
@@ -1,5 +1,4 @@
-import { Check } from '../constructs/check'
-import { RunLocation } from '../services/abstract-check-runner'
+import { RunLocation, CheckRunId } from '../services/abstract-check-runner'
 import CiReporter from './ci'
 import DotReporter from './dot'
 import GithubReporter from './github'
@@ -7,9 +6,9 @@ import ListReporter from './list'
 
 export interface Reporter {
   onBeginStatic(): void;
-  onBegin(testSessionId: string, testResultIds?: { [key: string]: string }): void;
+  onBegin(checks: Array<{ check: any, checkRunId: CheckRunId, testResultId?: string }>, testSessionId?: string): void;
   onEnd(): void;
-  onCheckEnd(checkResult: any): void;
+  onCheckEnd(checkRunId: CheckRunId, checkResult: any): void;
   onError(err: Error): void,
 }
 
@@ -18,19 +17,18 @@ export type ReporterType = 'list' | 'dot' | 'ci' | 'github'
 export const createReporters = (
   types: ReporterType[],
   runLocation: RunLocation,
-  checks: Array<Check>,
   verbose: boolean,
 ): Reporter[] => types.map(t => {
   switch (t) {
     case 'dot':
-      return new DotReporter(runLocation, checks, verbose)
+      return new DotReporter(runLocation, verbose)
     case 'list':
-      return new ListReporter(runLocation, checks, verbose)
+      return new ListReporter(runLocation, verbose)
     case 'ci':
-      return new CiReporter(runLocation, checks, verbose)
+      return new CiReporter(runLocation, verbose)
     case 'github':
-      return new GithubReporter(runLocation, checks, verbose)
+      return new GithubReporter(runLocation, verbose)
     default:
-      return new ListReporter(runLocation, checks, verbose)
+      return new ListReporter(runLocation, verbose)
   }
 })

--- a/packages/cli/src/services/test-runner.ts
+++ b/packages/cli/src/services/test-runner.ts
@@ -35,7 +35,10 @@ export default class TestRunner extends AbstractCheckRunner {
 
   async scheduleChecks (
     checkRunSuiteId: string,
-  ): Promise<{ testSessionId?: string, testResultIds?: Map<string, string>, checks: Map<CheckRunId, any> }> {
+  ): Promise<{
+    testSessionId?: string,
+    checks: Array<{ check: any, checkRunId: CheckRunId, testSessionId?: string }>,
+  }> {
     const checkRunIdMap = new Map(
       this.checkConstructs.map((check) => [uuid.v4(), check]),
     )
@@ -60,7 +63,9 @@ export default class TestRunner extends AbstractCheckRunner {
         shouldRecord: this.shouldRecord,
       })
       const { testSessionId, testResultIds } = data
-      return { testSessionId, testResultIds, checks: checkRunIdMap }
+      const checks = Array.from(checkRunIdMap.entries())
+        .map(([checkRunId, check]) => ({ check, checkRunId, testResultId: testResultIds?.[check.logicalId] }))
+      return { testSessionId, checks }
     } catch (err: any) {
       throw new Error(err.response?.data?.message ?? err.message)
     }


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
The reporters are currently quite coupled to `checkly test` and will be tricky to work with for `checkly trigger`. This PR refactors the reporters to prepare for the `checkly trigger` command (https://github.com/checkly/checkly-cli/pull/609).

In particular:
1. All of the `Reporters` currently take the list of checks that will be run in the constructor. With `checkly trigger`, though, we won't know in advance which checks will actually be run (since the backend applies tag filters). This PR makes the reporters accept a list of checks that will be run in `onBegin` instead. Unfortunately, this means that we sometimes need to use the null assertion operator `!` in the reporters.
2. `AbstractListReporter` currently tracks the state of checks using a map `checkFilesMap` from `file -> check logicalId -> check+result`. With `checkly trigger`, though, we can't assume that all checks have a logical ID. This PR refactors the map to track the check state using the `CheckRunId` as a key instead, since we always have this for checks.
     * `checkly trigger` won't have a `file` for checks either. This could cause problems for `AbstractListReporter.checkFilesMap`. To work around this, we can simply use `null` as the file for `checkly trigger`. The reporters will need to be updated accordingly, to just not print a filename if the file is `null`.
3. Currently the reporters track the `testResultIds` as a map from logical ID to the `testResultId`. We won't have logical IDs for `checkly trigger`, though. Instead, we can move the `testResultId`'s into `AbstractListReporter.checkFilesMap` which is indexed by `CheckRunId`.