### PR TITLE
chore: increase timeout for flaky e2e tests

### DIFF
--- a/packages/cli/e2e/__tests__/test.spec.ts
+++ b/packages/cli/e2e/__tests__/test.spec.ts
@@ -12,6 +12,7 @@ describe('test', () => {
       apiKey: config.get('apiKey'),
       accountId: config.get('accountId'),
       directory: path.join(__dirname, 'fixtures', 'test-project'),
+      timeout: 120000, // 2 minutes
     })
     expect(result.stdout).not.toContain('File extension type example')
     expect(result.stdout).toContain(secretEnv)
@@ -123,6 +124,7 @@ describe('test', () => {
       accountId: config.get('accountId'),
       directory: path.join(__dirname, 'fixtures', 'test-project'),
       env: { CHECKLY_REPORTER_GITHUB_OUTPUT: reportFilename },
+      timeout: 120000, // 2 minutes
     })
     expect(result.stdout).toContain('Github summary saved in')
     expect(fs.existsSync(path.join(__dirname, 'fixtures', 'test-project', reportFilename))).toBe(true)


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [ ] CLI
* [ ] Create CLI
* [x] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Currently the e2e test GH Action can be a bit flaky. After looking at past flakiness, it looks like most of the failures (not all, though) are from `test › Test project should run successfully` and `test › Should use Github reporter`.  Both of these tests run [homepage.test.ts](https://github.com/checkly/checkly-cli/blob/main/packages/cli/e2e/__tests__/fixtures/test-project/src/__checks__/homepage.test.ts), which is an actual PW test taking several seconds. From looking at the failures (f.ex: [here](https://github.com/checkly/checkly-cli/actions/runs/4862530190/jobs/8669023267#step:7:49) or [here](https://github.com/checkly/checkly-cli/actions/runs/4861862224/jobs/8667435359#step:7:27)), it looks like `checkly test` reaches the 30 second timeout for `runChecklyTest`. That would explain the `null` status code for `test › Test project should run successfully` failures and why the GitHub summary isn't written for `test › Should use Github reporter` failures.

To fix the issue, this PR simply bumps the timeout for these two tests. If we continue seeing flaky test failures, we can try other solutions as well.
