### PR TITLE
feat: add --test-session-name arg to test command [gh-704]

### DIFF
--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -83,6 +83,10 @@ export default class Test extends AuthCommand {
       description: 'Record test results in Checkly as a test session with full logs, traces and videos.',
       default: false,
     }),
+    'test-session-name': Flags.string({
+      char: 'n',
+      description: 'A name to use when storing results in Checkly with --record.',
+    }),
   }
 
   static args = {
@@ -112,6 +116,7 @@ export default class Test extends AuthCommand {
       reporter: reporterFlag,
       config: configFilename,
       record: shouldRecord,
+      'test-session-name': testSessionName,
     } = flags
     const filePatterns = argv as string[]
 
@@ -132,7 +137,7 @@ export default class Test extends AuthCommand {
     const project = await parseProject({
       directory: configDirectory,
       projectLogicalId: checklyConfig.logicalId,
-      projectName: checklyConfig.projectName,
+      projectName: testSessionName ?? checklyConfig.projectName,
       repoUrl: checklyConfig.repoUrl,
       checkMatch: checklyConfig.checks?.checkMatch,
       browserCheckMatch: checklyConfig.checks?.browserChecks?.testMatch,


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Add the `--test-session-name` as a `test` command argument. It follows the same pattern using for the 
`trigger` command: it allows the user to override the `projectName` specified in the Checkly config file when the `--record` flag is activated.
We should deploy https://github.com/checkly/checkly-backend/pull/4197 first to override the `projectName` even if the project was already deployed/stored in the database.
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #704

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
