### PR TITLE
feat: display testOnly checks in deployment summary

### DIFF
--- a/packages/cli/e2e/__tests__/deploy.spec.ts
+++ b/packages/cli/e2e/__tests__/deploy.spec.ts
@@ -70,17 +70,51 @@ describe('deploy', () => {
     expect(status).toBe(0)
   })
 
-  it('Shouldn\'t include a testOnly check', () => {
+  it('Should mark testOnly check as skipped', () => {
     const { status, stdout } = runChecklyCli({
       args: ['deploy', '--preview'],
       apiKey: config.get('apiKey'),
       accountId: config.get('accountId'),
       directory: path.join(__dirname, 'fixtures', 'test-only-project'),
-      env: { PROJECT_LOGICAL_ID: projectLogicalId },
+      env: { PROJECT_LOGICAL_ID: projectLogicalId, TEST_ONLY: 'true' },
     })
-    expect(stdout).toContain('not-testonly-default-check')
-    expect(stdout).toContain('not-testonly-false-check')
-    expect(stdout).not.toContain('testonly-true-check')
+    expect(stdout).toContain(
+`Create:
+    ApiCheck: not-testonly-default-check
+    ApiCheck: not-testonly-false-check
+
+Skip (testOnly):
+    ApiCheck: testonly-true-check
+`)
+    expect(status).toBe(0)
+  })
+
+  it('Should mark testOnly check as deleted if there is a deletion', () => {
+    // Deploy a check (testOnly=false)
+    runChecklyCli({
+      args: ['deploy', '--force'],
+      apiKey: config.get('apiKey'),
+      accountId: config.get('accountId'),
+      directory: path.join(__dirname, 'fixtures', 'test-only-project'),
+      env: { TEST_ONLY: 'false', PROJECT_LOGICAL_ID: projectLogicalId },
+    })
+    // Deploy a check (testOnly=true)
+    const { status, stdout } = runChecklyCli({
+      args: ['deploy', '--force', '--output'],
+      apiKey: config.get('apiKey'),
+      accountId: config.get('accountId'),
+      directory: path.join(__dirname, 'fixtures', 'test-only-project'),
+      env: { TEST_ONLY: 'true', PROJECT_LOGICAL_ID: projectLogicalId },
+    })
+    // Moving the check to testOnly causes it to be deleted.
+    // The check should only be listed under "Delete" and not "Skip".
+    expect(stdout).toContain(
+`Delete:
+    Check: testonly-true-check
+
+Update and Unchanged:
+    ApiCheck: not-testonly-default-check
+    ApiCheck: not-testonly-false-check`)
     expect(status).toBe(0)
   })
 

--- a/packages/cli/e2e/__tests__/fixtures/test-only-project/checkly.config.ts
+++ b/packages/cli/e2e/__tests__/fixtures/test-only-project/checkly.config.ts
@@ -1,6 +1,6 @@
 const config = {
   projectName: 'Test Project (Check testOnly flag)',
-  logicalId: 'test-project',
+  logicalId: process.env.PROJECT_LOGICAL_ID,
   repoUrl: 'https://github.com/checkly/checkly-cli',
 }
 export default config

--- a/packages/cli/e2e/__tests__/fixtures/test-only-project/checks.check.ts
+++ b/packages/cli/e2e/__tests__/fixtures/test-only-project/checks.check.ts
@@ -8,6 +8,7 @@ new ApiCheck('not-testonly-default-check', {
     method: 'GET',
     assertions: []
   },
+  activated: false,
 })
 
 new ApiCheck('testonly-true-check', {
@@ -17,7 +18,8 @@ new ApiCheck('testonly-true-check', {
     method: 'GET',
     assertions: []
   },
-  testOnly: true,
+  activated: false,
+  testOnly: process.env.TEST_ONLY === 'true',
 })
 
 new ApiCheck('not-testonly-false-check', {
@@ -27,5 +29,6 @@ new ApiCheck('not-testonly-false-check', {
     method: 'GET',
     assertions: []
   },
+  activated: false,
   testOnly: false,
 })

--- a/packages/cli/e2e/__tests__/test.spec.ts
+++ b/packages/cli/e2e/__tests__/test.spec.ts
@@ -105,6 +105,7 @@ describe('test', () => {
       apiKey: config.get('apiKey'),
       accountId: config.get('accountId'),
       directory: path.join(__dirname, 'fixtures', 'test-only-project'),
+      env: { PROJECT_LOGICAL_ID: 'test-only-project', TEST_ONLY: 'true' },
     })
     expect(result.stdout).toContain('TestOnly=false (default) Check')
     expect(result.stdout).toContain('TestOnly=false Check')

--- a/packages/cli/src/constructs/project.ts
+++ b/packages/cli/src/constructs/project.ts
@@ -89,6 +89,15 @@ export class Project extends Construct {
     }
   }
 
+  getTestOnlyConstructs (): Construct[] {
+    return Object
+      .values(this.data)
+      .flatMap((record: Record<string, Construct>) =>
+        Object
+          .values(record)
+          .filter((construct: Construct) => construct instanceof Check && construct.testOnly))
+  }
+
   private synthesizeRecord (record: Record<string,
     Check|CheckGroup|AlertChannel|AlertChannelSubscription|MaintenanceWindow>, addTestOnly = true) {
     return Object.entries(record)


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Currently checks with `testOnly=true` aren't displayed at all in the deployment summary of `npx checkly deploy --preview` or `npx checkly deploy --output`. To give more info to users, this PR adds a "Skip" section to the deployment summary containing the `testOnly` checks.

There's an edge case where a check was deployed, then in a subsequent deployment the check is marked as `testOnly=true`. In this case, the check should be considered deleted rather than skipped, since it will be removed from Checkly. I added handling for this edge case and an integration test.

Choosing a color is tricky. Depending on the theme, it isn't super clear. I think that the grey is OK for now, though.
Example (dark theme):
![Screenshot 2023-06-07 at 11 09 30](https://github.com/checkly/checkly-cli/assets/10483186/518e64fa-a3e9-487c-b089-8b777536fe00)


Example (light theme):
<img width="337" alt="Screenshot 2023-06-07 at 11 08 53" src="https://github.com/checkly/checkly-cli/assets/10483186/b3830662-0ad3-4aae-8fb3-b26305885fd6">

thanks @stefanjudis for the suggestion 🦝 