### PR TITLE
chore(deps): bump axios to 1.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4854,9 +4854,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -16430,7 +16430,7 @@
         "acorn": "8.8.1",
         "acorn-walk": "8.2.0",
         "async-mqtt": "2.6.3",
-        "axios": "1.4.0",
+        "axios": "1.6.2",
         "chalk": "4.1.2",
         "ci-info": "3.8.0",
         "conf": "10.2.0",
@@ -16592,7 +16592,7 @@
         "@oclif/core": "2.8.11",
         "@oclif/plugin-help": "5.1.20",
         "@oclif/plugin-plugins": "2.3.0",
-        "axios": "1.4.0",
+        "axios": "1.6.2",
         "chalk": "4.1.2",
         "debug": "4.3.4",
         "execa": "5.1.0",
@@ -20182,9 +20182,9 @@
       }
     },
     "axios": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -20584,7 +20584,7 @@
         "acorn": "8.8.1",
         "acorn-walk": "8.2.0",
         "async-mqtt": "2.6.3",
-        "axios": "1.4.0",
+        "axios": "1.6.2",
         "chalk": "4.1.2",
         "ci-info": "3.8.0",
         "conf": "10.2.0",
@@ -21124,7 +21124,7 @@
         "@types/node": "20.3.3",
         "@types/prompts": "2.4.2",
         "@types/uuid": "9.0.1",
-        "axios": "1.4.0",
+        "axios": "1.6.2",
         "chalk": "4.1.2",
         "config": "3.3.8",
         "debug": "4.3.4",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -77,7 +77,7 @@
     "acorn": "8.8.1",
     "acorn-walk": "8.2.0",
     "async-mqtt": "2.6.3",
-    "axios": "1.4.0",
+    "axios": "1.6.2",
     "chalk": "4.1.2",
     "ci-info": "3.8.0",
     "conf": "10.2.0",

--- a/packages/create-cli/package.json
+++ b/packages/create-cli/package.json
@@ -42,7 +42,7 @@
     "@oclif/core": "2.8.11",
     "@oclif/plugin-help": "5.1.20",
     "@oclif/plugin-plugins": "2.3.0",
-    "axios": "1.4.0",
+    "axios": "1.6.2",
     "chalk": "4.1.2",
     "debug": "4.3.4",
     "execa": "5.1.0",


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [x] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer

This bumps `axios` to `1.6.2` to resolve [CVE-2023-45857](https://github.com/advisories/GHSA-wf5p-g6vw-rhxx)
