### PR TITLE
fix: print checks for 'checkly test --list'

### DIFF
--- a/packages/cli/e2e/__tests__/test.spec.ts
+++ b/packages/cli/e2e/__tests__/test.spec.ts
@@ -63,6 +63,17 @@ describe('test', () => {
     expect(result.status).toBe(0)
   })
 
+  it('Should list checks and not execute them with `--list`', () => {
+    const result = runChecklyCli({
+      args: ['test', '--list'],
+      apiKey: config.get('apiKey'),
+      accountId: config.get('accountId'),
+      directory: path.join(__dirname, 'fixtures', 'test-project'),
+    })
+    expect(result.stdout).toContain('Listing all checks')
+    expect(result.status).toBe(0)
+  })
+
   it('Should terminate with error when JS/TS throws error', () => {
     const result = runChecklyCli({
       args: ['test'],

--- a/packages/cli/src/reporters/abstract-list.ts
+++ b/packages/cli/src/reporters/abstract-list.ts
@@ -35,8 +35,6 @@ export default abstract class AbstractListReporter implements Reporter {
     this.verbose = verbose
   }
 
-  abstract onBeginStatic(): void
-
   onBegin (checks: Array<{ check: any, checkRunId: CheckRunId, testResultId?: string }>, testSessionId?: string): void {
     this.testSessionId = testSessionId
     this.numChecks = checks.length

--- a/packages/cli/src/reporters/ci.ts
+++ b/packages/cli/src/reporters/ci.ts
@@ -5,11 +5,6 @@ import { formatCheckTitle, formatCheckResult, CheckStatus, printLn } from './uti
 import { CheckRunId } from '../services/abstract-check-runner'
 
 export default class CiReporter extends AbstractListReporter {
-  onBeginStatic () {
-    printLn('Listing all checks:', 2, 1)
-    this._printSummary({ skipCheckCount: true })
-  }
-
   onBegin (checks: Array<{ check: any, checkRunId: CheckRunId, testResultId?: string }>, testSessionId?: string) {
     super.onBegin(checks, testSessionId)
     printLn(`Running ${this.numChecks} checks in ${this._runLocationString()}:`, 2, 1)

--- a/packages/cli/src/reporters/dot.ts
+++ b/packages/cli/src/reporters/dot.ts
@@ -4,13 +4,9 @@ import { CheckRunId } from '../services/abstract-check-runner'
 import { print, printLn } from './util'
 
 export default class DotReporter extends AbstractListReporter {
-  onBeginStatic () {
-    printLn(`Running ${this.numChecks} checks in ${this._runLocationString()}.`, 2, 1)
-  }
-
   onBegin (checks: Array<{ check: any, checkRunId: CheckRunId, testResultId?: string }>, testSessionId?: string) {
     super.onBegin(checks, testSessionId)
-    this.onBeginStatic()
+    printLn(`Running ${this.numChecks} checks in ${this._runLocationString()}.`, 2, 1)
   }
 
   onEnd () {

--- a/packages/cli/src/reporters/github.ts
+++ b/packages/cli/src/reporters/github.ts
@@ -96,13 +96,9 @@ export class GithubMdBuilder {
 }
 
 export default class GithubReporter extends AbstractListReporter {
-  onBeginStatic () {
-    printLn(`Running ${this.numChecks} checks in ${this._runLocationString()}.`, 2, 1)
-  }
-
   onBegin (checks: Array<{ check: any, checkRunId: CheckRunId, testResultId?: string }>, testSessionId?: string) {
     super.onBegin(checks, testSessionId)
-    this.onBeginStatic()
+    printLn(`Running ${this.numChecks} checks in ${this._runLocationString()}.`, 2, 1)
   }
 
   onEnd () {

--- a/packages/cli/src/reporters/list.ts
+++ b/packages/cli/src/reporters/list.ts
@@ -7,11 +7,6 @@ import { formatCheckTitle, formatCheckResult, CheckStatus, printLn } from './uti
 import { TestResultsShortLinks } from '../rest/test-sessions'
 
 export default class ListReporter extends AbstractListReporter {
-  onBeginStatic () {
-    printLn('Listing all checks:', 2, 1)
-    this._printSummary({ skipCheckCount: true })
-  }
-
   onBegin (checks: Array<{ check: any, checkRunId: CheckRunId, testResultId?: string }>, testSessionId?: string) {
     super.onBegin(checks, testSessionId)
     printLn(`Running ${this.numChecks} checks in ${this._runLocationString()}.`, 2, 1)

--- a/packages/cli/src/reporters/reporter.ts
+++ b/packages/cli/src/reporters/reporter.ts
@@ -6,7 +6,6 @@ import GithubReporter from './github'
 import ListReporter from './list'
 
 export interface Reporter {
-  onBeginStatic(): void;
   onBegin(checks: Array<{ check: any, checkRunId: CheckRunId, testResultId?: string }>, testSessionId?: string): void;
   onEnd(): void;
   onCheckEnd(checkRunId: CheckRunId, checkResult: any, links?: TestResultsShortLinks): void;


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
> Resolves #677

There's been a regression in `checkly test --list` (for more info, see the linked issue). This regression was introduced in https://github.com/checkly/checkly-cli/pull/662, where we required the list of checks to be passed to the reporter in `reporter.onBegin()` rather than in the constructor. Since `onBegin()` wasn't called for `checkly test --list`, the reporter wasn't properly initialized and there would be an error.

This PR resolves the issue by removing `reporter.onBeginStatic()`, which is the reporter-specific implementation for `checkly test --list`. `onBeginStatic()` was nice since it let `checkly test --list` reuse code from the reporter, but I think that it's also awkward having each reporter implement printing for `checkly test --list`. For example, the GitHub reporter would print "Running 5 checks in ...", which doesn't make sense for `--list` since the checks aren't running.

Rather than use `reporter.onBeginStatic()`, we now just have one method `Test.listChecks()` for printing the checks for `checkly test --list`. This new method doesn't require a reporter to be set up.

The integration test is from Tim: https://github.com/checkly/checkly-cli/pull/679