### PR TITLE
fix: Call NOT_CONTANS in notContains method

### DIFF
--- a/packages/cli/src/constructs/api-check.ts
+++ b/packages/cli/src/constructs/api-check.ts
@@ -148,7 +148,7 @@ class GeneralAssertionBuilder {
   }
 
   notContains (target: string): Assertion {
-    return this._toAssertion(AssertionComparison.CONTAINS, target)
+    return this._toAssertion(AssertionComparison.NOT_CONTAINS, target)
   }
 
   isNull () {


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

> Resolves #[306]
