### PR TITLE
fix: allow strings to be passed as urls [gh-0]

### DIFF
--- a/packages/cli/src/constructs/slack-alert-channel.ts
+++ b/packages/cli/src/constructs/slack-alert-channel.ts
@@ -2,7 +2,7 @@ import { AlertChannel, AlertChannelProps } from './alert-channel'
 import { Session } from './project'
 
 export interface SlackAlertChannelProps extends AlertChannelProps {
-  url: URL
+  url: URL|string
   channel?: string
 }
 
@@ -14,7 +14,7 @@ export interface SlackAlertChannelProps extends AlertChannelProps {
  * This class make use of the Alert Channel endpoints.
  */
 export class SlackAlertChannel extends AlertChannel {
-  url: URL
+  url: URL|string
   channel?: string
   /**
    * Constructs the Slack Alert Channel instance

--- a/packages/cli/src/constructs/webhook-alert-channel.ts
+++ b/packages/cli/src/constructs/webhook-alert-channel.ts
@@ -13,7 +13,7 @@ export interface WebhookAlertChannelProps extends AlertChannelProps {
   /**
    * The URL where to send the webhook HTTP request.
    */
-  url: URL
+  url: URL|string
   /**
    * This is commonly a JSON body. You can
    * use {@link https://www.checklyhq.com/docs/alerting/webhooks/#using-variables Handlebars-style template variables}
@@ -44,7 +44,7 @@ export interface WebhookAlertChannelProps extends AlertChannelProps {
 export class WebhookAlertChannel extends AlertChannel {
   name: string
   webhookType?: string
-  url: URL
+  url: URL|string
   template?: string
   method?: HttpRequestMethod
   headers?: Array<HttpHeader>


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Allow strings to be passed as urls. This is to handle handlebar templates in the string urls