### PR TITLE
feat: support top level await in browser check scripts

### DIFF
--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/top-level-await.js
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/top-level-await.js
@@ -1,0 +1,2 @@
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
+await sleep(10000)

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/top-level-await.ts
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/top-level-await.ts
@@ -1,0 +1,2 @@
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+await sleep(10000)

--- a/packages/cli/src/services/check-parser/__tests__/check-parser.spec.ts
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser.spec.ts
@@ -121,4 +121,18 @@ describe('dependency-parser - parser()', () => {
     const parser = new Parser(defaultNpmModules)
     parser.parse(entrypoint)
   })
+
+  // Checks run on Checkly are wrapped to support top level await.
+  // For consistency with checks created via the UI, the CLI should support this as well.
+  it('should allow top-level await', () => {
+    const entrypoint = path.join(__dirname, 'check-parser-fixtures', 'top-level-await.js')
+    const parser = new Parser(defaultNpmModules)
+    parser.parse(entrypoint)
+  })
+
+  it('should allow top-level await in TypeScript', () => {
+    const entrypoint = path.join(__dirname, 'check-parser-fixtures', 'top-level-await.ts')
+    const parser = new Parser(defaultNpmModules)
+    parser.parse(entrypoint)
+  })
 })

--- a/packages/cli/src/services/check-parser/parser.ts
+++ b/packages/cli/src/services/check-parser/parser.ts
@@ -187,6 +187,7 @@ export class Parser {
           allowReturnOutsideFunction: true,
           ecmaVersion: 'latest',
           allowImportExportEverywhere: true,
+          allowAwaitOutsideFunction: true,
         })
         walk.simple(ast, Parser.jsNodeVisitor(localDependencies, npmDependencies))
       } else if (extension === '.ts') {


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Checks created in Checkly via the UI already support top-level `await`. For example, the following check runs successfully when created from the UI:
```
const sleep = ms => new Promise(r => setTimeout(r, ms));
await sleep(10000);
```

The CLI currently fails to parse checks with top-level `await`, though. It fails with the following error:
```
    Encountered an error parsing check files for /Users/clample/projects/checkly-cli/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/top-level-await.js.

    The following NPM dependencies were used, but aren't supported in the runtimes.
    For more information, see https://www.checklyhq.com/docs/runtimes/.
        /Users/clample/projects/checkly-cli/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/top-level-await.js imports unsupported dependencies:
```

This PR fixes the issue by simply adding an additional flag to our javascript parser (docs [here](https://github.com/acornjs/acorn/tree/master/acorn/#interface)). This should make the CLI and the UI more consistent, and it's useful for migrating internal checks we have at Checkly to MaC.