### PR TITLE
fix: update e2e tests to use Danube

### DIFF
--- a/packages/cli/e2e/__tests__/fixtures/deploy-project/defaults.ts
+++ b/packages/cli/e2e/__tests__/fixtures/deploy-project/defaults.ts
@@ -1,5 +1,5 @@
 export const defaults = {
-  pageUrl: process.env.ENVIRONMENT_URL || 'https://checklyhq.com', // the pageUrl can be replaced by urls from a preview / staging environment.
+  pageUrl: process.env.ENVIRONMENT_URL || 'https://danube-web.shop', // the pageUrl can be replaced by urls from a preview / staging environment.
   playwright: {
     viewportSize: { width: 1920, height: 1080 },
   },

--- a/packages/cli/e2e/__tests__/fixtures/deploy-project/homepage.test.ts
+++ b/packages/cli/e2e/__tests__/fixtures/deploy-project/homepage.test.ts
@@ -2,11 +2,11 @@
 import { test, expect } from '@playwright/test'
 import { defaults } from './defaults'
 
-test('Checkly Homepage', async ({ page }: { page: any }) => {
+test('Danube Homepage', async ({ page }: { page: any }) => {
   await page.setViewportSize(defaults.playwright.viewportSize)
   const response = await page.goto(defaults.pageUrl)
 
   expect(response.status()).toBeLessThan(400)
-  await expect(page).toHaveTitle(/Build and Run Synthetics That Scale/)
+  await expect(page).toHaveTitle(/Danube WebShop/)
   await page.screenshot({ path: 'homepage.jpg' })
 })

--- a/packages/cli/e2e/__tests__/fixtures/test-project/src/__checks__/homepage.test.ts
+++ b/packages/cli/e2e/__tests__/fixtures/test-project/src/__checks__/homepage.test.ts
@@ -4,13 +4,13 @@ import { defaults } from '../defaults'
 import { ExternalFirstPage } from '../pages/external.first.page.js'
 import { ExternalSecondPage } from '../pages/external.second.page'
 
-test('Checkly Homepage', async ({ page }: { page: any }) => {
+test('Danube Homepage', async ({ page }: { page: any }) => {
   expect(ExternalFirstPage.title).toBe('External First Page')
   expect(ExternalSecondPage.title).toBe('External Second Page')
   await page.setViewportSize(defaults.playwright.viewportSize)
   const response = await page.goto(defaults.pageUrl)
 
   expect(response.status()).toBeLessThan(400)
-  await expect(page).toHaveTitle(/Build and Run Synthetics That Scale/)
+  await expect(page).toHaveTitle(/Danube WebShop/)
   await page.screenshot({ path: 'homepage.jpg' })
 })

--- a/packages/cli/e2e/__tests__/fixtures/test-project/src/defaults.ts
+++ b/packages/cli/e2e/__tests__/fixtures/test-project/src/defaults.ts
@@ -1,5 +1,5 @@
 export const defaults = {
-  pageUrl: process.env.ENVIRONMENT_URL || 'https://checklyhq.com', // the pageUrl can be replaced by urls from a preview / staging environment.
+  pageUrl: process.env.ENVIRONMENT_URL || 'https://danube-web.shop', // the pageUrl can be replaced by urls from a preview / staging environment.
   playwright: {
     viewportSize: { width: 1920, height: 1080 },
   },


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [ ] CLI
* [ ] Create CLI
* [x] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
The recent changes to checklyhq.com have broken the end to end tests. Since we now use Danube in the examples, this PR fixes the issue by also using Danube in the e2e tests.
