### PR TITLE
fix: detect if package.json exists [sc-15315]

### DIFF
--- a/packages/create-cli/src/utils/package.ts
+++ b/packages/create-cli/src/utils/package.ts
@@ -9,7 +9,7 @@ export interface PackageJson {
 }
 
 export function hasPackageJsonFile () {
-  return fs.existsSync(path.join(process.cwd(), './package.json'))
+  return fs.existsSync(path.join(process.cwd(), 'package.json'))
 }
 
 export function readPackageJson (): PackageJson {

--- a/packages/create-cli/src/utils/package.ts
+++ b/packages/create-cli/src/utils/package.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs'
+import path from 'path'
 
 export interface PackageJson {
   name: string;
@@ -8,7 +9,7 @@ export interface PackageJson {
 }
 
 export function hasPackageJsonFile () {
-  return fs.existsSync('./package.json')
+  return fs.existsSync(path.join(process.cwd(), './package.json'))
 }
 
 export function readPackageJson (): PackageJson {


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [ ] CLI
* [x] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
For some reason `npm create checkly` doesn't detect `package.json` even if exists. Couldn't reproduce it in local mode, but this fix aims to solve it by having the full path of the file.