### PR TITLE
feat(heartbeat): print `pingUrl` in the console after deploy for heartbeat checks [sc-17085]

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -116,6 +116,14 @@ export default class Deploy extends AuthCommand {
       if (!preview) {
         await ux.wait(500)
         this.log(`Successfully deployed project "${project.name}" to account "${account.name}".`)
+
+        // Print the ping URL for heartbeat checks.
+        data.diff.forEach(async (check) => {
+          if (check.checkId) {
+            const { data: { pingUrl, name } } = await api.heartbeatCheck.get(check.checkId)
+            this.log(`The ping URL for the heartbeat check ${chalk.greenBright(name)} is available at ${chalk.italic.underline.cyanBright(pingUrl)}.`)
+          }
+        })
       }
     } catch (err: any) {
       if (err?.response?.status === 400) {

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -118,10 +118,14 @@ export default class Deploy extends AuthCommand {
         this.log(`Successfully deployed project "${project.name}" to account "${account.name}".`)
 
         // Print the ping URL for heartbeat checks.
-        data.diff.forEach(async (check) => {
-          if (check.checkId) {
-            const { data: { pingUrl, name } } = await api.heartbeatCheck.get(check.checkId)
-            this.log(`The ping URL for the heartbeat check ${chalk.greenBright(name)} is available at ${chalk.italic.underline.cyanBright(pingUrl)}.`)
+        const heartbeatLogicalIds = project.getHeartbeatLogicalIds()
+        const heartbeatCheckIds = data.diff.filter((check) => heartbeatLogicalIds.includes(check.logicalId))
+          .map(check => check?.physicalId)
+
+        heartbeatCheckIds.forEach(async (id) => {
+          if (id) {
+            const { data: { pingUrl, name } } = await api.heartbeatCheck.get(id)
+            this.log(`Ping URL of heartbeat check ${chalk.green(name)} is ${chalk.italic.underline.blue(pingUrl)}.`)
           }
         })
       }

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -123,10 +123,8 @@ export default class Deploy extends AuthCommand {
           .map(check => check?.physicalId)
 
         heartbeatCheckIds.forEach(async (id) => {
-          if (id && typeof id === 'string') {
-            const { data: { pingUrl, name } } = await api.heartbeatCheck.get(id)
-            this.log(`Ping URL of heartbeat check ${chalk.green(name)} is ${chalk.italic.underline.blue(pingUrl)}.`)
-          }
+          const { data: { pingUrl, name } } = await api.heartbeatCheck.get(id as string)
+          this.log(`Ping URL of heartbeat check ${chalk.green(name)} is ${chalk.italic.underline.blue(pingUrl)}.`)
         })
       }
     } catch (err: any) {

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -123,7 +123,7 @@ export default class Deploy extends AuthCommand {
           .map(check => check?.physicalId)
 
         heartbeatCheckIds.forEach(async (id) => {
-          if (id) {
+          if (id && typeof id === 'string') {
             const { data: { pingUrl, name } } = await api.heartbeatCheck.get(id)
             this.log(`Ping URL of heartbeat check ${chalk.green(name)} is ${chalk.italic.underline.blue(pingUrl)}.`)
           }

--- a/packages/cli/src/constructs/project.ts
+++ b/packages/cli/src/constructs/project.ts
@@ -111,6 +111,13 @@ export class Project extends Construct {
           .filter((construct: Construct) => construct instanceof Check && construct.testOnly))
   }
 
+  getHeartbeatLogicalIds (): string[] {
+    return Object
+      .values(this.data.check)
+      .filter((construct: Construct) => construct instanceof Check && construct.constructor.name === 'HeartbeatCheck')
+      .map((construct: Check) => construct.logicalId)
+  }
+
   private synthesizeRecord (record: Record<string,
     Check|CheckGroup|AlertChannel|AlertChannelSubscription|MaintenanceWindow|Dashboard|
     PrivateLocation|PrivateLocationCheckAssignment|PrivateLocationGroupAssignment>, addTestOnly = true) {

--- a/packages/cli/src/constructs/project.ts
+++ b/packages/cli/src/constructs/project.ts
@@ -6,7 +6,7 @@ import { ValidationError } from './validator-error'
 import type { Runtime } from '../rest/runtimes'
 import {
   Check, AlertChannelSubscription, AlertChannel, CheckGroup, MaintenanceWindow, Dashboard,
-  PrivateLocation, PrivateLocationCheckAssignment, PrivateLocationGroupAssignment,
+  PrivateLocation, HeartbeatCheck, PrivateLocationCheckAssignment, PrivateLocationGroupAssignment,
 } from './'
 import { ResourceSync } from '../rest/projects'
 import { PrivateLocationApi } from '../rest/private-locations'
@@ -114,7 +114,7 @@ export class Project extends Construct {
   getHeartbeatLogicalIds (): string[] {
     return Object
       .values(this.data.check)
-      .filter((construct: Construct) => construct instanceof Check && construct.constructor.name === 'HeartbeatCheck')
+      .filter((construct: Construct) => construct instanceof HeartbeatCheck)
       .map((construct: Check) => construct.logicalId)
   }
 

--- a/packages/cli/src/rest/api.ts
+++ b/packages/cli/src/rest/api.ts
@@ -10,6 +10,7 @@ import PrivateLocations from './private-locations'
 import Locations from './locations'
 import TestSessions from './test-sessions'
 import EnvironmentVariables from './environment-variables'
+import HeartbeatChecks from './heartbeat-checks'
 
 export function getDefaults () {
   const apiKey = config.getApiKey()
@@ -76,3 +77,4 @@ export const locations = new Locations(api)
 export const privateLocations = new PrivateLocations(api)
 export const testSessions = new TestSessions(api)
 export const environmentVariables = new EnvironmentVariables(api)
+export const heartbeatCheck = new HeartbeatChecks(api)

--- a/packages/cli/src/rest/heartbeat-checks.ts
+++ b/packages/cli/src/rest/heartbeat-checks.ts
@@ -1,0 +1,24 @@
+import type { AxiosInstance } from 'axios'
+
+export interface HeartbeatCheck {
+  pingUrl: string
+  name: string
+}
+
+class HeartbeatChecks {
+  api: AxiosInstance
+  constructor (api: AxiosInstance) {
+    this.api = api
+  }
+
+  get (id: string) {
+    return this.api.get<HeartbeatCheck>(`/v1/checks/${id}`, {
+      transformResponse: (data: any) => {
+        const { heartbeat: { pingUrl }, name } = JSON.parse(data)
+        return { pingUrl, name }
+      },
+    })
+  }
+}
+
+export default HeartbeatChecks

--- a/packages/cli/src/rest/projects.ts
+++ b/packages/cli/src/rest/projects.ts
@@ -11,7 +11,7 @@ type ProjectResponse = Project & { id: string, created_at: string }
 
 export interface Change {
   logicalId: string,
-  physicalId?: string,
+  physicalId?: string|number,
   checkId?: string,
   type: string,
   action: string

--- a/packages/cli/src/rest/projects.ts
+++ b/packages/cli/src/rest/projects.ts
@@ -12,6 +12,7 @@ type ProjectResponse = Project & { id: string, created_at: string }
 export interface Change {
   logicalId: string,
   physicalId?: string,
+  checkId?: string,
   type: string,
   action: string
 }

--- a/packages/cli/src/rest/projects.ts
+++ b/packages/cli/src/rest/projects.ts
@@ -12,7 +12,6 @@ type ProjectResponse = Project & { id: string, created_at: string }
 export interface Change {
   logicalId: string,
   physicalId?: string|number,
-  checkId?: string,
   type: string,
   action: string
 }


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->
When creating or updating heartbeat checks from `npx checkly deploy`, we want to print in the console the ping URL of each heartbeat check.
iTerm2:
![image](https://github.com/checkly/checkly-cli/assets/25155364/2a112bd0-1f69-4891-805e-173aa13b9272)

Terminal with default theme:
![image](https://github.com/checkly/checkly-cli/assets/25155364/9b6b7614-7053-46b7-8458-f55c47c07c91)

Note: needs [deploy response adjustment PR](https://github.com/checkly/checkly-backend/pull/4593) on the BE when testing.