### PR TITLE
fix: properly close scheduling timer to avoid checkly test hanging

### DIFF
--- a/packages/cli/src/services/abstract-check-runner.ts
+++ b/packages/cli/src/services/abstract-check-runner.ts
@@ -213,7 +213,10 @@ export default abstract class AbstractCheckRunner extends EventEmitter {
       return
     }
     this.schedulingDelayExceededTimeout = setTimeout(
-      () => this.emit(Events.MAX_SCHEDULING_DELAY_EXCEEDED),
+      () => {
+        this.emit(Events.MAX_SCHEDULING_DELAY_EXCEEDED)
+        this.schedulingDelayExceededTimeout = undefined
+      },
       DEFAULT_SCHEDULING_DELAY_EXCEEDED_MS,
     )
     this.on(Events.CHECK_INPROGRESS, () => {


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
With the current canary release from `main`, test runs with `checkly test` always takes 20 seconds. This occurs even when the checks are shown as finished after only several seconds. This can be reproduced with `time checkly test` on the boilerplate example. 

This issue is because we aren't closing the timeout for `MAX_SCHEDULING_DELAY_EXCEEDED`, so the node process hangs until after it runs (in 20 seconds). This issue doesn't affect any public releases since it was merged after v4.0.8.

This PR fixes the issue by closing the timeout after all of the check runs have been scheduled. The code is similar to what we already have for `AbstractCheckRunner.allChecksFinished`.


#### Testing:

Tested `time checkly test` on the boilerplate example. It finishes after ~7 seconds rather than 20.


Also tested that the scheduling delay message is working. To test, I used the following code snippet with `checkly test --location eu-south-1`:
```
const checkTime = 30000
const sleepScript = `await new Promise(resolve => setTimeout(resolve, ${checkTime}))`

for (let i = 0; i < 10; i++) {
  new BrowserCheck(`check-${i}`, {
    name: `Check ${i}`,
    code: {
      content: sleepScript,
    }
  })
}
```