### PR TITLE
fix: use correct spelling for AssertionBuilder.responseTime()

### DIFF
--- a/packages/cli/src/constructs/api-check.ts
+++ b/packages/cli/src/constructs/api-check.ts
@@ -60,7 +60,12 @@ export class AssertionBuilder {
     return new GeneralAssertionBuilder(AssertionSource.TEXT_BODY, property)
   }
 
+  /** @deprecated Use responseTime() instead */
   static responseTme () {
+    return new NumericAssertionBuilder(AssertionSource.RESPONSE_TIME)
+  }
+
+  static responseTime () {
     return new NumericAssertionBuilder(AssertionSource.RESPONSE_TIME)
   }
 }


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer

`AssertionBuilder.responseTme()` had a typo. This PR fixes the typo in a backwards compatible way. To avoid breaking existing projects, this PR leaves `responseTme()` in the codebase. This PR also marks the method as deprecated. This puts it at the bottom of the Visual Studio code suggestions. 

![Screenshot 2023-08-03 at 16 53 07](https://github.com/checkly/checkly-cli/assets/10483186/18a4a841-dc4b-4b00-a009-67bbde77e558)
![Screenshot 2023-08-03 at 16 48 57](https://github.com/checkly/checkly-cli/assets/10483186/769a6625-7221-47de-bb1b-f299db192bb5)
