### PR TITLE
feat: sms & phone call alert channels optional name support [sc-00]

### DIFF
--- a/packages/cli/src/constructs/phone-call-alert-channel.ts
+++ b/packages/cli/src/constructs/phone-call-alert-channel.ts
@@ -6,6 +6,10 @@ export interface PhoneCallAlertChannelProps extends AlertChannelProps {
    * The phone number where to send the alert notifications.
    */
   phoneNumber: string
+  /**
+   * The name of the alert channel.
+   */
+  name?: string;
 }
 
 /**
@@ -17,6 +21,7 @@ export interface PhoneCallAlertChannelProps extends AlertChannelProps {
  */
 export class PhoneCallAlertChannel extends AlertChannel {
   phoneNumber: string
+  name?: string
   /**
    * Constructs the Phone Call Alert Channel instance
    *
@@ -30,6 +35,7 @@ export class PhoneCallAlertChannel extends AlertChannel {
   constructor (logicalId: string, props: PhoneCallAlertChannelProps) {
     super(logicalId, props)
     this.phoneNumber = props.phoneNumber
+    this.name = props.name
     Session.registerConstruct(this)
   }
 
@@ -39,6 +45,7 @@ export class PhoneCallAlertChannel extends AlertChannel {
       type: 'CALL',
       config: {
         number: this.phoneNumber,
+        name: this.name,
       },
     }
   }

--- a/packages/cli/src/constructs/sms-alert-channel.ts
+++ b/packages/cli/src/constructs/sms-alert-channel.ts
@@ -6,6 +6,10 @@ export interface SmsAlertChannelProps extends AlertChannelProps {
    * The phone number where to send the alert notifications.
    */
   phoneNumber: string
+  /**
+   * The name of the alert channel.
+   */
+  name?: string;
 }
 
 /**
@@ -17,6 +21,7 @@ export interface SmsAlertChannelProps extends AlertChannelProps {
  */
 export class SmsAlertChannel extends AlertChannel {
   phoneNumber: string
+  name?: string
   /**
    * Constructs the SMS Alert Channel instance
    *
@@ -28,6 +33,7 @@ export class SmsAlertChannel extends AlertChannel {
   constructor (logicalId: string, props: SmsAlertChannelProps) {
     super(logicalId, props)
     this.phoneNumber = props.phoneNumber
+    this.name = props.name
     Session.registerConstruct(this)
   }
 
@@ -37,6 +43,7 @@ export class SmsAlertChannel extends AlertChannel {
       type: 'SMS',
       config: {
         number: this.phoneNumber,
+        name: this.name,
       },
     }
   }


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Adding optional `name` support to SMS &  Phone call constructs