### PR TITLE
fix: lazily initialize config file

### DIFF
--- a/packages/cli/src/services/__tests__/config.spec.ts
+++ b/packages/cli/src/services/__tests__/config.spec.ts
@@ -1,0 +1,13 @@
+import Conf from 'conf'
+import config from '../config'
+jest.mock('conf')
+
+describe('config', () => {
+  it('should avoid reading config file if environment variables are set', () => {
+    process.env.CHECKLY_API_KEY = 'test-api-key'
+    const apiKey = config.getApiKey()
+    expect(apiKey).toEqual(process.env.CHECKLY_API_KEY)
+    expect(Conf).toHaveBeenCalledTimes(0)
+    delete process.env.CHECKLY_API_KEY
+  })
+})

--- a/packages/cli/src/services/config.ts
+++ b/packages/cli/src/services/config.ts
@@ -19,26 +19,38 @@ enum Env {
   local = 'local',
 }
 
-const config = {
-  auth: new Conf({
-    projectName: '@checkly/cli',
-    configName: 'auth',
-    projectSuffix,
-    // @ts-ignore
-    schema: authSchema,
-  }),
-  data: new Conf({
-    projectName: '@checkly/cli',
-    configName: 'config',
-    projectSuffix,
-    // @ts-ignore
-    schema: dataSchema,
-  }),
+class ChecklyConfig {
+  private _auth?: Conf<{ apiKey: unknown }>
+  private _data?: Conf<{ accountId: unknown, accountName: unknown }>
+
+  // Accessing auth or data will cause a config file to be created.
+  // We should avoid doing this unless absolutely necessary, since this operation can fail due to file permissions.
+  get auth () {
+    // Create this._auth lazily
+    return this._auth ?? (this._auth = new Conf({
+      projectName: '@checkly/cli',
+      configName: 'auth',
+      projectSuffix,
+      // @ts-ignore
+      schema: authSchema,
+    }))
+  }
+
+  get data () {
+    // Create this._data lazily
+    return this._data ?? (this._data = new Conf({
+      projectName: '@checkly/cli',
+      configName: 'config',
+      projectSuffix,
+      // @ts-ignore
+      schema: dataSchema,
+    }))
+  }
 
   clear () {
     this.auth.clear()
     this.data.clear()
-  },
+  }
 
   getEnv (): Env {
     const environments = ['production', 'development', 'staging', 'local']
@@ -49,21 +61,21 @@ const config = {
     }
 
     return env as Env
-  },
+  }
 
   getApiKey (): string {
     return process.env.CHECKLY_API_KEY || this.auth.get<string>('apiKey') as string || ''
-  },
+  }
 
   getAccountId (): string {
     return process.env.CHECKLY_ACCOUNT_ID || this.data.get<string>('accountId') as string || ''
-  },
+  }
 
   hasEnvVarsConfigured (): boolean {
     const apiKey = process.env.CHECKLY_API_KEY || ''
     const accoundId = process.env.CHECKLY_ACCOUNT_ID || ''
     return apiKey !== '' || accoundId !== ''
-  },
+  }
 
   getApiUrl (): string {
     const environments = {
@@ -73,7 +85,7 @@ const config = {
       production: 'https://api.checklyhq.com',
     }
     return environments[this.getEnv()]!
-  },
+  }
 
   getMqttUrl (): string {
     const environments = {
@@ -83,14 +95,15 @@ const config = {
       production: 'wss://events.checklyhq.com',
     }
     return environments[this.getEnv()]!
-  },
+  }
 
   hasValidCredentials (): boolean {
     if (this.getApiKey() !== '' && this.getAccountId() !== '') {
       return true
     }
     return false
-  },
+  }
 }
 
+const config = new ChecklyConfig()
 export default config


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Currently the CLI tries to create a config file even if `CHECKLY_ACCOUNT_ID` and `CHECKLY_API_KEY` are passed. In some environments (f.ex AWS Lambda), this can then trigger an error. This PR makes the creation of config files lazy. The config file should only be created if `CHECKLY_ACCOUNT_ID` or `CHECKLY_API_KEY` are missing, or for the `checkly switch` and `checkly login` commands.

The issue can be reproduced on Mac OS by deleting `~/Library/Preferences/@checkly/cli` and making `~/Library/Preferences/@checkly` read-only. `CHECKLY_ACCOUNT_ID=<someId> CHECKLY_API_KEY=<apiKey> npx checkly deploy` then fails with:
```
(node:7786) [EACCES] Error Plugin: checkly: EACCES: permission denied, mkdir '/Users/clample/Library/Preferences/@checkly/cli'
```

#### Testing
* Tested that `npx checkly test`, `npx checkly deploy`, and `npx checkly trigger` work when `~/LibraryPreferences/@checkly` is read-only and `CHECKLY_ACCOUNT_ID` and `CHECKLY_API_KEY` are set.
* Tested that `npx checkly login`, `npx checkly switch`, and `npx checkly whomai` are still working.