### PR TITLE
fix: gh actions release build job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       # Ensure that the README is published with the package
       - run: rm -f packages/cli/README.md && cp README.md packages/cli
-      - run: npm ci --workspace packages/cli
+      - run: npm ci
       - run: npm publish --provenance --workspace packages/cli
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,7 @@ jobs:
           cache-dependency-path: package-lock.json
       - run: npm config set fund false && npm set audit false
       - run: npm ci
+      - run: npm run prepack
       - run: npm run test
       - run: npm run test:e2e
         env:

--- a/package.json
+++ b/package.json
@@ -3,9 +3,10 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
-    "prepare": "npx simple-git-hooks && npm run prepare --workspaces",
     "lint": "eslint . --ext .ts,.js,.mjs",
     "lint:fix": "eslint . --ext .ts,.js,.mjs --fix",
+    "prepack": "npm run prepack --workspaces",
+    "prepare": "npx simple-git-hooks && npm run prepare --workspaces",
     "test": "npm run test --workspaces",
     "test:e2e": "npm run test:e2e --workspaces"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,8 +13,8 @@
   },
   "scripts": {
     "clean": "rimraf ./dist",
-    "prepare": "npm run clean && tsc --build",
     "prepack": "npx oclif manifest",
+    "prepare": "npm run clean && tsc --build",
     "test": "jest --selectProjects unit",
     "test:e2e": "npm run prepare && cross-env NODE_CONFIG_DIR=./e2e/config jest --selectProjects E2E",
     "test:e2e:local": "cross-env CHECKLY_ENV=local npm run test:e2e",

--- a/packages/create-cli/package.json
+++ b/packages/create-cli/package.json
@@ -8,9 +8,10 @@
   "private": false,
   "scripts": {
     "clean": "rimraf ./dist",
-    "test": "jest --selectProjects unit",
-    "test:e2e": "echo \"Error: no test specified\"",
+    "prepack": "echo \"Warning: no oclif manifest configured\"",
     "prepare": "npm run clean && tsc --build",
+    "test": "jest --selectProjects unit",
+    "test:e2e": "echo \"Warning: no test specified\"",
     "start": "node ./index.mjs",
     "watch": "tsc --watch"
   },


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [ ] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [x] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
After adding the linting for the monorepo, the `npm ci` must be executed for the complete monorepo including both packages. The `release.yml` workflow is updated to install all dependencies.
The PR adds the `npm run prepack` command before running `tests` jobs. Apparaently, this fixes issues when running tests where the `package.json` version was already modified, and no `package-lock.json` is updated in the new PR.
<!-- Anything the reviewer should pay extra attention to. -->

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
