### PR TITLE
chore: handle concurrent e2e test runs for env tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10877,6 +10877,18 @@
       "version": "0.0.8",
       "license": "ISC"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "dev": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "dev": true,
@@ -15187,6 +15199,7 @@
         "cross-env": "7.0.3",
         "eslint": "8.30.0",
         "jest": "29.3.1",
+        "nanoid": "3.3.4",
         "oclif": "3.7.3",
         "ts-jest": "29.0.3",
         "ts-node": "10.9.1",
@@ -18634,6 +18647,7 @@
         "jwt-decode": "3.1.2",
         "log-symbols": "4.1.0",
         "luxon": "3.2.1",
+        "nanoid": "3.3.4",
         "oclif": "3.7.3",
         "open": "8.4.0",
         "p-queue": "6.6.2",
@@ -22774,6 +22788,12 @@
     },
     "mute-stream": {
       "version": "0.0.8"
+    },
+    "nanoid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/packages/cli/e2e/__tests__/env/env.add.spec.ts
+++ b/packages/cli/e2e/__tests__/env/env.add.spec.ts
@@ -1,17 +1,20 @@
 // create test for checkly env add
 import * as path from 'path'
 import * as config from 'config'
+import { nanoid } from 'nanoid'
 import { runChecklyCli } from '../../run-checkly'
