### PR TITLE
fix(frequency): fix typo to handle `EVERY_3H` frequency [sc-00]

### DIFF
--- a/packages/cli/src/constructs/frequency.ts
+++ b/packages/cli/src/constructs/frequency.ts
@@ -12,7 +12,7 @@ export class Frequency {
 
   static EVERY_1H = new Frequency(1 * 60)
   static EVERY_2H = new Frequency(2 * 60)
-  static EVERY_3M = new Frequency(3 * 60)
+  static EVERY_3H = new Frequency(3 * 60)
   static EVERY_6H = new Frequency(6 * 60)
   static EVERY_12H = new Frequency(12 * 60)
   static EVERY_24H = new Frequency(24 * 60)


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->
When setting the check frequency, we don't allow `EVERY_3M`, instead we should allow `EVERY_3H` which is currently missing.