### PR TITLE
chore: add test-session link on github reporter [gh-822]

### DIFF
--- a/packages/cli/e2e/__tests__/test.spec.ts
+++ b/packages/cli/e2e/__tests__/test.spec.ts
@@ -113,14 +113,14 @@ describe('test', () => {
     expect(result.status).toBe(0)
   })
 
-  it('Should use Github reporter', async () => {
+  it('Should use Github reporter and show test-session link', async () => {
     const reportFilename = './reports/checkly-summary.md'
     try {
       fs.unlinkSync(reportFilename)
     } catch {
     }
     const result = await runChecklyCli({
-      args: ['test', '--reporter', 'github'],
+      args: ['test', '--record', '--reporter', 'github'],
       apiKey: config.get('apiKey'),
       accountId: config.get('accountId'),
       directory: path.join(__dirname, 'fixtures', 'test-project'),
@@ -128,6 +128,8 @@ describe('test', () => {
       timeout: 120000, // 2 minutes
     })
     expect(result.stdout).toContain('Github summary saved in')
+    expect(result.stdout).toContain('Detailed session summary at')
+    expect(result.stdout).toContain('https://chkly.link/l')
     expect(fs.existsSync(path.join(__dirname, 'fixtures', 'test-project', reportFilename))).toBe(true)
     expect(result.status).toBe(0)
   })

--- a/packages/cli/src/reporters/github.ts
+++ b/packages/cli/src/reporters/github.ts
@@ -101,7 +101,7 @@ export default class GithubReporter extends AbstractListReporter {
     printLn(`Running ${this.numChecks} checks in ${this._runLocationString()}.`, 2, 1)
   }
 
-  onEnd () {
+  async onEnd () {
     this._printBriefSummary()
     const githubMdBuilder = new GithubMdBuilder({
       testSessionId: this.testSessionId,
@@ -117,5 +117,7 @@ export default class GithubReporter extends AbstractListReporter {
     fs.writeFileSync(summaryFilename, markDown)
 
     printLn(`Github summary saved in '${path.resolve(summaryFilename)}'.`, 2)
+
+    await this._printTestSessionsUrl()
   }
 }

--- a/packages/cli/src/reporters/github.ts
+++ b/packages/cli/src/reporters/github.ts
@@ -101,7 +101,7 @@ export default class GithubReporter extends AbstractListReporter {
     printLn(`Running ${this.numChecks} checks in ${this._runLocationString()}.`, 2, 1)
   }
 
-  async onEnd () {
+  onEnd () {
     this._printBriefSummary()
     const githubMdBuilder = new GithubMdBuilder({
       testSessionId: this.testSessionId,
@@ -118,6 +118,6 @@ export default class GithubReporter extends AbstractListReporter {
 
     printLn(`Github summary saved in '${path.resolve(summaryFilename)}'.`, 2)
 
-    await this._printTestSessionsUrl()
+    this._printTestSessionsUrl()
   }
 }


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [x] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
This PR adds test-session link (if the `--record` flag is set) when using `--reporter=github`.

![image](https://github.com/checkly/checkly-cli/assets/5315705/ab57364f-c6b2-4ba8-917d-417fa3d416b4)


<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #822

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
