### PR TITLE
feat: allow no options for RetryStrategyBuilder

### DIFF
--- a/packages/cli/src/constructs/retry-strategy.ts
+++ b/packages/cli/src/constructs/retry-strategy.ts
@@ -31,7 +31,7 @@ export class RetryStrategyBuilder {
   /**
    * Each retry is run with the same backoff between attempts.
    */
-  static fixedStrategy (options: RetryStrategyOptions): RetryStrategy {
+  static fixedStrategy (options?: RetryStrategyOptions): RetryStrategy {
     return RetryStrategyBuilder.retryStrategy('FIXED', options)
   }
 
@@ -41,7 +41,7 @@ export class RetryStrategyBuilder {
    * The delay between retries is calculated using `baseBackoffSeconds * attempt`.
    * For example, retries will be run with a backoff of 10s, 20s, 30s, and so on.
    */
-  static linearStrategy (options: RetryStrategyOptions): RetryStrategy {
+  static linearStrategy (options?: RetryStrategyOptions): RetryStrategy {
     return RetryStrategyBuilder.retryStrategy('LINEAR', options)
   }
 
@@ -51,17 +51,17 @@ export class RetryStrategyBuilder {
    * The delay between retries is calculated using `baseBackoffSeconds ^ attempt`.
    * For example, retries will be run with a backoff of 10s, 100s, 1000s, and so on.
    */
-  static exponentialStrategy (options: RetryStrategyOptions): RetryStrategy {
+  static exponentialStrategy (options?: RetryStrategyOptions): RetryStrategy {
     return RetryStrategyBuilder.retryStrategy('EXPONENTIAL', options)
   }
 
-  private static retryStrategy (type: RetryStrategyType, options: RetryStrategyOptions): RetryStrategy {
+  private static retryStrategy (type: RetryStrategyType, options?: RetryStrategyOptions): RetryStrategy {
     return {
       type,
-      baseBackoffSeconds: options.baseBackoffSeconds ?? RetryStrategyBuilder.DEFAULT_BASE_BACKOFF_SECONDS,
-      maxRetries: options.maxRetries ?? RetryStrategyBuilder.DEFAULT_MAX_RETRIES,
-      maxDurationSeconds: options.maxDurationSeconds ?? RetryStrategyBuilder.DEFAULT_MAX_DURATION_SECONDS,
-      sameRegion: options.sameRegion ?? RetryStrategyBuilder.DEFAULT_SAME_REGION,
+      baseBackoffSeconds: options?.baseBackoffSeconds ?? RetryStrategyBuilder.DEFAULT_BASE_BACKOFF_SECONDS,
+      maxRetries: options?.maxRetries ?? RetryStrategyBuilder.DEFAULT_MAX_RETRIES,
+      maxDurationSeconds: options?.maxDurationSeconds ?? RetryStrategyBuilder.DEFAULT_MAX_DURATION_SECONDS,
+      sameRegion: options?.sameRegion ?? RetryStrategyBuilder.DEFAULT_SAME_REGION,
     }
   }
 }


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [ ] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
This PR updates the `RetryStrategyBuilder` to handle no `options` argument being passed. Since we already have default values for all options, the `options` argument isn't required. To improve the UX, we can update the types accordingly. Now it's possible to simply do `RetryStrategyBuilder.fixedStrategy()`.