### PR TITLE
fix: continue reading config for @checkly/cli

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "checkly",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Checkly CLI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/src/services/config.ts
+++ b/packages/cli/src/services/config.ts
@@ -21,12 +21,14 @@ enum Env {
 
 const config = {
   auth: new Conf({
+    projectName: '@checkly/cli',
     configName: 'auth',
     projectSuffix,
     // @ts-ignore
     schema: authSchema,
   }),
   data: new Conf({
+    projectName: '@checkly/cli',
     configName: 'config',
     projectSuffix,
     // @ts-ignore


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Relates to #566

We currently use [conf](https://www.npmjs.com/package/conf) for persisting credentials.  Conf persists credentials using a filename containing the package name. On MacOS, CLI credentials were persisted in `~/Library/Preferences/@checkly/cli`.

With https://github.com/checkly/checkly-cli/pull/665, we changed the package name to `checkly` and so the CLI now reads credentials from  `~/Library/Preferences/checkly`. This means that users migrating to the new CLI version need to recreate credentials and log in to Checkly!

To avoid this inconvenience and make the upgrade process smoother, we can simply continue using the old config file.
