### PR TITLE
chore: set CHECKLY_BASE_URL for local e2e tests

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,7 +17,7 @@
     "prepare": "npm run clean && tsc --build",
     "test": "jest --selectProjects unit",
     "test:e2e": "npm run prepare && cross-env NODE_CONFIG_DIR=./e2e/config jest --selectProjects E2E",
-    "test:e2e:local": "cross-env CHECKLY_ENV=local npm run test:e2e",
+    "test:e2e:local": "cross-env CHECKLY_BASE_URL=http://localhost:3000  CHECKLY_ENV=local npm run test:e2e",
     "watch": "tsc --watch"
   },
   "repository": {


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
The e2e tests make use of `CHECKLY_BASE_URL` to make API requests for cleanup. In particular, `deploy.spec.ts` is using `CHECKLY_BASE_URL` via `config`. Without setting this env var, `deploy.spec.ts` fails when running `npm run test:e2e:local`.

To avoid us needing to set this manually when running the e2e tests locally, this PR adds it to the `test:e2e:local` command.
