### PR TITLE
jangrzesik/sc-0/update-test-timeout-to-match-ecs-values

### DIFF
--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -56,7 +56,7 @@ export default class Test extends AuthCommand {
       description: 'list all checks but don\'t run them.',
     }),
     timeout: Flags.integer({
-      default: 240,
+      default: 300,
       description: 'A timeout (in seconds) to wait for checks to complete.',
     }),
     verbose: Flags.boolean({


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
* Updates the test command timeout to match 300s (5 mintues)
* This timeout takes into account 240s check run time timeout + additional buffer for the scheduling delay 
