### PR TITLE
feat: migrate @checkly/create-cli to new package

### DIFF
--- a/.github/workflows/release-create-package.yml
+++ b/.github/workflows/release-create-package.yml
@@ -1,0 +1,44 @@
+name: Publish create-checkly to npmjs
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci --workspace packages/create-cli
+      - run: npm publish --workspace packages/create-cli
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # Slack failure alert
+      - name: Slack Failure Notification
+        if: ${{ failure() }}
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_USERNAME: Checkly Github Bot
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_CHANNEL: cli
+          SLACK_ICON: https://github.com/checkly.png?size=48
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_TITLE: ':red_circle: NPM release of create-cli failed'
+          SLACK_MESSAGE: by ${{ github.actor }}
+          SLACK_FOOTER: ''
+      # Slack success alert
+      - name: Slack Success Notification
+        if: ${{ success() }}
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_USERNAME: Checkly Github Bot
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_CHANNEL: cli
+          SLACK_ICON: https://github.com/checkly.png?size=48
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_TITLE: ':white_check_mark: NPM release of create-cli succeeded'
+          SLACK_MESSAGE: by ${{ github.actor }}
+          SLACK_FOOTER: ''

--- a/package-lock.json
+++ b/package-lock.json
@@ -645,10 +645,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@checkly/create-cli": {
-      "resolved": "packages/create-cli",
-      "link": true
-    },
     "node_modules/@checkly/eslint-config": {
       "version": "0.14.1",
       "dev": true,
@@ -5144,6 +5140,10 @@
       "version": "1.0.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/create-checkly": {
+      "resolved": "packages/create-cli",
+      "link": true
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -15289,7 +15289,7 @@
       }
     },
     "packages/create-cli": {
-      "name": "@checkly/create-cli",
+      "name": "create-checkly",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
@@ -15701,129 +15701,6 @@
         "@babel/helper-string-parser": "^7.19.4",
         "@babel/helper-validator-identifier": "^7.19.1",
         "to-fast-properties": "^2.0.0"
-      }
-    },
-    "@checkly/create-cli": {
-      "version": "file:packages/create-cli",
-      "requires": {
-        "@checkly/eslint-config": "0.14.1",
-        "@oclif/core": "2.0.7",
-        "@oclif/plugin-help": "5.1.20",
-        "@oclif/plugin-plugins": "2.3.0",
-        "@types/config": "3.3.0",
-        "@types/debug": "^4.1.7",
-        "@types/glob": "8.0.0",
-        "@types/jest": "29.2.4",
-        "@types/luxon": "3.2.0",
-        "@types/node": "18.11.18",
-        "@types/prompts": "^2.4.2",
-        "@types/uuid": "9.0.1",
-        "@types/which-pm-runs": "^1.0.0",
-        "@types/ws": "8.5.3",
-        "@typescript-eslint/eslint-plugin": "5.46.1",
-        "@typescript-eslint/parser": "5.46.1",
-        "@typescript-eslint/typescript-estree": "5.46.1",
-        "axios": "1.3.1",
-        "chalk": "4.1.2",
-        "config": "3.3.8",
-        "debug": "^4.3.4",
-        "eslint": "8.30.0",
-        "execa": "^6.1.0",
-        "fullname": "4.0.1",
-        "giget": "^1.1.2",
-        "jest": "29.3.1",
-        "normalize-url": "8.0.0",
-        "ora": "^6.1.2",
-        "prompts": "^2.4.2",
-        "ts-jest": "29.0.3",
-        "ts-node": "10.9.1",
-        "typescript": "4.9.4",
-        "unique-names-generator": "^4.7.1",
-        "which-pm-runs": "^1.1.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "axios": {
-          "version": "1.3.1",
-          "requires": {
-            "follow-redirects": "^1.15.0",
-            "form-data": "^4.0.0",
-            "proxy-from-env": "^1.1.0"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4"
-        },
-        "execa": {
-          "version": "6.1.0",
-          "requires": {
-            "cross-spawn": "^7.0.3",
-            "get-stream": "^6.0.1",
-            "human-signals": "^3.0.1",
-            "is-stream": "^3.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^5.1.0",
-            "onetime": "^6.0.0",
-            "signal-exit": "^3.0.7",
-            "strip-final-newline": "^3.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0"
-        },
-        "is-stream": {
-          "version": "3.0.0"
-        },
-        "mimic-fn": {
-          "version": "4.0.0"
-        },
-        "normalize-url": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
-          "integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw=="
-        },
-        "npm-run-path": {
-          "version": "5.1.0",
-          "requires": {
-            "path-key": "^4.0.0"
-          }
-        },
-        "onetime": {
-          "version": "6.0.0",
-          "requires": {
-            "mimic-fn": "^4.0.0"
-          }
-        },
-        "path-key": {
-          "version": "4.0.0"
-        },
-        "strip-final-newline": {
-          "version": "3.0.0"
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
       }
     },
     "@checkly/eslint-config": {
@@ -19148,6 +19025,129 @@
     "core-util-is": {
       "version": "1.0.3",
       "dev": true
+    },
+    "create-checkly": {
+      "version": "file:packages/create-cli",
+      "requires": {
+        "@checkly/eslint-config": "0.14.1",
+        "@oclif/core": "2.0.7",
+        "@oclif/plugin-help": "5.1.20",
+        "@oclif/plugin-plugins": "2.3.0",
+        "@types/config": "3.3.0",
+        "@types/debug": "^4.1.7",
+        "@types/glob": "8.0.0",
+        "@types/jest": "29.2.4",
+        "@types/luxon": "3.2.0",
+        "@types/node": "18.11.18",
+        "@types/prompts": "^2.4.2",
+        "@types/uuid": "9.0.1",
+        "@types/which-pm-runs": "^1.0.0",
+        "@types/ws": "8.5.3",
+        "@typescript-eslint/eslint-plugin": "5.46.1",
+        "@typescript-eslint/parser": "5.46.1",
+        "@typescript-eslint/typescript-estree": "5.46.1",
+        "axios": "1.3.1",
+        "chalk": "4.1.2",
+        "config": "3.3.8",
+        "debug": "^4.3.4",
+        "eslint": "8.30.0",
+        "execa": "^6.1.0",
+        "fullname": "4.0.1",
+        "giget": "^1.1.2",
+        "jest": "29.3.1",
+        "normalize-url": "8.0.0",
+        "ora": "^6.1.2",
+        "prompts": "^2.4.2",
+        "ts-jest": "29.0.3",
+        "ts-node": "10.9.1",
+        "typescript": "4.9.4",
+        "unique-names-generator": "^4.7.1",
+        "which-pm-runs": "^1.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "axios": {
+          "version": "1.3.1",
+          "requires": {
+            "follow-redirects": "^1.15.0",
+            "form-data": "^4.0.0",
+            "proxy-from-env": "^1.1.0"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4"
+        },
+        "execa": {
+          "version": "6.1.0",
+          "requires": {
+            "cross-spawn": "^7.0.3",
+            "get-stream": "^6.0.1",
+            "human-signals": "^3.0.1",
+            "is-stream": "^3.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^5.1.0",
+            "onetime": "^6.0.0",
+            "signal-exit": "^3.0.7",
+            "strip-final-newline": "^3.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0"
+        },
+        "is-stream": {
+          "version": "3.0.0"
+        },
+        "mimic-fn": {
+          "version": "4.0.0"
+        },
+        "normalize-url": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
+          "integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw=="
+        },
+        "npm-run-path": {
+          "version": "5.1.0",
+          "requires": {
+            "path-key": "^4.0.0"
+          }
+        },
+        "onetime": {
+          "version": "6.0.0",
+          "requires": {
+            "mimic-fn": "^4.0.0"
+          }
+        },
+        "path-key": {
+          "version": "4.0.0"
+        },
+        "strip-final-newline": {
+          "version": "3.0.0"
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "create-require": {
       "version": "1.1.1"

--- a/packages/create-cli/package.json
+++ b/packages/create-cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@checkly/create-cli",
+  "name": "create-checkly",
   "version": "0.0.1",
   "description": "Checkly Create CLI",
   "type": "module",


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [ ] CLI
* [x] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

Relates to #566

Now that the CLI package is moved to [checkly](https://www.npmjs.com/package/checkly), we need to migrate the create-cli package to `create-checkly`.

AFAIK, we've also been publishing this package by hand so far. This PR adds a simple GH Action to handle publishing the package.
