### PR TITLE
feat: add alpha support for PWT snapshot testing

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -55,12 +55,25 @@ export default class Deploy extends AuthCommand {
       char: 'c',
       description: commonMessages.configFile,
     }),
+    'update-snapshots': Flags.boolean({
+      description: 'Update any snapshots using the actual result of this test run.',
+      default: false,
+      // Mark --update-snapshots as hidden until we're ready for GA
+      hidden: true,
+    }),
   }
 
   async run (): Promise<void> {
     ux.action.start('Parsing your project', undefined, { stdout: true })
     const { flags } = await this.parse(Deploy)
-    const { force, preview, 'schedule-on-deploy': scheduleOnDeploy, output, config: configFilename } = flags
+    const {
+      force,
+      preview,
+      'schedule-on-deploy': scheduleOnDeploy,
+      output,
+      config: configFilename,
+      'update-snapshots': updateSnapshots,
+    } = flags
     const { configDirectory, configFilenames } = splitConfigFilePath(configFilename)
     const {
       config: checklyConfig,
@@ -86,7 +99,7 @@ export default class Deploy extends AuthCommand {
     const repoInfo = getGitInformation(project.repoUrl)
     ux.action.stop()
 
-    if (!preview) {
+    if (!preview && updateSnapshots) {
       for (const check of Object.values(project.data.check)) {
         if (!(check instanceof BrowserCheck)) {
           continue

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -10,12 +10,13 @@ import type { Runtime } from '../rest/runtimes'
 import {
   Check, AlertChannelSubscription, AlertChannel, CheckGroup, Dashboard,
   MaintenanceWindow, PrivateLocation, PrivateLocationCheckAssignment, PrivateLocationGroupAssignment,
-  Project, ProjectData,
+  Project, ProjectData, BrowserCheck,
 } from '../constructs'
 import chalk from 'chalk'
 import { splitConfigFilePath, getGitInformation } from '../services/util'
 import commonMessages from '../messages/common-messages'
 import { ProjectDeployResponse } from '../rest/projects'
+import { uploadSnapshots } from '../services/snapshot-service'
 
 // eslint-disable-next-line no-restricted-syntax
 enum ResourceDeployStatus {
@@ -84,6 +85,10 @@ export default class Deploy extends AuthCommand {
     })
     const repoInfo = getGitInformation(project.repoUrl)
     ux.action.stop()
+
+    if (!preview) {
+      await uploadSnapshots(project)
+    }
 
     const projectPayload = project.synthesize(false)
     if (!projectPayload.resources.length) {

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -87,7 +87,12 @@ export default class Deploy extends AuthCommand {
     ux.action.stop()
 
     if (!preview) {
-      await uploadSnapshots(project)
+      for (const check of Object.values(project.data.check)) {
+        if (!(check instanceof BrowserCheck)) {
+          continue
+        }
+        check.snapshots = await uploadSnapshots(check.rawSnapshots)
+      }
     }
 
     const projectPayload = project.synthesize(false)

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -56,6 +56,7 @@ export default class Deploy extends AuthCommand {
       description: commonMessages.configFile,
     }),
     'update-snapshots': Flags.boolean({
+      char: 'u',
       description: 'Update any snapshots using the actual result of this test run.',
       default: false,
       // Mark --update-snapshots as hidden until we're ready for GA

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -95,6 +95,7 @@ export default class Test extends AuthCommand {
       description: 'A name to use when storing results in Checkly with --record.',
     }),
     'update-snapshots': Flags.boolean({
+      char: 'u',
       description: 'Update any snapshots using the actual result of this test run.',
       default: false,
       // Mark --update-snapshots as hidden until we're ready for GA

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -98,6 +98,8 @@ export default class Test extends AuthCommand {
     'update-snapshots': Flags.boolean({
       description: 'Update any snapshots using the actual result of this test run.',
       default: false,
+      // Mark --update-snapshots as hidden until we're ready for GA
+      hidden: true,
     }),
   }
 

--- a/packages/cli/src/constructs/__tests__/browser-check.spec.ts
+++ b/packages/cli/src/constructs/__tests__/browser-check.spec.ts
@@ -15,7 +15,7 @@ describe('BrowserCheck', () => {
     const bundle = BrowserCheck.bundle(getFilePath('entrypoint.js'), '2022.10')
     delete Session.basePath
 
-    expect(bundle).toEqual({
+    expect(bundle).toMatchObject({
       script: fs.readFileSync(getFilePath('entrypoint.js')).toString(),
       scriptPath: 'fixtures/browser-check/entrypoint.js',
       dependencies: [

--- a/packages/cli/src/constructs/browser-check.ts
+++ b/packages/cli/src/constructs/browser-check.ts
@@ -5,7 +5,7 @@ import { Parser } from '../services/check-parser/parser'
 import { CheckConfigDefaults } from '../services/checkly-config-loader'
 import { pathToPosix } from '../services/util'
 import { Content, Entrypoint } from './construct'
-import { detectSnapshots } from '../services/snapshot-service'
+import { detectSnapshots, Snapshot } from '../services/snapshot-service'
 
 export interface CheckDependency {
   path: string
@@ -41,7 +41,7 @@ export class BrowserCheck extends Check {
   // For snapshots, we first store `rawSnapshots` with the path to the file.
   // The `snapshots` field is set later (with a `key`) after these are uploaded to storage.
   rawSnapshots?: Array<{ absolutePath: string, path: string }>
-  snapshots?: Array<{ path: string, key: string }>
+  snapshots?: Array<Snapshot>
 
   /**
    * Constructs the Browser Check instance

--- a/packages/cli/src/rest/api.ts
+++ b/packages/cli/src/rest/api.ts
@@ -12,6 +12,7 @@ import Locations from './locations'
 import TestSessions from './test-sessions'
 import EnvironmentVariables from './environment-variables'
 import HeartbeatChecks from './heartbeat-checks'
+import ChecklyStorage from './checkly-storage'
 
 export function getDefaults () {
   const apiKey = config.getApiKey()
@@ -98,3 +99,4 @@ export const privateLocations = new PrivateLocations(api)
 export const testSessions = new TestSessions(api)
 export const environmentVariables = new EnvironmentVariables(api)
 export const heartbeatCheck = new HeartbeatChecks(api)
+export const checklyStorage = new ChecklyStorage(api)

--- a/packages/cli/src/rest/checkly-storage.ts
+++ b/packages/cli/src/rest/checkly-storage.ts
@@ -6,9 +6,14 @@ class ChecklyStorage {
     this.api = api
   }
 
-  getPresignedUrls (keys: string[]) {
+  getSignedUrls (keys: string[]) {
     const data = keys.map(key => ({ key }))
     return this.api.post<Array<{ signedUrl: string, key: string }>>('/next/checkly-storage/signed-urls', data)
+  }
+
+  getSignedUploadUrls (paths: string[]) {
+    const data = paths.map(path => ({ path }))
+    return this.api.post<Array<{ signedUrl: string, key: string, path: string }>>('/next/checkly-storage/signed-upload-urls', data)
   }
 }
 

--- a/packages/cli/src/rest/checkly-storage.ts
+++ b/packages/cli/src/rest/checkly-storage.ts
@@ -1,0 +1,15 @@
+import type { AxiosInstance } from 'axios'
+
+class ChecklyStorage {
+  api: AxiosInstance
+  constructor (api: AxiosInstance) {
+    this.api = api
+  }
+
+  getPresignedUrls (keys: string[]) {
+    const data = keys.map(key => ({ key }))
+    return this.api.post<Array<{ signedUrl: string, key: string }>>('/next/checkly-storage/signed-urls', data)
+  }
+}
+
+export default ChecklyStorage

--- a/packages/cli/src/rest/checkly-storage.ts
+++ b/packages/cli/src/rest/checkly-storage.ts
@@ -1,4 +1,5 @@
 import type { AxiosInstance } from 'axios'
+import type { Readable } from 'node:stream'
 
 class ChecklyStorage {
   api: AxiosInstance
@@ -6,14 +7,16 @@ class ChecklyStorage {
     this.api = api
   }
 
-  getSignedUrls (keys: string[]) {
-    const data = keys.map(key => ({ key }))
-    return this.api.post<Array<{ signedUrl: string, key: string }>>('/next/checkly-storage/signed-urls', data)
+  upload (contentLength: number, stream: Readable) {
+    return this.api.post<{ key: string }>(
+      '/next/checkly-storage/upload',
+      stream,
+      { headers: { 'Content-Type': 'application/octet-stream', 'Content-Length': contentLength } },
+    )
   }
 
-  getSignedUploadUrls (paths: string[]) {
-    const data = paths.map(path => ({ path }))
-    return this.api.post<Array<{ signedUrl: string, key: string, path: string }>>('/next/checkly-storage/signed-upload-urls', data)
+  download (key: string) {
+    return this.api.post('/next/checkly-storage/download', { key }, { responseType: 'stream' })
   }
 }
 

--- a/packages/cli/src/rest/checkly-storage.ts
+++ b/packages/cli/src/rest/checkly-storage.ts
@@ -7,11 +7,11 @@ class ChecklyStorage {
     this.api = api
   }
 
-  upload (contentLength: number, stream: Readable) {
+  upload (stream: Readable) {
     return this.api.post<{ key: string }>(
       '/next/checkly-storage/upload',
       stream,
-      { headers: { 'Content-Type': 'application/octet-stream', 'Content-Length': contentLength } },
+      { headers: { 'Content-Type': 'application/octet-stream' } },
     )
   }
 

--- a/packages/cli/src/services/abstract-check-runner.ts
+++ b/packages/cli/src/services/abstract-check-runner.ts
@@ -54,7 +54,7 @@ export default abstract class AbstractCheckRunner extends EventEmitter {
     timeout: number,
     verbose: boolean,
   ) {
-    super({ captureRejections: true })
+    super()
     this.checks = new Map()
     this.timeouts = new Map()
     this.queue = new PQueue({ autoStart: false, concurrency: 1 })

--- a/packages/cli/src/services/abstract-check-runner.ts
+++ b/packages/cli/src/services/abstract-check-runner.ts
@@ -141,26 +141,28 @@ export default abstract class AbstractCheckRunner extends EventEmitter {
     } else if (subtopic === 'run-end') {
       this.disableTimeout(checkRunId)
       const { result } = message
-      const {
-        region,
-        logPath,
-        checkRunDataPath,
-      } = result.assets
-      if (logPath && (this.verbose || result.hasFailures)) {
-        result.logs = await assets.getLogs(region, logPath)
-      }
-      if (checkRunDataPath && (this.verbose || result.hasFailures)) {
-        result.checkRunData = await assets.getCheckRunData(region, checkRunDataPath)
-      }
-
+      await this.processCheckResult(result)
       const links = testResultId && result.hasFailures && await this.getShortLinks(testResultId)
-
       this.emit(Events.CHECK_SUCCESSFUL, checkRunId, check, result, links)
       this.emit(Events.CHECK_FINISHED, check)
     } else if (subtopic === 'error') {
       this.disableTimeout(checkRunId)
       this.emit(Events.CHECK_FAILED, checkRunId, check, message)
       this.emit(Events.CHECK_FINISHED, check)
+    }
+  }
+
+  async processCheckResult (result: any) {
+    const {
+      region,
+      logPath,
+      checkRunDataPath,
+    } = result.assets
+    if (logPath && (this.verbose || result.hasFailures)) {
+      result.logs = await assets.getLogs(region, logPath)
+    }
+    if (checkRunDataPath && (this.verbose || result.hasFailures)) {
+      result.checkRunData = await assets.getCheckRunData(region, checkRunDataPath)
     }
   }
 

--- a/packages/cli/src/services/abstract-check-runner.ts
+++ b/packages/cli/src/services/abstract-check-runner.ts
@@ -54,7 +54,7 @@ export default abstract class AbstractCheckRunner extends EventEmitter {
     timeout: number,
     verbose: boolean,
   ) {
-    super()
+    super({ captureRejections: true })
     this.checks = new Map()
     this.timeouts = new Map()
     this.queue = new PQueue({ autoStart: false, concurrency: 1 })

--- a/packages/cli/src/services/snapshot-service.ts
+++ b/packages/cli/src/services/snapshot-service.ts
@@ -2,13 +2,9 @@ import * as fsAsync from 'node:fs/promises'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import * as stream from 'node:stream/promises'
-import * as https from 'node:https'
-import axios from 'axios'
 
 import { checklyStorage } from '../rest/api'
 import { findFilesRecursively, pathToPosix } from './util'
-import { BrowserCheck } from '../constructs'
-import type { Project } from '../constructs'
 
 export interface Snapshot {
   key: string,
@@ -20,54 +16,22 @@ export async function pullSnapshots (basePath: string, snapshots?: Snapshot[] | 
     return
   }
 
-  let signedUrls
   try {
-    ({ data: signedUrls } = await checklyStorage.getSignedUrls(snapshots.map(({ key }) => key)))
+    for (const snapshot of snapshots) {
+      const fullPath = path.resolve(basePath, snapshot.path)
+      if (!fullPath.startsWith(basePath)) {
+        // The snapshot file should always be within the project, but we validate this just in case.
+        throw new Error(`Detected invalid snapshot file ${fullPath}`)
+      }
+      await fsAsync.mkdir(path.dirname(fullPath), { recursive: true })
+      const fileStream = fs.createWriteStream(fullPath)
+      const { data: contentStream } = await checklyStorage.download(snapshot.key)
+      contentStream.pipe(fileStream)
+      await stream.finished(contentStream)
+    }
   } catch (err: any) {
-    throw new Error(`Error getting signed URLs for snapshots: ${err.message}`)
+    throw new Error(`Error downloading snapshots: ${err.message}`)
   }
-
-  const signedUrlsByKey: Map<string, string> = signedUrls!.reduce((acc, entry) => {
-    acc.set(entry.key, entry.signedUrl)
-    return acc
-  }, new Map())
-
-  await Promise.all(snapshots.map(async snapshot => {
-    const signedUrl = signedUrlsByKey.get(snapshot.key)
-    if (!signedUrl) {
-      throw new Error(`Unexpected error fetching signed URL for snapshot ${snapshot.key}`)
-    }
-
-    const fullPath = path.resolve(basePath, snapshot.path)
-    if (!fullPath.startsWith(basePath)) {
-      // The snapshot file should always be within the project, but we validate this just in case.
-      throw new Error(`Detected invalid snapshot file ${fullPath}`)
-    }
-
-    // We write the file as a stream to use less memory
-    let snapshotStream
-    try {
-      // TODO: Add support for proxies
-      ({ data: snapshotStream } = await axios.get(signedUrl, { responseType: 'stream' }))
-    } catch (err: any) {
-      throw new Error(`Error fetching snapshot: ${err.message}`)
-    }
-
-    await fsAsync.mkdir(path.dirname(fullPath), { recursive: true })
-    const fileStream = fs.createWriteStream(fullPath)
-    try {
-      snapshotStream.pipe(fileStream)
-      await stream.finished(snapshotStream)
-    } catch (err: any) {
-      // See https://nodejs.org/api/stream.html#readablepipedestination-options
-      // and https://nodejs.org/docs/latest-v16.x/api/fs.html#filehandlecreatewritestreamoptions
-      // If contentStream emits an error then fileStream is not closed automatically.
-      // Destroying the stream will close the underlying file descriptor.
-      // Probably doesn't matter since the CLI will exit, but can't hurt to clean up.
-      fileStream.destroy()
-      throw new Error(`Error writing snapshots to a file: ${err.message}`)
-    }
-  }))
 }
 
 export function detectSnapshots (projectBasePath: string, scriptFilePath: string) {
@@ -81,49 +45,21 @@ export function detectSnapshots (projectBasePath: string, scriptFilePath: string
   }))
 }
 
-export async function uploadSnapshots (project: Project) {
-  // TODO: Processing the whole project at ocne let's us reuse an httpsAgent and make a single
-  // request to get the signed upload URL's.
-  // Having this method just process a single check would probably be much more clear, though.
-  // Are there actual performance gains, or should we rewrite it?
-  const snapshotFiles = Object.values(project.data.check).flatMap(check => {
-    if (!(check instanceof BrowserCheck)) {
-      return []
-    }
-    return check.rawSnapshots?.map(({ path }) => path) ?? []
-  })
-
-  if (!snapshotFiles.length) {
+export async function uploadSnapshots (rawSnapshots?: Array<{ absolutePath: string, path: string }>) {
+  if (!rawSnapshots?.length) {
     return []
   }
 
-  const { data: signedUploadUrls } = await checklyStorage.getSignedUploadUrls(snapshotFiles)
-  // Reusing a single https will save from having an SSL handshake with every file upload.
-  // Should improve performance somewhat (but haven't profiled this)
-  const httpsAgent = new https.Agent({ keepAlive: true })
-
-  for (const check of Object.values(project.data.check)) {
-    if (!(check instanceof BrowserCheck) || !check.rawSnapshots?.length) {
-      continue
+  try {
+    const snapshots: Array<Snapshot> = []
+    for (const rawSnapshot of rawSnapshots) {
+      const snapshotStream = fs.createReadStream(rawSnapshot.absolutePath)
+      const { size } = await fsAsync.stat(rawSnapshot.absolutePath)
+      const { data: { key } } = await checklyStorage.upload(size, snapshotStream)
+      snapshots.push({ key, path: rawSnapshot.path })
     }
-
-    const checkSnapshotsAbsolutePaths = check.rawSnapshots.reduce((acc, { absolutePath, path }) => {
-      acc.set(path, absolutePath)
-      return acc
-    }, new Map())
-
-    const processedSnapshots = []
-    for (const { signedUrl, key, path } of signedUploadUrls) {
-      const absolutePath = checkSnapshotsAbsolutePaths.get(path)
-      const { size } = await fsAsync.stat(absolutePath)
-      const snapshotStream = fs.createReadStream(absolutePath)
-      try {
-        await axios.put(signedUrl, snapshotStream, { httpsAgent, headers: { 'Content-Length': size } })
-      } catch (err: any) {
-        throw new Error(`Error pushing snapshot file to storage: ${err.message}`)
-      }
-      processedSnapshots.push({ key, path })
-    }
-    check.snapshots = processedSnapshots
+    return snapshots
+  } catch (err: any) {
+    throw new Error(`Error uploading snapshots: ${err.message}`)
   }
 }

--- a/packages/cli/src/services/snapshot-service.ts
+++ b/packages/cli/src/services/snapshot-service.ts
@@ -1,0 +1,67 @@
+import * as fsAsync from 'node:fs/promises'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as stream from 'node:stream/promises'
+import axios from 'axios'
+
+import { checklyStorage } from '../rest/api'
+
+export interface Snapshot {
+  key: string,
+  path: string,
+}
+
+export async function pullSnapshots (basePath: string, snapshots?: Snapshot[] | null) {
+  if (!snapshots?.length) {
+    return
+  }
+
+  let signedUrls
+  try {
+    ({ data: signedUrls } = await checklyStorage.getPresignedUrls(snapshots.map(({ key }) => key)))
+  } catch (err: any) {
+    throw new Error(`Error getting signed URLs for snapshots: ${err.message}`)
+  }
+
+  const signedUrlsByKey: Map<string, string> = signedUrls!.reduce((acc, entry) => {
+    acc.set(entry.key, entry.signedUrl)
+    return acc
+  }, new Map())
+
+  await Promise.all(snapshots.map(async snapshot => {
+    const signedUrl = signedUrlsByKey.get(snapshot.key)
+    if (!signedUrl) {
+      throw new Error(`Unexpected error fetching signed URL for snapshot ${snapshot.key}`)
+    }
+
+    const fullPath = path.resolve(basePath, snapshot.path)
+    if (!fullPath.startsWith(basePath)) {
+      // The snapshot file should always be within the project, but we validate this just in case.
+      throw new Error(`Detected invalid snapshot file ${fullPath}`)
+    }
+
+    // We write the file as a stream to use less memory
+    let snapshotStream
+    try {
+      // TODO: Add support for proxies
+      ({ data: snapshotStream } = await axios.get(signedUrl, { responseType: 'stream' }))
+    } catch (err: any) {
+      throw new Error(`Error fetching snapshot: ${err.message}`)
+    }
+
+    await fsAsync.mkdir(path.dirname(fullPath), { recursive: true })
+    const fileStream = fs.createWriteStream(fullPath)
+    try {
+      snapshotStream.pipe(fileStream)
+      await stream.finished(snapshotStream)
+    } catch (err: any) {
+      // See https://nodejs.org/api/stream.html#readablepipedestination-options
+      // and https://nodejs.org/docs/latest-v16.x/api/fs.html#filehandlecreatewritestreamoptions
+      // If contentStream emits an error then fileStream is not closed automatically.
+      // Destroying the stream will close the underlying file descriptor.
+      // Probably doesn't matter since the CLI will exit, but can't hurt to clean up.
+      fileStream.destroy()
+      throw new Error(`Error writing snapshots to a file: ${err.message}`)
+    }
+  }))
+}

--- a/packages/cli/src/services/snapshot-service.ts
+++ b/packages/cli/src/services/snapshot-service.ts
@@ -54,8 +54,7 @@ export async function uploadSnapshots (rawSnapshots?: Array<{ absolutePath: stri
     const snapshots: Array<Snapshot> = []
     for (const rawSnapshot of rawSnapshots) {
       const snapshotStream = fs.createReadStream(rawSnapshot.absolutePath)
-      const { size } = await fsAsync.stat(rawSnapshot.absolutePath)
-      const { data: { key } } = await checklyStorage.upload(size, snapshotStream)
+      const { data: { key } } = await checklyStorage.upload(snapshotStream)
       snapshots.push({ key, path: rawSnapshot.path })
     }
     return snapshots

--- a/packages/cli/src/services/test-runner.ts
+++ b/packages/cli/src/services/test-runner.ts
@@ -13,6 +13,7 @@ export default class TestRunner extends AbstractCheckRunner {
   shouldRecord: boolean
   repoInfo: GitInformation | null
   environment: string | null
+  updateSnapshots: boolean
   constructor (
     accountId: string,
     project: Project,
@@ -23,6 +24,7 @@ export default class TestRunner extends AbstractCheckRunner {
     shouldRecord: boolean,
     repoInfo: GitInformation | null,
     environment: string | null,
+    updateSnapshots: boolean,
   ) {
     super(accountId, timeout, verbose)
     this.project = project
@@ -31,6 +33,7 @@ export default class TestRunner extends AbstractCheckRunner {
     this.shouldRecord = shouldRecord
     this.repoInfo = repoInfo
     this.environment = environment
+    this.updateSnapshots = updateSnapshots
   }
 
   async scheduleChecks (
@@ -46,7 +49,7 @@ export default class TestRunner extends AbstractCheckRunner {
       ...check.synthesize(),
       group: check.groupId ? this.project.data['check-group'][check.groupId.ref].synthesize() : undefined,
       groupId: undefined,
-      sourceInfo: { checkRunSuiteId, checkRunId },
+      sourceInfo: { checkRunSuiteId, checkRunId, updateSnapshots: this.updateSnapshots },
       logicalId: check.logicalId,
       filePath: check.getSourceFile(),
     }))


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

## Notes for the Reviewer
This PR adds initial support for PWT snapshot testing in the CLI . `npx checkly test --update-snapshots` updates any snapshots using the actual result of this test run. `npx checkly deploy` can then be used to actually push the snapshots: it updates the snapshots used by the check on Checkly.

TODO:
* [ ] Update examples
* [ ] Add integration test

One limitation in the current implementation is that we push the files to storage with every `npx checkly deploy`. We could probably improve this by adding some change detection using hashing. Such an implementation would be more complicated, though, so maybe we save it for later.

Integration tests are failing since the backend hasn't been deployed with the new schema yet.
