### PR TITLE
fix: handle edge case when formatting reporter titles

### DIFF
--- a/packages/cli/src/reporters/__tests__/__snapshots__/util.spec.ts.snap
+++ b/packages/cli/src/reporters/__tests__/__snapshots__/util.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`formatCheckResult() API Check result formats a basic API Check result : api-check-result-basic-format 1`] = `
-"──HTTP Request────────────────────────────────────────────────────────────────────
+"──HTTP Request──────────────────────────────────────────────────────────────
 POST https://httpbin.org/post
 Headers:
   User-Agent: Checkly/1.0 (https://www.checklyhq.com)
@@ -10,7 +10,7 @@ Headers:
 Body:
   {"data":1}
 
-──HTTP Response───────────────────────────────────────────────────────────────────
+──HTTP Response─────────────────────────────────────────────────────────────
 Status Code: 200 OK
 Headers:
   date: Fri, 24 Mar 2023 10:45:42 GMT
@@ -43,7 +43,7 @@ Body:
 `;
 
 exports[`formatCheckResult() API Check result formats an API Check result with a scheduleError: api-check-result-schedule-error-format 1`] = `
-"──HTTP Request────────────────────────────────────────────────────────────────────
+"──HTTP Request──────────────────────────────────────────────────────────────
 POST https://httpbin.org/post
 Headers:
   User-Agent: Checkly/1.0 (https://www.checklyhq.com)
@@ -52,7 +52,7 @@ Headers:
 Body:
   {"data":1}
 
-──HTTP Response───────────────────────────────────────────────────────────────────
+──HTTP Response─────────────────────────────────────────────────────────────
 Status Code: 200 OK
 Headers:
   date: Fri, 24 Mar 2023 10:45:42 GMT
@@ -83,12 +83,12 @@ Body:
   }
 
 
-──Scheduling Error────────────────────────────────────────────────────────────────
+──Scheduling Error──────────────────────────────────────────────────────────
 There was a scheduling error"
 `;
 
 exports[`formatCheckResult() API Check result formats an API Check result with assertions: api-check-result-assertions-format 1`] = `
-"──HTTP Request────────────────────────────────────────────────────────────────────
+"──HTTP Request──────────────────────────────────────────────────────────────
 POST https://httpbin.org/post
 Headers:
   User-Agent: Checkly/1.0 (https://www.checklyhq.com)
@@ -97,7 +97,7 @@ Headers:
 Body:
   {"data":1}
 
-──HTTP Response───────────────────────────────────────────────────────────────────
+──HTTP Response─────────────────────────────────────────────────────────────
 Status Code: 200 OK
 Headers:
   date: Fri, 24 Mar 2023 10:45:42 GMT
@@ -130,7 +130,7 @@ Body:
 `;
 
 exports[`formatCheckResult() API Check result formats an API Check result with setup & teardown logs: api-check-result-logs-format 1`] = `
-"──HTTP Request────────────────────────────────────────────────────────────────────
+"──HTTP Request──────────────────────────────────────────────────────────────
 POST https://httpbin.org/post
 Headers:
   User-Agent: Checkly/1.0 (https://www.checklyhq.com)
@@ -139,7 +139,7 @@ Headers:
 Body:
   {"data":1}
 
-──HTTP Response───────────────────────────────────────────────────────────────────
+──HTTP Response─────────────────────────────────────────────────────────────
 Status Code: 200 OK
 Headers:
   date: Fri, 24 Mar 2023 10:45:42 GMT
@@ -172,7 +172,7 @@ Body:
 `;
 
 exports[`formatCheckResult() Browser Check result formats a Browser Check result with a scheduleError: browser-check-result-schedule-error-format 1`] = `
-"──Logs────────────────────────────────────────────────────────────────────────────
+"──Logs──────────────────────────────────────────────────────────────────────
 10:53:15 DEBUG Starting job
 10:53:15 DEBUG Compiling environment variables
 10:53:15 DEBUG Creating runtime using version 2022.10
@@ -186,12 +186,12 @@ exports[`formatCheckResult() Browser Check result formats a Browser Check result
 10:53:22 DEBUG Run finished
 10:53:22 DEBUG Uploading log file
 
-──Scheduling Error────────────────────────────────────────────────────────────────
+──Scheduling Error──────────────────────────────────────────────────────────
 There was a scheduling error"
 `;
 
 exports[`formatCheckResult() Browser Check result formats a Browser Check result with logs: browser-check-result-logs-format 1`] = `
-"──Logs────────────────────────────────────────────────────────────────────────────
+"──Logs──────────────────────────────────────────────────────────────────────
 10:53:15 DEBUG Starting job
 10:53:15 DEBUG Compiling environment variables
 10:53:15 DEBUG Creating runtime using version 2022.10

--- a/packages/cli/src/reporters/util.ts
+++ b/packages/cli/src/reporters/util.ts
@@ -230,8 +230,14 @@ function formatRunError (err: string | Error): string {
 }
 
 function formatSectionTitle (title: string): string {
-  const width = process.stdout.isTTY ? Math.min(process.stdout.columns, 80) : 80
-  return `──${chalk.bold(title)}${'─'.repeat(width - title.length)}`
+  const width = process.stdout.isTTY ? process.stdout.columns : 80
+  // For style reasons, we only extend the title with "----" to a maximum of 80 characters
+  const targetTitleWidth = Math.min(width, 80)
+  const leftPaddingLength = 6 // Account for an indent of 4 and two dashes
+  // On CI, process.stdout.columns might be 0
+  // We take Math.max(0, ...) to avoid a negative padding length from causing errors
+  const rightPaddingLength = Math.max(0, targetTitleWidth - title.length - leftPaddingLength)
+  return `──${chalk.bold(title)}${'─'.repeat(rightPaddingLength)}`
 }
 
 function truncate (val: any, opts: { chars?: number, lines?: number, ending?: string }) {


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
> Resolves after release #697 

The linked issue reports `checkly trigger` causing an out of bounds error. This appears to happen in a CI environment:
```
RangeError: Invalid count value: -4
    at String.repeat (<anonymous>)
    at formatSectionTitle (/home/circleci/.npm/_npx/a66ee913fe899ce0/node_modules/checkly/src/reporters/util.ts:234:39)
...
```

This is caused by the terminal width being 0 in some CI environments (https://github.com/aws/aws-cdk/issues/2253).

When we format the section title, we then get a negative number and cause this out of bounds error:
https://github.com/checkly/checkly-cli/blob/e1b75b6a0f7d93ecc0a4fe48c630162fc2c24bf9/packages/cli/src/reporters/util.ts#L234

To fix the issue, this PR uses `Math.max(..., 0)` to ensure that the padding length is always non-negative. When working on the PR, I also noticed that the formula doesn't take the indentation and extra left-side `--` into account when calculating the right padding. This causes always 6 characters of wrap-around in the title (see first screenshot below). This PR also updates the calculation for the right padding to take this into account and avoid the wraparound (see second screenshot below).

Before PR:
<img width="324" alt="Screenshot 2023-05-10 at 13 23 08" src="https://github.com/checkly/checkly-cli/assets/10483186/2ff942ba-ccb6-4d44-b519-de0a56d45e18">

After PR:
<img width="327" alt="Screenshot 2023-05-10 at 13 15 26" src="https://github.com/checkly/checkly-cli/assets/10483186/c53f1a49-7c97-4176-bbf1-4cab3cd73b3f">
