### PR TITLE
fix: re-introduce @oclif/plugin-help dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2677,7 +2677,8 @@
     },
     "node_modules/@oclif/plugin-help": {
       "version": "5.1.20",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-5.1.20.tgz",
+      "integrity": "sha512-N8xRxE/isFcdBDI8cobixEZA5toxIK5jbxpwALNTr4s8KNAtBA3ORQrSiY0fWGkcv0sCGMwZw7rJ0Izh18JPsw==",
       "dependencies": {
         "@oclif/core": "^1.21.0"
       },
@@ -17045,6 +17046,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@oclif/core": "2.0.7",
+        "@oclif/plugin-help": "5.1.20",
         "@oclif/plugin-not-found": "2.3.23",
         "@oclif/plugin-plugins": "2.3.0",
         "@oclif/plugin-warn-if-update-available": "2.0.24",
@@ -19262,6 +19264,8 @@
     },
     "@oclif/plugin-help": {
       "version": "5.1.20",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-5.1.20.tgz",
+      "integrity": "sha512-N8xRxE/isFcdBDI8cobixEZA5toxIK5jbxpwALNTr4s8KNAtBA3ORQrSiY0fWGkcv0sCGMwZw7rJ0Izh18JPsw==",
       "requires": {
         "@oclif/core": "^1.21.0"
       },
@@ -21006,6 +21010,7 @@
       "version": "file:packages/cli",
       "requires": {
         "@oclif/core": "2.0.7",
+        "@oclif/plugin-help": "5.1.20",
         "@oclif/plugin-not-found": "2.3.23",
         "@oclif/plugin-plugins": "2.3.0",
         "@oclif/plugin-warn-if-update-available": "2.0.24",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -70,6 +70,7 @@
   "homepage": "https://github.com/checkly/checkly-cli#readme",
   "dependencies": {
     "@oclif/core": "2.0.7",
+    "@oclif/plugin-help": "5.1.20",
     "@oclif/plugin-not-found": "2.3.23",
     "@oclif/plugin-plugins": "2.3.0",
     "@oclif/plugin-warn-if-update-available": "2.0.24",


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
From a recent canary release of the CLI (`checkly@0.0.0-pr.763.ed8b35d`), there's been a regression in the CLI related to `@oclif/plugin-help`:

```
$ npx checkly whoami
(node:11081) Error Plugin: checkly: could not find package.json with {
  type: 'core',
  root: '/Users/clample/projects/test/lime-cheetah/node_modules/checkly',
  name: '@oclif/plugin-help'
}
module: @oclif/core@2.0.7
task: loadPlugins
plugin: checkly
root: /Users/clample/projects/test/lime-cheetah/node_modules/checkly
See more details with DEBUG=*
(Use `node --trace-warnings ...` to show where the warning was created)
You are currently on account "chris@checklyhq.com" (bf7babe3-0589-4cc9-9358-f706b3b11362) as Chris Lample.
```

The dependency on `@oclif/plugin-help` was removed in https://github.com/checkly/checkly-cli/commit/62891ff0ec3102896b8467ed58159aaf7c353d63#diff-6e2e2a1851648938b325ba84de634407a4e69a644ea61102df15ca4a8a7a9758L76. This PR re-adds the dependency with the same version.