### PR TITLE
docs: Update api-check construct's doc url to lead to correct url

### DIFF
--- a/packages/cli/src/constructs/api-check.ts
+++ b/packages/cli/src/constructs/api-check.ts
@@ -280,7 +280,7 @@ export class ApiCheck extends Check {
    * @param logicalId unique project-scoped resource name identification
    * @param props check configuration properties
    *
-   * {@link https://checklyhq.com/docs/cli/constructs/#apicheck Read more in the docs}
+   * {@link https://checklyhq.com/docs/cli/using-constructs/#creating-an-api-check Read more in the docs}
    */
 
   constructor (logicalId: string, props: ApiCheckProps) {


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [ ] CLI
* [ ] Create CLI
* [ ] Test
* [x] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
**Actual behavior**:
[Current doc link](https://www.checklyhq.com/docs/cli/constructs/#apicheck) leads to a `404` page:
![image](https://user-images.githubusercontent.com/68233869/235174159-196ad734-184b-4675-be4f-4412f3533aae.png)

**Expected/Proposed behavior**:
Link leads to a [correct page](https://www.checklyhq.com/docs/cli/using-constructs/#creating-an-api-check):
![image](https://user-images.githubusercontent.com/68233869/235174574-ad1190e3-d65a-493d-a38e-9debefec7812.png)
