### PR TITLE
chore: adds CI name as header to API

### DIFF
--- a/packages/cli/src/rest/api.ts
+++ b/packages/cli/src/rest/api.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance, InternalAxiosRequestConfig } from 'axios'
+import { name as CIname } from 'ci-info'
 import config from '../services/config'
 import { assignProxy } from '../services/util'
 import Accounts from './accounts'
@@ -55,6 +56,8 @@ export function requestInterceptor (config: InternalAxiosRequestConfig) {
   if (accountId && config.headers) {
     config.headers['x-checkly-account'] = accountId
   }
+
+  config.headers['x-checkly-ci-name'] = CIname
 
   return config
 }


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

## Notes for the Reviewer
Adds a header with the CI name if available. This helps us determine which CI systems are mostly used so we can have better docs and integration support.