### PR TITLE
chore(deps-dev): Bump @types/node from 18.11.18 to 20.3.3 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3423,8 +3423,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "18.11.18",
-      "license": "MIT"
+      "version": "20.3.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.3.tgz",
+      "integrity": "sha512-wheIYdr4NYML61AjC8MKj/2jrR/kDQri/CIpVoZwldwhnIrD/j9jIU5bJ8yBKuB2VhpFV7Ab6G2XkBjv9r9Zzw=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -16778,7 +16779,7 @@
         "@types/glob": "8.0.0",
         "@types/jest": "29.2.4",
         "@types/luxon": "3.2.0",
-        "@types/node": "18.11.18",
+        "@types/node": "20.3.3",
         "@types/prompts": "2.4.4",
         "@types/uuid": "9.0.1",
         "@types/ws": "8.5.3",
@@ -16916,7 +16917,7 @@
         "@types/glob": "8.0.0",
         "@types/jest": "29.2.4",
         "@types/luxon": "3.2.0",
-        "@types/node": "18.11.18",
+        "@types/node": "20.3.3",
         "@types/prompts": "^2.4.2",
         "@types/uuid": "9.0.1",
         "@types/which-pm-runs": "^1.0.0",
@@ -19506,7 +19507,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.11.18"
+      "version": "20.3.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.3.tgz",
+      "integrity": "sha512-wheIYdr4NYML61AjC8MKj/2jrR/kDQri/CIpVoZwldwhnIrD/j9jIU5bJ8yBKuB2VhpFV7Ab6G2XkBjv9r9Zzw=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -20626,7 +20629,7 @@
         "@types/glob": "8.0.0",
         "@types/jest": "29.2.4",
         "@types/luxon": "3.2.0",
-        "@types/node": "18.11.18",
+        "@types/node": "20.3.3",
         "@types/prompts": "2.4.4",
         "@types/uuid": "9.0.1",
         "@types/ws": "8.5.3",
@@ -21155,7 +21158,7 @@
         "@types/glob": "8.0.0",
         "@types/jest": "29.2.4",
         "@types/luxon": "3.2.0",
-        "@types/node": "18.11.18",
+        "@types/node": "20.3.3",
         "@types/prompts": "^2.4.2",
         "@types/uuid": "9.0.1",
         "@types/which-pm-runs": "^1.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -98,7 +98,7 @@
     "@types/glob": "8.0.0",
     "@types/jest": "29.2.4",
     "@types/luxon": "3.2.0",
-    "@types/node": "18.11.18",
+    "@types/node": "20.3.3",
     "@types/prompts": "2.4.4",
     "@types/uuid": "9.0.1",
     "@types/ws": "8.5.3",

--- a/packages/create-cli/package.json
+++ b/packages/create-cli/package.json
@@ -56,7 +56,7 @@
     "@types/glob": "8.0.0",
     "@types/jest": "29.2.4",
     "@types/luxon": "3.2.0",
-    "@types/node": "18.11.18",
+    "@types/node": "20.3.3",
     "@types/prompts": "^2.4.2",
     "@types/uuid": "9.0.1",
     "@types/which-pm-runs": "^1.0.0",


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [x] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->
I created a separate PR for the @types/node update. It seems to be fine and all the tests are passing. For some reason the original Dependabot PR is just missing the secrets (see screenshot) so all requests fail with HTTP 401 Unauthorized. I did not bother looking into why. 
<img width="235" alt="CleanShot 2023-07-04 at 10 33 45@2x" src="https://github.com/checkly/checkly-cli/assets/4331621/707994b7-4c25-4f84-9cd4-54dfe5568a8f">

Example CI run I took the screenshot from: https://github.com/checkly/checkly-cli/actions/runs/5451590463/jobs/9918010210?pr=783

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
