### PR TITLE
 fix: override ts-node module behaviour [gh-768] 

### DIFF
--- a/packages/cli/e2e/__tests__/fixtures/esm-module/checkly.config.ts
+++ b/packages/cli/e2e/__tests__/fixtures/esm-module/checkly.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'checkly'
+
+const config = defineConfig({
+  projectName: 'Boilerplate Project',
+  logicalId: 'boilerplate-project',
+  repoUrl: 'https://github.com/checkly/checkly-cli',
+  checks: {
+    checkMatch: '**/__checks__/**/*.check.ts',
+  },
+  cli: {
+    runLocation: 'eu-west-1',
+  },
+})
+
+export default config

--- a/packages/cli/e2e/__tests__/fixtures/esm-module/checkly.config.ts
+++ b/packages/cli/e2e/__tests__/fixtures/esm-module/checkly.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from 'checkly'
 
 const config = defineConfig({
-  projectName: 'Boilerplate Project',
-  logicalId: 'boilerplate-project',
+  projectName: 'Test ECMAScript Module Project',
+  logicalId: 'test-esm-project',
   repoUrl: 'https://github.com/checkly/checkly-cli',
   checks: {
-    checkMatch: '**/__checks__/**/*.check.ts',
+    checkMatch: '**/*.check.ts',
   },
   cli: {
     runLocation: 'eu-west-1',

--- a/packages/cli/e2e/__tests__/fixtures/esm-module/checks.check.ts
+++ b/packages/cli/e2e/__tests__/fixtures/esm-module/checks.check.ts
@@ -1,0 +1,9 @@
+import { BrowserCheck } from 'checkly/constructs'
+
+const browserCheck = new BrowserCheck('secret-browser-check', {
+  name: 'Show SECRET_ENV value',
+  activated: false,
+  code: {
+    content: 'console.info(process.env.SECRET_ENV);',
+  },
+})

--- a/packages/cli/e2e/__tests__/fixtures/esm-module/package.json
+++ b/packages/cli/e2e/__tests__/fixtures/esm-module/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "boilerlate-project",
+  "name": "Test ECMAScript Module Project",
   "version": "1.0.0",
   "description": "",
   "scripts": {

--- a/packages/cli/e2e/__tests__/fixtures/esm-module/package.json
+++ b/packages/cli/e2e/__tests__/fixtures/esm-module/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "boilerlate-project",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {},
+  "type": "module"
+}

--- a/packages/cli/e2e/__tests__/test.spec.ts
+++ b/packages/cli/e2e/__tests__/test.spec.ts
@@ -143,7 +143,7 @@ describe('test', () => {
     expect(result.stdout).toContain('Reached timeout of 0 seconds waiting for check result.')
   })
 
-  it.only('ESModule project should run successfully', () => {
+  it('ESModule project should run successfully', () => {
     const secretEnv = uuid.v4()
     const result = runChecklyCli({
       args: ['test', '-e', `SECRET_ENV=${secretEnv}`, '--verbose'],
@@ -152,7 +152,6 @@ describe('test', () => {
       directory: path.join(__dirname, 'fixtures', 'esm-module'),
       timeout: 120000, // 2 minutes
     })
-    console.log('GOT ', result)
     expect(result.stdout).not.toContain('File extension type example')
     expect(result.stdout).toContain(secretEnv)
     expect(result.status).toBe(0)

--- a/packages/cli/e2e/__tests__/test.spec.ts
+++ b/packages/cli/e2e/__tests__/test.spec.ts
@@ -142,4 +142,19 @@ describe('test', () => {
     expect(result.status).toBe(1)
     expect(result.stdout).toContain('Reached timeout of 0 seconds waiting for check result.')
   })
+
+  it.only('ESModule project should run successfully', () => {
+    const secretEnv = uuid.v4()
+    const result = runChecklyCli({
+      args: ['test', '-e', `SECRET_ENV=${secretEnv}`, '--verbose'],
+      apiKey: config.get('apiKey'),
+      accountId: config.get('accountId'),
+      directory: path.join(__dirname, 'fixtures', 'esm-module'),
+      timeout: 120000, // 2 minutes
+    })
+    console.log('GOT ', result)
+    expect(result.stdout).not.toContain('File extension type example')
+    expect(result.stdout).toContain(secretEnv)
+    expect(result.status).toBe(0)
+  })
 })

--- a/packages/cli/src/services/util.ts
+++ b/packages/cli/src/services/util.ts
@@ -84,6 +84,9 @@ async function getTsCompiler (): Promise<Service> {
   try {
     const tsNode = await import('ts-node')
     tsCompiler = tsNode.register({
+      moduleTypes: {
+        '**/*': 'cjs',
+      },
       compilerOptions: {
         module: 'CommonJS',
       },


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
> Resolves #768

#### The bug
Currently the CLI is unable to support TypeScript `checkly.config.ts` and `**.check.ts` files in projects that are configured as ECMAScript Module projects. This can be reproduced by setting `"type": "module"` in `package.json` for the boilerplate project:

```
$ npx checkly deploy
Parsing your project... !
    Error: Error loading file /Users/clample/projects/test/amber-snake/checkly.config.ts
    Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: /Users/clample/projects/test/amber-snake/checkly.config.ts
    require() of ES modules is not supported.
    require() of /Users/clample/projects/test/amber-snake/checkly.config.ts from /Users/clample/projects/test/amber-snake/node_modules/checkly/dist/services/util.js is an ES module file as it is a .ts file whose nearest parent package.json contains "type": "module" which defines all .ts files in that package scope
    as ES modules.
    Instead change the requiring code to use import(), or remove "type": "module" from /Users/clample/projects/test/amber-snake/package.json.

        at createErrRequireEsm (/Users/clample/projects/test/amber-snake/node_modules/ts-node/dist-raw/node-internal-errors.js:46:15)
        at assertScriptCanLoadAsCJSImpl (/Users/clample/projects/test/amber-snake/node_modules/ts-node/dist-raw/node-internal-modules-cjs-loader.js:584:11)
        at Object.require.extensions.<computed> [as .ts] (/Users/clample/projects/test/amber-snake/node_modules/ts-node/src/index.ts:1610:5)
        at Module.load (node:internal/modules/cjs/loader:1004:32)
        at Function.Module._load (node:internal/modules/cjs/loader:839:12)
        at Module.require (node:internal/modules/cjs/loader:1028:19)
        at require (node:internal/modules/cjs/helpers:102:18)
        at /Users/clample/projects/test/amber-snake/node_modules/checkly/src/services/util.ts:69:54
        at processTicksAndRejections (node:internal/process/task_queues:96:5)
        at async loadTsFile (/Users/clample/projects/test/amber-snake/node_modules/checkly/src/services/util.ts:69:33)
```

The issue occurs when importing the project files via `ts-node`. The `ts-node` documentation has extensive notes on this: [ts-node CommonJS vs native ECMAScript modules](https://typestrong.org/ts-node/docs/imports) and [ts-node Module type overrides](https://typestrong.org/ts-node/docs/module-type-overrides/).

#### The Fix

The Checkly CLI is currently compiled to CommonJS and the `await import` in [loadTsFile](https://github.com/checkly/checkly-cli/blob/3f86e8f8077d99afb4a92fea289077ace9b42fcd/packages/cli/src/services/util.ts#L69) is compiled to a `require`:

```
async function loadTsFile(filepath) {
    try {
        const tsCompiler = await getTsCompiler();
        tsCompiler.enabled(true);
        let { default: exported } = await (_a = filepath, Promise.resolve().then(() => require(_a)));
        if (exported instanceof Function) {
            exported = await exported();
        }
        tsCompiler.enabled(false); // Re-disable the TS compiler
        return exported;
    }
    catch (err) {
        throw new Error(`Error loading file ${filepath}\n${err.stack}`);
    }
}
```

One option could be to leave the MaC project code as an ECMAScript Module, and import it using a similar trick we use for `.mjs` support ([here](https://github.com/checkly/checkly-cli/pull/628/files#diff-7c8fd3b27e844411b3b9322d7e7e16fdd90515d80a9917d88fead3067af2a298R10). This would be difficult, though, with `ts-node`. We would need to use [`ts-node`'s Native ECMAScript Modules Support](https://typestrong.org/ts-node/docs/imports#native-ecmascript-modules), and this requires passing the `--loader` flag to `node`.

Instead, this PR configures `ts-node` to ignore the project's `package.json` and compile the code to CommonJS. This is described in [ts-node Module Type Overrides](https://typestrong.org/ts-node/docs/module-type-overrides). This let's us continue to `require` the project's `checkly.config.ts` and `*.check.ts` files. 

One downside with this approach may be with projects importing other dependencies that are [pure ESM packages](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c). In this case, I think that they will run into `ERR_REQUIRE_ESM`.


