### PR TITLE
chore: show help info with sorted commands [gh-723]

### DIFF
--- a/packages/cli/e2e/__tests__/help.spec.ts
+++ b/packages/cli/e2e/__tests__/help.spec.ts
@@ -10,6 +10,21 @@ describe('help', () => {
     expect(result).toHaveStdoutContaining('EXAMPLES')
   })
 
+  it('should print topic help', () => {
+    const result = runChecklyCli({
+      args: ['env', '--help'],
+    })
+    // use a 80 char line output
+    expect(result).toHaveStdoutContaining(`COMMANDS
+  env add     Add environment variable via "checkly env add <key> <value>".
+  env ls      List all Checkly environment variables via "checkly env ls".
+  env pull    Pull Checkly environment variables via "checkly env pull
+              <filename>".
+  env rm      Remove environment variable via "checkly env rm <key>".
+  env update  Update environment variable via "checkly env update <key>
+              <value>".`)
+  })
+
   it('should print core and additional commands and topic', () => {
     const result = runChecklyCli({
       args: ['--help'],

--- a/packages/cli/e2e/__tests__/help.spec.ts
+++ b/packages/cli/e2e/__tests__/help.spec.ts
@@ -9,4 +9,25 @@ describe('help', () => {
     })
     expect(result).toHaveStdoutContaining('EXAMPLES')
   })
+
+  it('should print core and additional commands and topic', () => {
+    const result = runChecklyCli({
+      args: ['--help'],
+    })
+    expect(result).toHaveStdoutContaining(`CORE COMMANDS
+  deploy   Deploy your project to your Checkly account.
+  test     Test your checks on Checkly.
+  trigger  Trigger checks on Checkly`)
+
+    expect(result).toHaveStdoutContaining(`ADDITIONAL COMMANDS
+  autocomplete  display autocomplete installation instructions
+  destroy       Destroy your project with all its related resources.
+  env           Manage Checkly environment variables
+  help          Display help for checkly.
+  login         Login to your Checkly account or create a new one.
+  logout        Log out and clear any local credentials.
+  runtimes      List all supported runtimes and dependencies.
+  switch        Switch user account.
+  whoami        See your currently logged in account and user.`)
+  })
 })

--- a/packages/cli/e2e/__tests__/help.spec.ts
+++ b/packages/cli/e2e/__tests__/help.spec.ts
@@ -37,7 +37,7 @@ describe('help', () => {
     expect(result).toHaveStdoutContaining(`ADDITIONAL COMMANDS
   autocomplete  display autocomplete installation instructions
   destroy       Destroy your project with all its related resources.
-  env           Manage Checkly environment variables
+  env           Manage Checkly environment variables.
   help          Display help for checkly.
   login         Login to your Checkly account or create a new one.
   logout        Log out and clear any local credentials.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,7 +41,6 @@
   "oclif": {
     "bin": "checkly",
     "commands": "./dist/commands",
-    "topicSeparator": " ",
     "additionalHelpFlags": [
       "-h"
     ],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,6 +41,7 @@
   "oclif": {
     "bin": "checkly",
     "commands": "./dist/commands",
+    "topicSeparator": " ",
     "additionalHelpFlags": [
       "-h"
     ],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -61,7 +61,7 @@
     },
     "topics": {
       "env": {
-        "description": "Manage Checkly environment variables"
+        "description": "Manage Checkly environment variables."
       }
     },
     "helpClass": "./dist/help/help-extension"

--- a/packages/cli/src/commands/baseCommand.ts
+++ b/packages/cli/src/commands/baseCommand.ts
@@ -1,7 +1,12 @@
 import { Command } from '@oclif/core'
 import { api } from '../rest/api'
 
+export type BaseCommandClass = typeof Command & {
+  coreCommand: boolean
+}
+
 export abstract class BaseCommand extends Command {
+  static coreCommand = false
   static hidden = true
 
   protected init (): Promise<void> {

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -23,6 +23,7 @@ enum ResourceDeployStatus {
 }
 
 export default class Deploy extends AuthCommand {
+  static coreCommand = true
   static hidden = false
   static description = 'Deploy your project to your Checkly account.'
 

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -30,6 +30,7 @@ import { printLn, formatCheckTitle, CheckStatus } from '../reporters/util'
 const DEFAULT_REGION = 'eu-central-1'
 
 export default class Test extends AuthCommand {
+  static coreCommand = true
   static hidden = false
   static description = 'Test your checks on Checkly.'
   static flags = {

--- a/packages/cli/src/commands/trigger.ts
+++ b/packages/cli/src/commands/trigger.ts
@@ -15,6 +15,7 @@ import { TestResultsShortLinks } from '../rest/test-sessions'
 const DEFAULT_REGION = 'eu-central-1'
 
 export default class Trigger extends AuthCommand {
+  static coreCommand = true
   static hidden = false
   static description = 'Trigger checks on Checkly'
   static flags = {

--- a/packages/cli/src/help/help-extension.ts
+++ b/packages/cli/src/help/help-extension.ts
@@ -10,8 +10,8 @@ export default class ChecklyHelpClass extends Help {
     const additionalCommands = commands.filter(c => !c.coreCommand)
 
     const format = (commands: Array<BaseCommandClass | Command.Loadable | Command.Cached>) => commands.map(c => {
-      if (this.config.topicSeparator !== ':') {
-        c.id = c.id.replace(/:/g, ' ')
+      if (this.config.topicSeparator) {
+        c.id = c.id.replace(new RegExp(`${this.config.topicSeparator}`, 'g'), ' ')
       }
       return [
         c.id,
@@ -28,8 +28,7 @@ export default class ChecklyHelpClass extends Help {
 
     return this.section('CORE COMMANDS', reder(format(coreCommands))) +
       '\n' + '\n' +
-      this.section('ADDITIONAL COMMANDS', reder(format(additionalCommands))) +
-      this.log('')
+      this.section('ADDITIONAL COMMANDS', reder(format(additionalCommands)))
   }
 
   public showRootHelp (): Promise<void> {

--- a/packages/cli/src/help/help-extension.ts
+++ b/packages/cli/src/help/help-extension.ts
@@ -10,9 +10,7 @@ export default class ChecklyHelpClass extends Help {
     const additionalCommands = commands.filter(c => !c.coreCommand)
 
     const format = (commands: Array<BaseCommandClass | Command.Loadable | Command.Cached>) => commands.map(c => {
-      if (this.config.topicSeparator) {
-        c.id = c.id.replace(new RegExp(`${this.config.topicSeparator}`, 'g'), ' ')
-      }
+      c.id = c.id.replace(/:/g, ' ')
       return [
         c.id,
         this.summary(c),


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Modify the `--help` information format, showing all commands treating the ones under topics as root commands. Commands are sorted by `CORE` and `ADDITIONAL` (default) categories.
Commands can be configured marked as `CORE COMMANDS` setting the `static coreCommand` property to `true`.
<!-- Anything the reviewer should pay extra attention to. -->

![image](https://github.com/checkly/checkly-cli/assets/5315705/ffdf0ab6-a568-48f4-9495-66059cd3a31f)

> Resolves #723

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
