### PR TITLE
chore: validate tag format during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,20 @@ on:
   release:
     types: [published]
 jobs:
+  validate-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-ecosystem/action-regex-match@v2
+        id: tag-match
+        with:
+          text: ${{ github.event.release.tag_name }}
+          regex: '^\d+\.\d+\.\d+$'
+      - run: echo "Please create tag for release with format like 4.0.1" && exit 1
+        if: ${{ steps.tag-match.outputs.match == '' }}
+
   # Build package and publish a prerelease
   prerelease:
+    needs: validate-tag
     permissions:
       id-token: write
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,9 +74,9 @@ Both packages [checkly](https://www.npmjs.com/package/checkly) and [create-cli](
 
 To release packages to NPM:
 
-1. Publish a Github Release with a valid tag `v#.#.#` and click the `Generate release notes` button to auto-generate notes following format defined [here](https://github.com/checkly/checkly-cli/blob/main/.github/release.yml) 
-2. When release is published the Github action is triggered. It builds and publishes `v#.#.#-prerelease` prereleases (for both packages).
-3. A `production` deployment will be waiting for approval. After it's approved, the `v#.#.#` version will be published and set as `latest`
+1. Publish a Github Release with a valid tag `#.#.#` and click the `Generate release notes` button to auto-generate notes following format defined [here](https://github.com/checkly/checkly-cli/blob/main/.github/release.yml) 
+2. When release is published the Github action is triggered. It builds and publishes `#.#.#-prerelease` prereleases (for both packages).
+3. A `production` deployment will be waiting for approval. After it's approved, the `#.#.#` version will be published and set as `latest`
 
 ## Style Guide
 


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [ ] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
We've run into different issues with `create-checkly` fetching the examples (https://github.com/checkly/checkly-cli/issues/844). To avoid any mistakes during CLI releases, this PR adds validation to make sure that versions are formatted like `4.1.0` (and not `v4.1.0`). Even if adding a `v` prefix doesn't cause issues, I think that having complete consistency between releases is going to be safer.

Tested on a personal repo:
https://github.com/clample/commerce/actions
![image](https://github.com/checkly/checkly-cli/assets/10483186/88db4ca3-885a-4585-a103-3b6e3e92afb1)

