### PR TITLE
fix(examples): update docs-search.spec.ts to match docs updates

### DIFF
--- a/examples/advanced-project/src/services/docs/__checks__/docs-search.spec.ts
+++ b/examples/advanced-project/src/services/docs/__checks__/docs-search.spec.ts
@@ -16,7 +16,7 @@ test.describe('Docs', () => {
     const response = await page.goto(`${defaults.pageUrl}/docs`)
 
     expect(response?.status()).toBeLessThan(400)
-    await expect(page).toHaveTitle(/Getting started/i)
+    await expect(page).toHaveTitle(/Introduction to Checkly | Checkly/)
     await page.screenshot({ path: 'docs_landing.jpg' })
   })
 
@@ -25,7 +25,7 @@ test.describe('Docs', () => {
     const response = await page.goto(`${defaults.pageUrl}/docs`)
 
     expect(response?.status()).toBeLessThan(400)
-    await expect(page).toHaveTitle(/Getting started/i)
+    await expect(page).toHaveTitle(/Introduction to Checkly | Checkly/)
 
     await page.getByPlaceholder('Press / to search').fill('browser')
     await expect(page.locator('.ds-dataset-1')).toBeVisible()


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [ ] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [x] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Currently the `docs-search.spec.ts` advanced example is failing. This is likely due to recent updates in the docs pages. This PR updates the test so that it's passing.

Shout-out to @modern-sapien for finding the issue and giving the fix.
