### PR TITLE
feat: show shortlinks for failed checks and test-session summary [sc-…

### DIFF
--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -14,6 +14,7 @@ import type { Region } from '..'
 import { splitConfigFilePath, getGitInformation, getCiInformation, getEnvs } from '../services/util'
 import { createReporters, ReporterType } from '../reporters/reporter'
 import commonMessages from '../messages/common-messages'
+import { TestResultsShortLinks } from '../rest/test-sessions'
 
 const DEFAULT_REGION = 'eu-central-1'
 
@@ -191,7 +192,7 @@ export default class Test extends AuthCommand {
     runner.on(Events.RUN_STARTED,
       (checks: Array<{ check: any, checkRunId: CheckRunId, testResultId?: string }>, testSessionId: string) =>
         reporters.forEach(r => r.onBegin(checks, testSessionId)))
-    runner.on(Events.CHECK_SUCCESSFUL, (checkRunId, check, result) => {
+    runner.on(Events.CHECK_SUCCESSFUL, (checkRunId, check, result, links?: TestResultsShortLinks) => {
       if (result.hasFailures) {
         process.exitCode = 1
       }
@@ -199,7 +200,7 @@ export default class Test extends AuthCommand {
         logicalId: check.logicalId,
         sourceFile: check.getSourceFile(),
         ...result,
-      }))
+      }, links))
     })
     runner.on(Events.CHECK_FAILED, (checkRunId, check, message: string) => {
       reporters.forEach(r => r.onCheckEnd(checkRunId, {

--- a/packages/cli/src/commands/trigger.ts
+++ b/packages/cli/src/commands/trigger.ts
@@ -10,6 +10,7 @@ import TriggerRunner from '../services/trigger-runner'
 import { RunLocation, Events, PrivateRunLocation, CheckRunId } from '../services/abstract-check-runner'
 import config from '../services/config'
 import { createReporters, ReporterType } from '../reporters/reporter'
+import { TestResultsShortLinks } from '../rest/test-sessions'
 
 const DEFAULT_REGION = 'eu-central-1'
 
@@ -123,11 +124,11 @@ export default class Trigger extends AuthCommand {
     runner.on(Events.RUN_STARTED,
       (checks: Array<{ check: any, checkRunId: CheckRunId, testResultId?: string }>, testSessionId: string) =>
         reporters.forEach(r => r.onBegin(checks, testSessionId)))
-    runner.on(Events.CHECK_SUCCESSFUL, (checkRunId, _, result) => {
+    runner.on(Events.CHECK_SUCCESSFUL, (checkRunId, _, result, links?: TestResultsShortLinks) => {
       if (result.hasFailures) {
         process.exitCode = 1
       }
-      reporters.forEach(r => r.onCheckEnd(checkRunId, result))
+      reporters.forEach(r => r.onCheckEnd(checkRunId, result, links))
     })
     runner.on(Events.CHECK_FAILED, (checkRunId, check, message: string) => {
       reporters.forEach(r => r.onCheckEnd(checkRunId, {

--- a/packages/cli/src/reporters/list.ts
+++ b/packages/cli/src/reporters/list.ts
@@ -3,7 +3,8 @@ import * as chalk from 'chalk'
 
 import AbstractListReporter from './abstract-list'
 import { CheckRunId } from '../services/abstract-check-runner'
-import { formatCheckTitle, formatCheckResult, CheckStatus, printLn, getTestSessionUrl, getTraceUrl } from './util'
+import { formatCheckTitle, formatCheckResult, CheckStatus, printLn } from './util'
+import { TestResultsShortLinks } from '../rest/test-sessions'
 
 export default class ListReporter extends AbstractListReporter {
   onBeginStatic () {
@@ -23,9 +24,8 @@ export default class ListReporter extends AbstractListReporter {
     this._printTestSessionsUrl()
   }
 
-  onCheckEnd (checkRunId: CheckRunId, checkResult: any) {
+  onCheckEnd (checkRunId: CheckRunId, checkResult: any, links?: TestResultsShortLinks) {
     super.onCheckEnd(checkRunId, checkResult)
-    const { testResultId } = this.checkFilesMap!.get(checkResult.sourceFile)!.get(checkRunId)!
     this._clearSummary()
 
     if (this.verbose) {
@@ -38,29 +38,16 @@ export default class ListReporter extends AbstractListReporter {
       }
     }
 
-    if (checkResult.hasFailures) {
-      if (checkResult.traceFilesUrls) {
+    if (links) {
+      if (links.testTraceLinks?.length) {
         // TODO: print all video files URLs
-        printLn(indentString(
-          'View trace : ' + chalk.underline.cyan(
-            getTraceUrl(checkResult.traceFilesUrls[0]))
-          , 4,
-        ))
+        printLn(indentString('View trace : ' + chalk.underline.cyan(links.testTraceLinks.join(', ')), 4))
       }
-      if (checkResult.videoFilesUrls) {
+      if (links.videoLinks?.length) {
         // TODO: print all trace files URLs
-        printLn(indentString(
-          'View video : ' + chalk.underline.cyan(
-            `${checkResult.videoFilesUrls[0]}`)
-          , 4,
-        ))
+        printLn(indentString('View video : ' + chalk.underline.cyan(`${links.videoLinks.join(', ')}`), 4))
       }
-      if (testResultId && this.testSessionId) {
-        printLn(indentString(
-          'View result: ' + chalk.underline.cyan(`${getTestSessionUrl(this.testSessionId)}/results/${testResultId}`)
-          , 4,
-        ), 2)
-      }
+      printLn(indentString('View result: ' + chalk.underline.cyan(`${links.testResultLink}`), 4), 2)
     }
 
     this._printSummary()

--- a/packages/cli/src/reporters/list.ts
+++ b/packages/cli/src/reporters/list.ts
@@ -39,6 +39,7 @@ export default class ListReporter extends AbstractListReporter {
     }
 
     if (links) {
+      printLn(indentString('View result: ' + chalk.underline.cyan(`${links.testResultLink}`), 4))
       if (links.testTraceLinks?.length) {
         // TODO: print all video files URLs
         printLn(indentString('View trace : ' + chalk.underline.cyan(links.testTraceLinks.join(', ')), 4))
@@ -47,7 +48,7 @@ export default class ListReporter extends AbstractListReporter {
         // TODO: print all trace files URLs
         printLn(indentString('View video : ' + chalk.underline.cyan(`${links.videoLinks.join(', ')}`), 4))
       }
-      printLn(indentString('View result: ' + chalk.underline.cyan(`${links.testResultLink}`), 4), 2)
+      printLn('')
     }
 
     this._printSummary()

--- a/packages/cli/src/reporters/reporter.ts
+++ b/packages/cli/src/reporters/reporter.ts
@@ -1,3 +1,4 @@
+import { TestResultsShortLinks } from '../rest/test-sessions'
 import { RunLocation, CheckRunId } from '../services/abstract-check-runner'
 import CiReporter from './ci'
 import DotReporter from './dot'
@@ -8,7 +9,7 @@ export interface Reporter {
   onBeginStatic(): void;
   onBegin(checks: Array<{ check: any, checkRunId: CheckRunId, testResultId?: string }>, testSessionId?: string): void;
   onEnd(): void;
-  onCheckEnd(checkRunId: CheckRunId, checkResult: any): void;
+  onCheckEnd(checkRunId: CheckRunId, checkResult: any, links?: TestResultsShortLinks): void;
   onError(err: Error): void,
 }
 

--- a/packages/cli/src/rest/test-sessions.ts
+++ b/packages/cli/src/rest/test-sessions.ts
@@ -22,6 +22,13 @@ type TriggerTestSessionRequest = {
   environment: string | null,
 }
 
+export type TestResultsShortLinks = {
+  testResultLink: string
+  testTraceLinks: string[]
+  videoLinks: string[]
+  screenshotLinks: string[]
+}
+
 class TestSessions {
   api: AxiosInstance
   constructor (api: AxiosInstance) {
@@ -34,6 +41,14 @@ class TestSessions {
 
   trigger (payload: TriggerTestSessionRequest) {
     return this.api.post('/next/test-sessions/trigger', payload)
+  }
+
+  getShortLink (id: string) {
+    return this.api.get<{ link: string }>(`/next/test-sessions/${id}/link`)
+  }
+
+  getResultShortLinks (testSessionId: string, testResultId: string) {
+    return this.api.get<TestResultsShortLinks>(`/next/test-sessions/${testSessionId}/results/${testResultId}/links`)
   }
 }
 


### PR DESCRIPTION
…15066]

I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
We want to show short-links for assets (trace and video files) and test-results pages, ONLY for failed check results and using the `list` reporter. Also, the test-session URL is shown with a short-link.
I have to request the short-links when processing the socket messages because doing it in the `onCheckEnd()` resulted in getting the terminal prints summaries disorder, caused by the `RUN_FINISHED` is received before the the short-link requests completes.
The `github` reporter is still using the long URL because they are used within markdown links.
The request are wrapped in try/catch blocks so, if there is some problem obtaining the short-links, nothing is shown for check failures and, for test-session summary, it shows the long URL.
<!-- Anything the reviewer should pay extra attention to. -->

> Result 
![image](https://user-images.githubusercontent.com/5315705/235690930-6e1c9626-d830-4879-9013-de6f08cb3926.png)

> Resolves [[sc-10566]](https://app.shortcut.com/checkly/story/15066/add-chkly-link-shortlink-to-test-results-link-in-the-cli-terminal-output)

> PR https://github.com/checkly/checkly-backend/pull/4129 contains the new API endpoints.
## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
