### PR TITLE
feat: fetch checkRunSuiteId from backend

### DIFF
--- a/packages/cli/src/rest/test-sessions.ts
+++ b/packages/cli/src/rest/test-sessions.ts
@@ -52,7 +52,7 @@ class TestSessions {
   }
 
   getCheckRunSuiteId () {
-    return this.api.get<{checkRunSuiteId: string}>('/next/test-sessions/checkRunSuiteId')
+    return this.api.get<{checkRunSuiteId: string}>('/next/test-sessions/check-run-suite-id')
   }
 }
 

--- a/packages/cli/src/rest/test-sessions.ts
+++ b/packages/cli/src/rest/test-sessions.ts
@@ -50,6 +50,10 @@ class TestSessions {
   getResultShortLinks (testSessionId: string, testResultId: string) {
     return this.api.get<TestResultsShortLinks>(`/next/test-sessions/${testSessionId}/results/${testResultId}/links`)
   }
+
+  getCheckRunSuiteId () {
+    return this.api.get<{checkRunSuiteId: string}>('/next/test-sessions/checkRunSuiteId')
+  }
 }
 
 export default TestSessions

--- a/packages/cli/src/services/abstract-check-runner.ts
+++ b/packages/cli/src/services/abstract-check-runner.ts
@@ -74,7 +74,7 @@ export default abstract class AbstractCheckRunner extends EventEmitter {
     try {
       socketClient = await SocketClient.connect()
 
-      const checkRunSuiteId = uuid.v4()
+      const { data: { checkRunSuiteId } } = await testSessions.getCheckRunSuiteId()
       // Configure the socket listener and allChecksFinished listener before starting checks to avoid race conditions
       await this.configureResultListener(checkRunSuiteId, socketClient)
 


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

## Notes for the Reviewer

- We need to fetch the check run ID from our backend to listen to the run-end socket event to know how many API calls were made during the run.