### PR TITLE
feat: deprecate doubleCheck property

### DIFF
--- a/packages/cli/src/constructs/check-group.ts
+++ b/packages/cli/src/constructs/check-group.ts
@@ -49,6 +49,7 @@ export interface CheckGroupProps {
   /**
    * Setting this to "true" will trigger a retry when a check fails from the failing region and another,
    * randomly selected region before marking the check as failed.
+   * @deprecated Use {@link CheckGroupProps.retryStrategy} instead.
    */
   doubleCheck?: boolean
   /**

--- a/packages/cli/src/constructs/check.ts
+++ b/packages/cli/src/constructs/check.ts
@@ -28,6 +28,7 @@ export interface CheckProps {
   /**
    * Setting this to "true" will trigger a retry when a check fails from the failing region and another,
    * randomly selected region before marking the check as failed.
+   * @deprecated Use {@link CheckProps.retryStrategy} instead.
    */
   doubleCheck?: boolean
   /**


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
The `doubleCheck` property for checks and groups is being replaced with `retryStrategy`, which allows for more flexibility in specifying how to retry failed check runs. This PR marks the `doubleCheck` property as deprecated so that users can begin migrating.

I also verified that `doubleCheck` isn't used in any of the examples.

![Screenshot 2023-08-31 at 14 21 33](https://github.com/checkly/checkly-cli/assets/10483186/94d28b48-660a-4d93-a047-d8370ab5bd15)

