### PR TITLE
chore: add sslCheckDomain property [gh-0]

### DIFF
--- a/packages/cli/e2e/__tests__/fixtures/deploy-project/browser.check.ts
+++ b/packages/cli/e2e/__tests__/fixtures/deploy-project/browser.check.ts
@@ -9,4 +9,5 @@ new BrowserCheck('homepage-browser-check', {
   code: {
     entrypoint: path.join(__dirname, 'homepage.test.ts')
   },
+  sslCheckDomain: 'acme.com',
 })

--- a/packages/cli/src/constructs/browser-check.ts
+++ b/packages/cli/src/constructs/browser-check.ts
@@ -133,7 +133,7 @@ export class BrowserCheck extends Check {
       script: this.script,
       scriptPath: this.scriptPath,
       dependencies: this.dependencies,
-      sslCheckDomain: this.sslCheckDomain ?? null,
+      sslCheckDomain: this.sslCheckDomain || null, // empty string is converted to null
     }
   }
 }

--- a/packages/cli/src/constructs/browser-check.ts
+++ b/packages/cli/src/constructs/browser-check.ts
@@ -18,7 +18,8 @@ export interface BrowserCheckProps extends CheckProps {
    */
   code: Content|Entrypoint
   /**
-   * A valid fully qualified domain name (FQDN) to check for SSL certificate expiration. For example, 'app.checklyhq.com'.
+   * A valid fully qualified domain name (FQDN) to check for SSL certificate
+   * expiration. For example, 'app.checklyhq.com'.
    */
   sslCheckDomain?: string
 }

--- a/packages/cli/src/constructs/browser-check.ts
+++ b/packages/cli/src/constructs/browser-check.ts
@@ -17,6 +17,10 @@ export interface BrowserCheckProps extends CheckProps {
    * with the Puppeteer or Playwright frameworks.
    */
   code: Content|Entrypoint
+  /**
+   * A valid fully qualified domain name (FQDN) to check its SSL certificate.
+   */
+  sslCheckDomain?: string
 }
 
 /**
@@ -30,6 +34,7 @@ export class BrowserCheck extends Check {
   script: string
   scriptPath?: string
   dependencies?: Array<CheckDependency>
+  sslCheckDomain?: string
 
   /**
    * Constructs the Browser Check instance
@@ -44,6 +49,7 @@ export class BrowserCheck extends Check {
     }
     BrowserCheck.applyDefaultBrowserCheckConfig(props)
     super(logicalId, props)
+    this.sslCheckDomain = props.sslCheckDomain
     if ('content' in props.code) {
       const script = props.code.content
       this.script = script
@@ -127,6 +133,7 @@ export class BrowserCheck extends Check {
       script: this.script,
       scriptPath: this.scriptPath,
       dependencies: this.dependencies,
+      sslCheckDomain: this.sslCheckDomain ?? null,
     }
   }
 }

--- a/packages/cli/src/constructs/browser-check.ts
+++ b/packages/cli/src/constructs/browser-check.ts
@@ -18,7 +18,7 @@ export interface BrowserCheckProps extends CheckProps {
    */
   code: Content|Entrypoint
   /**
-   * A valid fully qualified domain name (FQDN) to check its SSL certificate.
+   * A valid fully qualified domain name (FQDN) to check for SSL certificate expiration. For example, 'app.checklyhq.com'.
    */
   sslCheckDomain?: string
 }


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [x] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
This PR adds `sslCheckDomain` into `BrowserCheck` construct.
<!-- Anything the reviewer should pay extra attention to. -->

> Depends on https://github.com/checkly/checkly-backend/pull/4591

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