+
+const executionId = nanoid(5)
 
 function cleanupEnvVars () {
   runChecklyCli({
-    args: ['env', 'rm', 'testenvvars', '--force'],
+    args: ['env', 'rm', `testenvvars-${executionId}`, '--force'],
     apiKey: config.get('apiKey'),
     accountId: config.get('accountId'),
     directory: path.join(__dirname, '../fixtures/check-parse-error'),
   })
   runChecklyCli({
-    args: ['env', 'rm', 'testenvvarslocked', '--force'],
+    args: ['env', 'rm', `testenvvarslocked-${executionId}`, '--force'],
     apiKey: config.get('apiKey'),
     accountId: config.get('accountId'),
     directory: path.join(__dirname, '../fixtures/check-parse-error'),
@@ -29,37 +32,37 @@ describe('checkly env add', () => {
 
   it('should add a new env variable called testenvvars', () => {
     const result = runChecklyCli({
-      args: ['env', 'add', 'testenvvars', 'testvalue'],
+      args: ['env', 'add', `testenvvars-${executionId}`, 'testvalue'],
       apiKey: config.get('apiKey'),
       accountId: config.get('accountId'),
       directory: path.join(__dirname, '../fixtures/check-parse-error'),
     })
-    expect(result.stdout).toContain('Environment variable testenvvars added.')
+    expect(result.stdout).toContain(`Environment variable testenvvars-${executionId} added.`)
   })
 
   it('should add a new locked env variable called testenvvars', () => {
     const result = runChecklyCli({
-      args: ['env', 'add', 'testenvvarslocked', 'testvalue', '--locked'],
+      args: ['env', 'add', `testenvvarslocked-${executionId}`, 'testvalue', '--locked'],
       apiKey: config.get('apiKey'),
       accountId: config.get('accountId'),
       directory: path.join(__dirname, '../fixtures/check-parse-error'),
     })
-    expect(result.stdout).toContain('Environment variable testenvvarslocked added.')
+    expect(result.stdout).toContain(`Environment variable testenvvarslocked-${executionId} added.`)
   })
 
   it('should add fail because env variable called testenvvars exists', () => {
     runChecklyCli({
-      args: ['env', 'add', 'testenvvarslocked', 'testvalue', '--locked'],
+      args: ['env', 'add', `testenvvarslocked-${executionId}`, 'testvalue', '--locked'],
       apiKey: config.get('apiKey'),
       accountId: config.get('accountId'),
       directory: path.join(__dirname, '../fixtures/check-parse-error'),
     })
     const result = runChecklyCli({
-      args: ['env', 'add', 'testenvvarslocked', 'testvalue', '--locked'],
+      args: ['env', 'add', `testenvvarslocked-${executionId}`, 'testvalue', '--locked'],
       apiKey: config.get('apiKey'),
       accountId: config.get('accountId'),
       directory: path.join(__dirname, '../fixtures/check-parse-error'),
     })
-    expect(result.stderr).toContain('Environment variable testenvvarslocked already exists.')
+    expect(result.stderr).toContain(`Environment variable testenvvarslocked-${executionId} already exists.`)
   })
 })

--- a/packages/cli/e2e/__tests__/env/env.ls.spec.ts
+++ b/packages/cli/e2e/__tests__/env/env.ls.spec.ts
@@ -1,13 +1,16 @@
 // create test for checkly env ls
 import * as path from 'path'
 import * as config from 'config'
+import { nanoid } from 'nanoid'
 import { runChecklyCli } from '../../run-checkly'
 
 describe('checkly env ls', () => {
+  const executionId = nanoid(5)
+
   // before testing add a new environment variable vi checkly env add test true
   beforeAll(() => {
     runChecklyCli({
-      args: ['env', 'add', 'testenvvarsls', 'testvalue'],
+      args: ['env', 'add', `testenvvarsls-${executionId}`, 'testvalue'],
       apiKey: config.get('apiKey'),
       accountId: config.get('accountId'),
       directory: path.join(__dirname, '../fixtures/check-parse-error'),
@@ -17,7 +20,7 @@ describe('checkly env ls', () => {
   // after testing remove the environment variable vi checkly env rm test
   afterAll(() => {
     runChecklyCli({
-      args: ['env', 'rm', 'testenvvarsls', '--force'],
+      args: ['env', 'rm', `testenvvarsls-${executionId}`, '--force'],
       apiKey: config.get('apiKey'),
       accountId: config.get('accountId'),
       directory: path.join(__dirname, '../fixtures/check-parse-error'),
@@ -32,6 +35,6 @@ describe('checkly env ls', () => {
       directory: path.join(__dirname, '../fixtures/check-parse-error'),
     })
     // expect that 'testenvvars' is in the output
-    expect(result.stdout).toContain('testenvvarsls')
+    expect(result.stdout).toContain(`testenvvarsls-${executionId}`)
   })
 })

--- a/packages/cli/e2e/__tests__/env/env.pull.spec.ts
+++ b/packages/cli/e2e/__tests__/env/env.pull.spec.ts
@@ -1,16 +1,19 @@
 // create test for checkly env pull
 import * as path from 'path'
 import * as config from 'config'
-import { runChecklyCli } from '../../run-checkly'
+import { nanoid } from 'nanoid'
 import * as fs from 'fs'
 
+import { runChecklyCli } from '../../run-checkly'
+
 describe('checkly env pull', () => {
+  const executionId = nanoid(5)
   const directory = path.join(__dirname, '../fixtures/check-parse-error')
   // before testing add a new environment variable call envPullTest with value testvalue
   // additionally delete .envPullTest file if it exists
   beforeAll(() => {
     runChecklyCli({
-      args: ['env', 'add', 'envPullTest', 'testvalue'],
+      args: ['env', 'add', `envPullTest-${executionId}`, 'testvalue'],
       apiKey: config.get('apiKey'),
       accountId: config.get('accountId'),
       directory,
@@ -26,7 +29,7 @@ describe('checkly env pull', () => {
   // additionally delete .envPullTest file if it exists
   afterAll(() => {
     runChecklyCli({
-      args: ['env', 'rm', 'envPullTest', '--force'],
+      args: ['env', 'rm', `envPullTest-${executionId}`, '--force'],
       apiKey: config.get('apiKey'),
       accountId: config.get('accountId'),
       directory,
@@ -47,7 +50,7 @@ describe('checkly env pull', () => {
     const filename = path.join(directory, '.envPullTest')
     // expect that 'testenvvars' is in the output
     expect(fs.existsSync(filename)).toBe(true)
-    expect(fs.readFileSync(filename, 'utf8')).toContain('envPullTest=testvalue')
+    expect(fs.readFileSync(filename, 'utf8')).toContain(`envPullTest-${executionId}=testvalue`)
     // result.stdout contains Success! ${filename} file
     expect(result.stdout).toContain('Success! Environment variables written to .envPullTest.')
   })

--- a/packages/cli/e2e/__tests__/env/env.rm.spec.ts
+++ b/packages/cli/e2e/__tests__/env/env.rm.spec.ts
@@ -1,11 +1,14 @@
 // create test for checkly env add
 import * as path from 'path'
 import * as config from 'config'
+import { nanoid } from 'nanoid'
 import { runChecklyCli } from '../../run-checkly'
+
+const executionId = nanoid(5)
 
 function cleanupEnvVars () {
   runChecklyCli({
-    args: ['env', 'rm', 'testenvvarsrm', '--force'],
+    args: ['env', 'rm', `testenvvarsrm-${executionId}`, '--force'],
     apiKey: config.get('apiKey'),
     accountId: config.get('accountId'),
     directory: path.join(__dirname, '../fixtures/check-parse-error'),
@@ -15,7 +18,7 @@ function cleanupEnvVars () {
 describe('checkly env rm', () => {
   beforeEach(() => {
     runChecklyCli({
-      args: ['env', 'add', 'testenvvarsrm', 'testvalue'],
+      args: ['env', 'add', `testenvvarsrm-${executionId}`, 'testvalue'],
       apiKey: config.get('apiKey'),
       accountId: config.get('accountId'),
       directory: path.join(__dirname, '../fixtures/check-parse-error'),
@@ -28,18 +31,18 @@ describe('checkly env rm', () => {
 
   it('should remove the testenvvarsrm env variable', () => {
     const result = runChecklyCli({
-      args: ['env', 'rm', 'testenvvarsrm', '--force'],
+      args: ['env', 'rm', `testenvvarsrm-${executionId}`, '--force'],
       apiKey: config.get('apiKey'),
       accountId: config.get('accountId'),
       directory: path.join(__dirname, '../fixtures/check-parse-error'),
     })
     // expect that 'testenvvars' is in the output
-    expect(result.stdout).toContain('Environment variable testenvvarsrm deleted.')
+    expect(result.stdout).toContain(`Environment variable testenvvarsrm-${executionId} deleted.`)
   })
 
   it('should ask for permision to remove the testenvvarsrm env variable', () => {
     const result = runChecklyCli({
-      args: ['env', 'rm', 'testenvvarsrm'],
+      args: ['env', 'rm', `testenvvarsrm-${executionId}`],
       apiKey: config.get('apiKey'),
       accountId: config.get('accountId'),
       directory: path.join(__dirname, '../fixtures/check-parse-error'),
@@ -51,12 +54,12 @@ describe('checkly env rm', () => {
   it('should throw an error because testenvvarsrm env variable does not exist', () => {
     cleanupEnvVars()
     const result = runChecklyCli({
-      args: ['env', 'rm', 'testenvvarsrm', '--force'],
+      args: ['env', 'rm', `testenvvarsrm-${executionId}`, '--force'],
       apiKey: config.get('apiKey'),
       accountId: config.get('accountId'),
       directory: path.join(__dirname, '../fixtures/check-parse-error'),
     })
     // expect that 'testenvvars' does not exist
-    expect(result.stderr).toContain('Environment variable testenvvarsrm does not exist.')
+    expect(result.stderr).toContain(`Environment variable testenvvarsrm-${executionId} does not exist.`)
   })
 })

--- a/packages/cli/e2e/__tests__/env/env.upate.spec.ts
+++ b/packages/cli/e2e/__tests__/env/env.upate.spec.ts
@@ -1,17 +1,20 @@
 // create test for checkly env update
 import * as path from 'path'
 import * as config from 'config'
+import { nanoid } from 'nanoid'
 import { runChecklyCli } from '../../run-checkly'
+
+const executionId = nanoid(5)
 
 function cleanupEnvVars () {
   runChecklyCli({
-    args: ['env', 'rm', 'testenvvarsUpdate', '--force'],
+    args: ['env', 'rm', `testenvvarsUpdate-${executionId}`, '--force'],
     apiKey: config.get('apiKey'),
     accountId: config.get('accountId'),
     directory: path.join(__dirname, '../fixtures/check-parse-error'),
   })
   runChecklyCli({
-    args: ['env', 'rm', 'testenvvarsUpdatelocked', '--force'],
+    args: ['env', 'rm', `testenvvarsUpdatelocked-${executionId}`, '--force'],
     apiKey: config.get('apiKey'),
     accountId: config.get('accountId'),
     directory: path.join(__dirname, '../fixtures/check-parse-error'),
@@ -22,7 +25,7 @@ describe('checkly env update', () => {
   beforeEach(() => {
     // create a env variable to update testenvvarsUpdate
     runChecklyCli({
-      args: ['env', 'add', 'testenvvarsUpdate', 'testvalue'],
+      args: ['env', 'add', `testenvvarsUpdate-${executionId}`, 'testvalue'],
       apiKey: config.get('apiKey'),
       accountId: config.get('accountId'),
       directory: path.join(__dirname, '../fixtures/check-parse-error'),
@@ -35,12 +38,12 @@ describe('checkly env update', () => {
 
   it('should update a env variable called testenvvarsUpdate', () => {
     const result = runChecklyCli({
-      args: ['env', 'update', 'testenvvarsUpdate', 'testvalue'],
+      args: ['env', 'update', `testenvvarsUpdate-${executionId}`, 'testvalue'],
       apiKey: config.get('apiKey'),
       accountId: config.get('accountId'),
       directory: path.join(__dirname, '../fixtures/check-parse-error'),
     })
     // expect that 'testenvvarsUpdate' is in the output
-    expect(result.stdout).toContain('Environment variable testenvvarsUpdate updated.')
+    expect(result.stdout).toContain(`Environment variable testenvvarsUpdate-${executionId} updated.`)
   })
 })

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,7 +55,9 @@
       "message": "<%= config.name %> update available from <%= chalk.greenBright(config.version) %> to <%= chalk.greenBright(latest) %>."
     },
     "topics": {
-      "env": { "description": "Manage Checkly environment variables" }
+      "env": {
+        "description": "Manage Checkly environment variables"
+      }
     },
     "helpClass": "./dist/help/help-extension"
   },
@@ -106,6 +108,7 @@
     "cross-env": "7.0.3",
     "eslint": "8.30.0",
     "jest": "29.3.1",
+    "nanoid": "3.3.4",
     "oclif": "3.7.3",
     "ts-jest": "29.0.3",
     "ts-node": "10.9.1",


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [ ] CLI
* [ ] Create CLI
* [x] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
The e2e tests for `checkly env` modify the account environment variables on the e2e test Checkly account. When there are multiple e2e tests ongoing in parallel, they can then interfere with each other and cause failures. For example, one test instance could delete the environment variable in it's cleanup right after it's added in the setup of the other test instance.

Running the e2e tests in parallel locally, this does end up causing failures. Looking at our history of flaky GitHub actions, though, this only caused a few flaky runs. Still, we should fix the issue.

This PR fixes the issue by creating a unique `executionId`. This string is then appended to the environment variable names.

## New Dependencies
`nanoid`: this is used for generating the unique ID's. It's more convenient than `uuid` since we can create shorter IDs.