### PR TITLE
fix: ensure check run timeouts give clear error message

### DIFF
--- a/packages/cli/e2e/__tests__/test.spec.ts
+++ b/packages/cli/e2e/__tests__/test.spec.ts
@@ -130,4 +130,15 @@ describe('test', () => {
     expect(fs.existsSync(path.join(__dirname, 'fixtures', 'test-project', reportFilename))).toBe(true)
     expect(result.status).toBe(0)
   })
+
+  it('Should report timeouts correctly', () => {
+    const result = runChecklyCli({
+      args: ['test', 'homepage.test.ts','--timeout', '0'],
+      apiKey: config.get('apiKey'),
+      accountId: config.get('accountId'),
+      directory: path.join(__dirname, 'fixtures', 'test-project'),
+    })
+    expect(result.status).toBe(1)
+    expect(result.stdout).toContain('Reached timeout of 0 seconds waiting for check result.')
+  })
 })

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -6,7 +6,13 @@ import { isCI } from 'ci-info'
 import * as api from '../rest/api'
 import config from '../services/config'
 import { parseProject } from '../services/project-parser'
-import { Events, RunLocation, PrivateRunLocation, CheckRunId } from '../services/abstract-check-runner'
+import {
+  Events,
+  RunLocation,
+  PrivateRunLocation,
+  CheckRunId,
+  DEFAULT_CHECK_RUN_TIMEOUT_SECONDS,
+} from '../services/abstract-check-runner'
 import TestRunner from '../services/test-runner'
 import { loadChecklyConfig } from '../services/checkly-config-loader'
 import { filterByFileNamePattern, filterByCheckNamePattern } from '../services/test-filters'
@@ -56,7 +62,7 @@ export default class Test extends AuthCommand {
       description: 'list all checks but don\'t run them.',
     }),
     timeout: Flags.integer({
-      default: 300,
+      default: DEFAULT_CHECK_RUN_TIMEOUT_SECONDS,
       description: 'A timeout (in seconds) to wait for checks to complete.',
     }),
     verbose: Flags.boolean({


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
There is currently an issue with timeout support for `checkly test` and `checkly trigger`. This can be reproduced by running with `--timeout 0`:

```
$ npx checkly test --timeout 1
Parsing your project... done

Running 2 checks in eu-west-1.

__checks__/api.check.ts
  - Fetch Book List
__checks__/homepage.spec.ts
  - homepage.spec.ts

2 pending, 2 total

/Users/clample/projects/checkly-cli/packages/cli/src/commands/test.ts:211
      reporters.forEach(r => r.onCheckEnd(checkRunId, {
                ^
TypeError: check.getSourceFile is not a function
    at /Users/clample/projects/checkly-cli/packages/cli/src/commands/test.ts:214:27
    at Array.forEach (<anonymous>)
    at TestRunner.<anonymous> (/Users/clample/projects/checkly-cli/packages/cli/src/commands/test.ts:211:17)
    at TestRunner.emit (node:events:513:28)
    at TestRunner.emit (node:domain:489:12)
    at Timeout._onTimeout (/Users/clample/projects/checkly-cli/packages/cli/src/services/abstract-check-runner.ts:176:14)
    at listOnTimeout (node:internal/timers:559:17)
    at processTimers (node:internal/timers:502:7)
```

After more investigation, this is a regression from https://github.com/checkly/checkly-cli/pull/662. This PR changed the arguments for the `CHECK_FAILED` event, but didn't update the timeout code path.

This PR fixes the issue and adds an integration test. The timeout case is now working as it did before:
```
$ npx checkly test --timeout 1
Parsing your project... done

Running 2 checks in eu-west-1.

✖ homepage.spec.ts

    ──Execution Error───
    Reached timeout of 1 seconds waiting for check result.

__checks__/api.check.ts
  ✔ Fetch Book List (233ms)
__checks__/homepage.spec.ts
  ✖ homepage.spec.ts

1 failed, 1 passed, 2 total
```

When the default timeout is used (300s), this case should only occur for Checkly infrastructure problems. Checkly should always report a result within 240s. In this case, the CLI also points the user to the status page and support email address:

```
✖ homepage.spec.ts

    ──Execution Error────
    Reached timeout of 300 seconds waiting for check result. Checkly may be experiencing problems. Please check https://is.checkly.online or reach out to support@checklyhq.com.
```