### PR TITLE
fix: use ipv4 for local setup

### DIFF
--- a/packages/cli/src/services/config.ts
+++ b/packages/cli/src/services/config.ts
@@ -79,7 +79,7 @@ class ChecklyConfig {
 
   getApiUrl (): string {
     const environments = {
-      local: 'http://localhost:3000',
+      local: 'http://127.0.0.1:3000',
       development: 'https://api-dev.checklyhq.com',
       staging: 'https://api-test.checklyhq.com',
       production: 'https://api.checklyhq.com',


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
On Mac, I receive the following error when running the CLI with `CHECKLY_ENV=local`:
```
 Error: Encountered an error connecting to Checkly. Please check that the internet connection is working. connect ECONNREFUSED ::1:3000
```

The CLI tries to connect to the IPv6 loopback address. The local setup isn't bound to the IPv6 interface, though, so this fails. To fix the issue, we can make sure that the CLI always uses the IPv4 address.