### PR TITLE
fix(heartbeats): addSubscriptions to alert channels [sc-17522]

### DIFF
--- a/packages/cli/src/constructs/heartbeat-check.ts
+++ b/packages/cli/src/constructs/heartbeat-check.ts
@@ -80,6 +80,7 @@ export class HeartbeatCheck extends Check {
     }
 
     Session.registerConstruct(this)
+    this.addSubscriptions()
   }
 
   synthesize (): any | null {


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
`addSubscription` is needed to register all the alert channels connected to a heartbeat