### PR TITLE
fix: don't run oclif manifest for create-cli package

### DIFF
--- a/packages/create-cli/package.json
+++ b/packages/create-cli/package.json
@@ -10,7 +10,6 @@
     "clean": "rimraf ./dist",
     "test": "jest --selectProjects unit",
     "prepare": "npm run clean && tsc --build",
-    "prepack": "npx oclif manifest",
     "lint": "eslint src",
     "start": "node ./index.mjs"
   },


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [ ] CLI
* [x] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Publishing the `create-cli` package to NPM is currently broken due to `npx oclif manifest` failing during `prepack`: https://github.com/checkly/checkly-cli/actions/runs/4830121579.

From what I can see, this manifest step isn't actually necessary, though. The simplest way to fix this seems to be just removing this step. Since no customers are currently using the package with the new name, it should be safe to publish to NPM to try this.