### PR TITLE
feat: add retryStrategy to the advanced examples

### DIFF
--- a/examples/advanced-project-js/checkly.config.js
+++ b/examples/advanced-project-js/checkly.config.js
@@ -1,4 +1,5 @@
 const { defineConfig } = require('checkly');
+const { RetryStrategyBuilder } = require('checkly/constructs');
 
 /**
  * See https://www.checklyhq.com/docs/cli/project-structure/
@@ -24,6 +25,8 @@ const config = defineConfig({
      * See https://www.checklyhq.com/docs/cli/npm-packages/
      */
     runtimeId: '2023.02',
+    /* Failed check runs will be retried before triggering alerts */
+    retryStrategy: RetryStrategyBuilder.fixedStrategy({ baseBackoffSeconds: 60, maxAttempts: 4, sameRegion: true }),
     /* A glob pattern that matches the Checks inside your repo, see https://www.checklyhq.com/docs/cli/using-check-test-match/ */
     checkMatch: '**/__checks__/**/*.check.js',
     browserChecks: {

--- a/examples/advanced-project-js/src/__checks__/website-group.check.js
+++ b/examples/advanced-project-js/src/__checks__/website-group.check.js
@@ -1,4 +1,4 @@
-const { CheckGroup } = require('checkly/constructs');
+const { CheckGroup, RetryStrategyBuilder } = require('checkly/constructs');
 const { smsChannel, emailChannel } = require('../alert-channels');
 const alertChannels = [smsChannel, emailChannel];
 /*
@@ -24,6 +24,11 @@ const websiteGroup = new CheckGroup('website-check-group-1', {
   apiCheckDefaults: {},
   concurrency: 100,
   alertChannels,
+  /*
+   * Failed check runs in this group will be retried before triggering alerts.
+   * The wait time between retries will increase linearly: 30 seconds, 60 seconds, and then 90 seconds between the retries.
+   */
+  retryStrategy: RetryStrategyBuilder.linearStrategy({ baseBackoffSeconds: 30, maxAttempts: 3, sameRegion: false }),
 });
 
-module.exports = websiteGroup;
+module.exports = { websiteGroup };

--- a/examples/advanced-project/checkly.config.ts
+++ b/examples/advanced-project/checkly.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'checkly'
+import { RetryStrategyBuilder } from 'checkly/constructs'
 
 /**
  * See https://www.checklyhq.com/docs/cli/project-structure/
@@ -24,6 +25,8 @@ const config = defineConfig({
      * See https://www.checklyhq.com/docs/cli/npm-packages/
      */
     runtimeId: '2023.02',
+    /* Failed check runs will be retried before triggering alerts */
+    retryStrategy: RetryStrategyBuilder.fixedStrategy({ baseBackoffSeconds: 60, maxAttempts: 4, sameRegion: true }),
     /* A glob pattern that matches the Checks inside your repo, see https://www.checklyhq.com/docs/cli/using-check-test-match/ */
     checkMatch: '**/__checks__/**/*.check.ts',
     browserChecks: {

--- a/examples/advanced-project/src/__checks__/website-group.check.ts
+++ b/examples/advanced-project/src/__checks__/website-group.check.ts
@@ -1,4 +1,4 @@
-import { CheckGroup } from 'checkly/constructs'
+import { CheckGroup, RetryStrategyBuilder } from 'checkly/constructs'
 import { smsChannel, emailChannel } from '../alert-channels'
 const alertChannels = [smsChannel, emailChannel]
 /*
@@ -24,4 +24,9 @@ export const websiteGroup = new CheckGroup('website-check-group-1', {
   apiCheckDefaults: {},
   concurrency: 100,
   alertChannels,
+  /*
+   * Failed check runs in this group will be retried before triggering alerts.
+   * The wait time between retries will increase linearly: 30 seconds, 60 seconds, and then 90 seconds between the retries.
+   */
+  retryStrategy: RetryStrategyBuilder.linearStrategy({ baseBackoffSeconds: 30, maxAttempts: 3, sameRegion: false }),
 })


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
This PR adds examples of the new `retryStrategy` property to the advanced examples. Since this isn't supported on deprecated plans, deprecated users will get errors when running the advanced example.