### PR TITLE
fix: update checkMatch to support check-group.ts

### DIFF
--- a/examples/advanced-project/checkly.config.ts
+++ b/examples/advanced-project/checkly.config.ts
@@ -25,7 +25,7 @@ const config = defineConfig({
      */
     runtimeId: '2023.02',
     /* A glob pattern that matches the Checks inside your repo, see https://www.checklyhq.com/docs/cli/using-check-test-match/ */
-    checkMatch: '**/__checks__/**/*.check.ts',
+    checkMatch: '**/__checks__/**/*.check?(-group).{js,ts}',
     browserChecks: {
       /* A glob pattern matches any Playwright .spec.ts files and automagically creates a Browser Check. This way, you
       * can just write native Playwright code. See https://www.checklyhq.com/docs/cli/using-check-test-match/

--- a/examples/boilerplate-project/checkly.config.ts
+++ b/examples/boilerplate-project/checkly.config.ts
@@ -25,7 +25,7 @@ const config = defineConfig({
      */
     runtimeId: '2023.02',
     /* A glob pattern that matches the Checks inside your repo, see https://www.checklyhq.com/docs/cli/using-check-test-match/ */
-    checkMatch: '**/__checks__/**/*.check.ts',
+    checkMatch: '**/__checks__/**/*.check?(-group).{js,ts}',
     browserChecks: {
       /* A glob pattern matches any Playwright .spec.ts files and automagically creates a Browser Check. This way, you
       * can just write native Playwright code. See https://www.checklyhq.com/docs/cli/using-check-test-match/

--- a/packages/cli/src/services/__tests__/project-parser-fixtures/simple-project/src/group.check-group.ts
+++ b/packages/cli/src/services/__tests__/project-parser-fixtures/simple-project/src/group.check-group.ts
@@ -1,0 +1,6 @@
+const { CheckGroup } = require('../../../../../constructs')
+
+new CheckGroup('check-group-test', {
+  name: 'CheckGroup',
+  locations: ['eu-central-1'],
+})

--- a/packages/cli/src/services/__tests__/project-parser.spec.ts
+++ b/packages/cli/src/services/__tests__/project-parser.spec.ts
@@ -31,9 +31,13 @@ describe('parseProject()', () => {
           type: 'check',
           logicalId: 'check-2',
         },
+        {
+          type: 'check-group',
+          logicalId: 'check-group-test',
+        },
       ],
     })
-    expect(Object.keys(synthesizedProject.resources)).toHaveLength(2)
+    expect(Object.keys(synthesizedProject.resources)).toHaveLength(3)
   })
 
   it('should parse a project with TypeScript check files', async () => {

--- a/packages/cli/src/services/project-parser.ts
+++ b/packages/cli/src/services/project-parser.ts
@@ -31,7 +31,7 @@ const BASE_CHECK_DEFAULTS = {
 export async function parseProject (opts: ProjectParseOpts): Promise<Project> {
   const {
     directory,
-    checkMatch = '**/*.check.{js,ts}',
+    checkMatch = '**/*.check?(-group).{js,ts}',
     browserCheckMatch,
     projectLogicalId,
     projectName,


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [ ] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [x] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
The advanced example currently contains a [website.check-group.ts](https://github.com/checkly/checkly-cli/blob/main/examples/advanced-project/src/__checks__/website.check-group.ts) check file. Declaring constructs in `*.check-group.ts` files isn't fully supported, though, since the examples have `checkMatch: *.check.ts` (not matching any check-group.ts files).

The reason why the constructs in [website.check-group.ts](https://github.com/checkly/checkly-cli/blob/main/examples/advanced-project/src/__checks__/website.check-group.ts) are loaded, despite not matching the `checkMatch` pattern, is that the file is imported by other `*.check.ts` files. For users that build on the advanced example, though, and try to use the `*.check-group.ts` pattern, there setup won't work.

To fix this, we could either:
1. rename `website.check-group.ts`, so that there's no suggestion of using a `*.check-group.ts` pattern
2. update `checkMatch` to support `*.check-group.ts` files

This PR takes approach 2 to give full support to `check-group.ts`. In addition to updating the examples, I also update the default `checkMatch` value. This way users don't run into any surprises when using `check-group.ts`.