### PR TITLE
feat: enhance empty script or env var value error [gh-714]

### DIFF
--- a/packages/cli/src/constructs/browser-check.ts
+++ b/packages/cli/src/constructs/browser-check.ts
@@ -51,12 +51,15 @@ export class BrowserCheck extends Check {
         absoluteEntrypoint = entrypoint
       } else {
         if (!Session.checkFileAbsolutePath) {
-          throw new Error('You cant use relative paths without the checkFileAbsolutePath in session')
+          throw new Error('You cannot use relative paths without the checkFileAbsolutePath in session')
         }
         absoluteEntrypoint = path.join(path.dirname(Session.checkFileAbsolutePath), entrypoint)
       }
       // runtimeId will always be set by check or browser check defaults so it is safe to use ! operator
       const bundle = BrowserCheck.bundle(absoluteEntrypoint, this.runtimeId!)
+      if (!bundle.script) {
+        throw new Error(`Browser check "${logicalId}" is not allowed to be empty`)
+      }
       this.script = bundle.script
       this.scriptPath = bundle.scriptPath
       this.dependencies = bundle.dependencies

--- a/packages/cli/src/constructs/check-group.ts
+++ b/packages/cli/src/constructs/check-group.ts
@@ -133,7 +133,15 @@ export class CheckGroup extends Construct {
     this.privateLocations = props.privateLocations
     this.concurrency = props.concurrency
     this.apiCheckDefaults = { ...defaultApiCheckDefaults, ...props.apiCheckDefaults }
+
     this.environmentVariables = props.environmentVariables ?? []
+    this.environmentVariables.forEach(ev => {
+      // only empty string is checked because the KeyValuePair.value doesn't allow undefined or null.
+      if (ev.value === '') {
+        throw new Error(`Environment variable "${ev.key}" from check group "${logicalId}" is not allowed to be empty`)
+      }
+    })
+
     this.alertChannels = props.alertChannels ?? []
     this.localSetupScript = props.localSetupScript
     this.localTearDownScript = props.localTearDownScript

--- a/packages/cli/src/services/__tests__/project-parser-fixtures/empty-script-project/src/empty-envvar.check.js
+++ b/packages/cli/src/services/__tests__/project-parser-fixtures/empty-script-project/src/empty-envvar.check.js
@@ -1,0 +1,16 @@
+const { BrowserCheck, CheckGroup } = require('../../../../../constructs')
+
+const group = new CheckGroup('check-group-1', {
+  name: 'group',
+  environmentVariables: [{ key: 'FOO', value: 'bar' }, { key: 'EMPTY_FOO', value: '' }],
+})
+
+new BrowserCheck('check-1', {
+  name: 'login check',
+  locations: ['eu-central-1'],
+  frequency: 10,
+  group,
+  code: {
+    content: 'console.log("performing login")',
+  }
+})

--- a/packages/cli/src/services/__tests__/project-parser-fixtures/typescript-project/ts-test.check.ts
+++ b/packages/cli/src/services/__tests__/project-parser-fixtures/typescript-project/ts-test.check.ts
@@ -1,7 +1,6 @@
 import { BrowserCheck } from '../../../../constructs'
 
-
-export default async function createCheck () {
+export default function createCheck () {
   return new BrowserCheck('ts-check', {
     name: 'typescript-check',
     muted: false,

--- a/packages/cli/src/services/__tests__/project-parser.spec.ts
+++ b/packages/cli/src/services/__tests__/project-parser.spec.ts
@@ -54,4 +54,41 @@ describe('parseProject()', () => {
       ],
     })
   })
+
+  it('should throw error for empty browser-check script', async () => {
+    try {
+      const projectPath = path.join(__dirname, 'project-parser-fixtures', 'empty-script-project')
+      await parseProject({
+        directory: projectPath,
+        projectLogicalId: 'empty-script-project-id',
+        projectName: 'empty script project',
+        repoUrl: 'https://github.com/checkly/checkly-cli',
+        availableRuntimes: runtimes,
+        checkMatch: '**/*.foobar.js', // don't match .check.js files used for a different test
+        browserCheckMatch: '**/*.spec.js',
+      })
+      // shouldn't reach this point
+      expect(true).toBe(false)
+    } catch (e: any) {
+      expect(e.message).toBe('Browser check "src/empty-script.spec.js" is not allowed to be empty')
+    }
+  })
+
+  it('should throw error for empty environment variable', async () => {
+    try {
+      const projectPath = path.join(__dirname, 'project-parser-fixtures', 'empty-script-project')
+      await parseProject({
+        directory: projectPath,
+        projectLogicalId: 'empty-script-project-id',
+        projectName: 'empty script project',
+        repoUrl: 'https://github.com/checkly/checkly-cli',
+        availableRuntimes: runtimes,
+        browserCheckMatch: '**/*.foobar.js', // don't match .spec.js files used for a different test
+      })
+      // shouldn't reach this point
+      expect(true).toBe(false)
+    } catch (e: any) {
+      expect(e.message).toContain('Environment variable "EMPTY_FOO" from check group "check-group-1" is not allowed to be empty')
+    }
+  })
 })


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [x] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
The PR adds a check for browser-check script payloads and check-group environment variable values during the project parsing. If there is an empty string, it throws a clear error message indicating the `logicalId` and/or environment variable.

![image](https://github.com/checkly/checkly-cli/assets/5315705/d14e2481-846a-49fc-8612-15d562862990)

![image](https://github.com/checkly/checkly-cli/assets/5315705/39a49d44-0148-4cdb-8d4e-889428f40c85)

<!-- Anything the reviewer should pay extra attention to. -->

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
