### PR TITLE
refactor: replace `/public-stats` usage [sc-15393]

### DIFF
--- a/packages/cli/e2e/__tests__/fixtures/test-project/src/services/api/api.check.ts
+++ b/packages/cli/e2e/__tests__/fixtures/test-project/src/services/api/api.check.ts
@@ -1,23 +1,6 @@
 import { ApiCheck, AssertionBuilder } from 'checkly/constructs'
 import { slackChannel, webhookChannel } from '../../alert-channels'
 
-const apiCheck = new ApiCheck('homepage-api-check-1', {
-  name: 'Public Stats',
-  alertChannels: [slackChannel, webhookChannel],
-  degradedResponseTime: 10000,
-  maxResponseTime: 20000,
-  request: {
-    url: 'https://api.checklyhq.com/public-stats',
-    method: 'GET',
-    followRedirects: true,
-    skipSSL: false,
-    assertions: [
-      AssertionBuilder.statusCode().equals(200),
-      AssertionBuilder.jsonBody('$.apiCheckResults').greaterThan(0),
-    ],
-  },
-})
-
 const skipSslApiCheck = new ApiCheck('ssl-api-check-1', {
   name: 'Skip SSL Check',
   alertChannels: [slackChannel, webhookChannel],

--- a/packages/cli/e2e/__tests__/fixtures/test-project/src/services/api/typo.checkz.ts
+++ b/packages/cli/e2e/__tests__/fixtures/test-project/src/services/api/typo.checkz.ts
@@ -3,7 +3,7 @@ import { ApiCheck } from 'checkly/constructs'
 const apiCheck = new ApiCheck('not-included-typo-api-check-1', {
   name: 'File extension type example',
   request: {
-    url: 'https://api.checklyhq.com/public-stats',
+    url: 'https://api.checklyhq.com/v1/runtimes',
     method: 'GET',
     assertions: [],
   },


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [ ] CLI
* [ ] Create CLI
* [x] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
Replace any usage of the `/public-stats` endpoint in tests in preparation of the removal of the endpoint.