### PR TITLE
feat: change CLI package name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -645,10 +645,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@checkly/cli": {
-      "resolved": "packages/cli",
-      "link": true
-    },
     "node_modules/@checkly/create-cli": {
       "resolved": "packages/create-cli",
       "link": true
@@ -4625,6 +4621,10 @@
     "node_modules/chardet": {
       "version": "0.7.0",
       "license": "MIT"
+    },
+    "node_modules/checkly": {
+      "resolved": "packages/cli",
+      "link": true
     },
     "node_modules/chownr": {
       "version": "2.0.0",
@@ -15138,8 +15138,8 @@
       }
     },
     "packages/cli": {
-      "name": "@checkly/cli",
-      "version": "0.4.13",
+      "name": "checkly",
+      "version": "4.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@oclif/core": "2.0.7",
@@ -15701,110 +15701,6 @@
         "@babel/helper-string-parser": "^7.19.4",
         "@babel/helper-validator-identifier": "^7.19.1",
         "to-fast-properties": "^2.0.0"
-      }
-    },
-    "@checkly/cli": {
-      "version": "file:packages/cli",
-      "requires": {
-        "@checkly/eslint-config": "0.14.1",
-        "@oclif/core": "2.0.7",
-        "@oclif/plugin-autocomplete": "2.1.8",
-        "@oclif/plugin-help": "5.1.20",
-        "@oclif/plugin-not-found": "2.3.23",
-        "@oclif/plugin-plugins": "2.3.0",
-        "@oclif/plugin-warn-if-update-available": "2.0.24",
-        "@types/config": "3.3.0",
-        "@types/glob": "8.0.0",
-        "@types/inquirer": "8.2.3",
-        "@types/jest": "29.2.4",
-        "@types/luxon": "3.2.0",
-        "@types/node": "18.11.18",
-        "@types/uuid": "9.0.1",
-        "@types/ws": "8.5.3",
-        "@typescript-eslint/eslint-plugin": "5.46.1",
-        "@typescript-eslint/parser": "5.46.1",
-        "@typescript-eslint/typescript-estree": "5.46.1",
-        "acorn": "8.8.1",
-        "acorn-walk": "8.2.0",
-        "async-mqtt": "2.6.3",
-        "axios": "1.2.1",
-        "chalk": "4.1.2",
-        "ci-info": "3.7.1",
-        "conf": "10.2.0",
-        "config": "3.3.8",
-        "cross-env": "7.0.3",
-        "dotenv": "16.0.3",
-        "eslint": "8.30.0",
-        "git-repo-info": "2.1.1",
-        "glob": "8.0.3",
-        "indent-string": "4.0.0",
-        "inquirer": "8.2.3",
-        "jest": "29.3.1",
-        "jwt-decode": "3.1.2",
-        "log-symbols": "4.1.0",
-        "luxon": "3.2.1",
-        "oclif": "3.7.3",
-        "open": "8.4.0",
-        "p-queue": "6.6.2",
-        "ts-jest": "29.0.3",
-        "ts-node": "10.9.1",
-        "typescript": "4.9.4",
-        "uuid": "9.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "brace-expansion": {
-          "version": "2.0.1",
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4"
-        },
-        "glob": {
-          "version": "8.0.3",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^5.0.1",
-            "once": "^1.3.0"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0"
-        },
-        "minimatch": {
-          "version": "5.1.6",
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
       }
     },
     "@checkly/create-cli": {
@@ -18820,6 +18716,110 @@
     },
     "chardet": {
       "version": "0.7.0"
+    },
+    "checkly": {
+      "version": "file:packages/cli",
+      "requires": {
+        "@checkly/eslint-config": "0.14.1",
+        "@oclif/core": "2.0.7",
+        "@oclif/plugin-autocomplete": "2.1.8",
+        "@oclif/plugin-help": "5.1.20",
+        "@oclif/plugin-not-found": "2.3.23",
+        "@oclif/plugin-plugins": "2.3.0",
+        "@oclif/plugin-warn-if-update-available": "2.0.24",
+        "@types/config": "3.3.0",
+        "@types/glob": "8.0.0",
+        "@types/inquirer": "8.2.3",
+        "@types/jest": "29.2.4",
+        "@types/luxon": "3.2.0",
+        "@types/node": "18.11.18",
+        "@types/uuid": "9.0.1",
+        "@types/ws": "8.5.3",
+        "@typescript-eslint/eslint-plugin": "5.46.1",
+        "@typescript-eslint/parser": "5.46.1",
+        "@typescript-eslint/typescript-estree": "5.46.1",
+        "acorn": "8.8.1",
+        "acorn-walk": "8.2.0",
+        "async-mqtt": "2.6.3",
+        "axios": "1.2.1",
+        "chalk": "4.1.2",
+        "ci-info": "3.7.1",
+        "conf": "10.2.0",
+        "config": "3.3.8",
+        "cross-env": "7.0.3",
+        "dotenv": "16.0.3",
+        "eslint": "8.30.0",
+        "git-repo-info": "2.1.1",
+        "glob": "8.0.3",
+        "indent-string": "4.0.0",
+        "inquirer": "8.2.3",
+        "jest": "29.3.1",
+        "jwt-decode": "3.1.2",
+        "log-symbols": "4.1.0",
+        "luxon": "3.2.1",
+        "oclif": "3.7.3",
+        "open": "8.4.0",
+        "p-queue": "6.6.2",
+        "ts-jest": "29.0.3",
+        "ts-node": "10.9.1",
+        "typescript": "4.9.4",
+        "uuid": "9.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "brace-expansion": {
+          "version": "2.0.1",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4"
+        },
+        "glob": {
+          "version": "8.0.3",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0"
+        },
+        "minimatch": {
+          "version": "5.1.6",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "chownr": {
       "version": "2.0.0"

--- a/packages/cli/e2e/__tests__/fixtures/check-parse-error/main.check.js
+++ b/packages/cli/e2e/__tests__/fixtures/check-parse-error/main.check.js
@@ -1,4 +1,4 @@
-const { BrowserCheck } = require('@checkly/cli/constructs')
+const { BrowserCheck } = require('checkly/constructs')
 new BrowserCheck('browser-check', {
   name: 'Browser Check',
   code: {

--- a/packages/cli/e2e/__tests__/fixtures/deploy-project/api.check.ts
+++ b/packages/cli/e2e/__tests__/fixtures/deploy-project/api.check.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import { ApiCheck, Frequency } from '@checkly/cli/constructs'
+import { ApiCheck, Frequency } from 'checkly/constructs'
 new ApiCheck('api-check', {
   name: 'Api Check',
   activated: false,

--- a/packages/cli/e2e/__tests__/fixtures/test-duplicated-groups/group1.check.ts
+++ b/packages/cli/e2e/__tests__/fixtures/test-duplicated-groups/group1.check.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import { ApiCheck, BrowserCheck, CheckGroup } from '@checkly/cli/constructs'
+import { ApiCheck, BrowserCheck, CheckGroup } from 'checkly/constructs'
 
 const group2 = new CheckGroup('my-check-group', {
   name: 'My Group',

--- a/packages/cli/e2e/__tests__/fixtures/test-duplicated-groups/group2.check.ts
+++ b/packages/cli/e2e/__tests__/fixtures/test-duplicated-groups/group2.check.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import { ApiCheck, BrowserCheck, CheckGroup } from '@checkly/cli/constructs'
+import { ApiCheck, BrowserCheck, CheckGroup } from 'checkly/constructs'
 
 const group1 = new CheckGroup('my-check-group', {
   name: 'My Group',

--- a/packages/cli/e2e/__tests__/fixtures/test-only-project/checks.check.ts
+++ b/packages/cli/e2e/__tests__/fixtures/test-only-project/checks.check.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import { ApiCheck, BrowserCheck } from '@checkly/cli/constructs'
+import { ApiCheck, BrowserCheck } from 'checkly/constructs'
 
 new ApiCheck('not-testonly-default-check', {
   name: 'TestOnly=false (default) Check',

--- a/packages/cli/e2e/__tests__/fixtures/test-project/checkly.config.ts
+++ b/packages/cli/e2e/__tests__/fixtures/test-project/checkly.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from '@checkly/cli'
+import { defineConfig } from 'checkly'
 
 const config = defineConfig({
   projectName: 'Test Project',

--- a/packages/cli/e2e/__tests__/fixtures/test-project/checkly.staging.config.ts
+++ b/packages/cli/e2e/__tests__/fixtures/test-project/checkly.staging.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from '@checkly/cli'
+import { defineConfig } from 'checkly'
 
 const config = defineConfig({
   projectName: 'Test Staging Project',

--- a/packages/cli/e2e/__tests__/fixtures/test-project/src/__checks__/group.check.ts
+++ b/packages/cli/e2e/__tests__/fixtures/test-project/src/__checks__/group.check.ts
@@ -1,4 +1,4 @@
-import { CheckGroup, BrowserCheck } from '@checkly/cli/constructs'
+import { CheckGroup, BrowserCheck } from 'checkly/constructs'
 import { smsChannel, emailChannel } from '../alert-channels'
 const alertChannels = [smsChannel, emailChannel]
 

--- a/packages/cli/e2e/__tests__/fixtures/test-project/src/__checks__/secret.check.ts
+++ b/packages/cli/e2e/__tests__/fixtures/test-project/src/__checks__/secret.check.ts
@@ -1,4 +1,4 @@
-import { BrowserCheck } from '@checkly/cli/constructs'
+import { BrowserCheck } from 'checkly/constructs'
 
 const browserCheck = new BrowserCheck('secret-browser-check', {
   name: 'Show SECRET_ENV value',

--- a/packages/cli/e2e/__tests__/fixtures/test-project/src/alert-channels.ts
+++ b/packages/cli/e2e/__tests__/fixtures/test-project/src/alert-channels.ts
@@ -4,7 +4,7 @@ import {
   EmailAlertChannel,
   SlackAlertChannel,
   WebhookAlertChannel,
-} from '@checkly/cli/constructs'
+} from 'checkly/constructs'
 
 const sendDefaults = {
   sendFailure: true,

--- a/packages/cli/e2e/__tests__/fixtures/test-project/src/services/api/api.check.ts
+++ b/packages/cli/e2e/__tests__/fixtures/test-project/src/services/api/api.check.ts
@@ -1,4 +1,4 @@
-import { ApiCheck, AssertionBuilder } from '@checkly/cli/constructs'
+import { ApiCheck, AssertionBuilder } from 'checkly/constructs'
 import { slackChannel, webhookChannel } from '../../alert-channels'
 
 const apiCheck = new ApiCheck('homepage-api-check-1', {

--- a/packages/cli/e2e/__tests__/fixtures/test-project/src/services/api/typo.checkz.ts
+++ b/packages/cli/e2e/__tests__/fixtures/test-project/src/services/api/typo.checkz.ts
@@ -1,4 +1,4 @@
-import { ApiCheck } from '@checkly/cli/constructs'
+import { ApiCheck } from 'checkly/constructs'
 
 const apiCheck = new ApiCheck('not-included-typo-api-check-1', {
   name: 'File extension type example',

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@checkly/cli",
-  "version": "0.4.13",
+  "name": "checkly",
+  "version": "4.0.0",
   "description": "Checkly CLI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -67,7 +67,7 @@ export default class Login extends BaseCommand {
 
   private _isLoginSuccess = async () => {
     await api.validateAuthentication()
-    this.log('Welcome to @checkly/cli')
+    this.log('Welcome to the Checkly CLI')
   }
 
   async run (): Promise<void> {

--- a/packages/cli/src/services/__tests__/fixtures/configs/checkly.config.ts
+++ b/packages/cli/src/services/__tests__/fixtures/configs/checkly.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from '@checkly/cli'
+import { defineConfig } from 'checkly'
 
 const config = defineConfig({
   projectName: 'test-config-project',

--- a/packages/cli/src/services/__tests__/fixtures/configs/good-config.ts
+++ b/packages/cli/src/services/__tests__/fixtures/configs/good-config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from '@checkly/cli'
+import { defineConfig } from 'checkly'
 
 const config = defineConfig({
   projectName: 'test-config-project',

--- a/packages/cli/src/services/check-parser/errors.ts
+++ b/packages/cli/src/services/check-parser/errors.ts
@@ -19,9 +19,9 @@ export class DependencyParseError extends Error {
       }
     }
     if (unsupportedNpmDependencies.length) {
-      if (unsupportedNpmDependencies.some(d => d.unsupportedDependencies.some(ud => ud === '@checkly/cli/constructs'))) {
-        message += '\n\nIt looks like you\'re trying to use @checkly/cli/constructs in a browser check file. ' +
-          '@checkly/cli/constructs should only be used in check files: files ending in .check.ts and .check.js, ' +
+      if (unsupportedNpmDependencies.some(d => d.unsupportedDependencies.some(ud => ud === 'checkly/constructs'))) {
+        message += '\n\nIt looks like you\'re trying to use checkly/constructs in a browser check file. ' +
+          'checkly/constructs should only be used in check files: files ending in .check.ts and .check.js, ' +
           'or the checkMatch pattern set in your configuration. For more information see on the difference between ' +
           'test files and check files, see https://www.checklyhq.com/docs/cli/\n'
       } else {


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

Relates to #566

We now control the `checkly` NPM package. This PR updates the CLI to be published their, instead of to `@checkly/cli`. Since the `checkly` package was previously used, we need to start by releasing version `4.0.0`.

In follow up PR's, I'll migrate the `@checkly/create-cli` package, the templates, and the README's. I first want to make sure that we can publish to `checkly`, though.
