### PR TITLE
feat: add support for playwright config on browser checks

### DIFF
--- a/packages/cli/src/constructs/browser-check.ts
+++ b/packages/cli/src/constructs/browser-check.ts
@@ -6,6 +6,7 @@ import { CheckConfigDefaults } from '../services/checkly-config-loader'
 import { pathToPosix } from '../services/util'
 import { Content, Entrypoint } from './construct'
 import { detectSnapshots, Snapshot } from '../services/snapshot-service'
+import { PlaywrightConfig } from './browser-defaults'
 
 export interface CheckDependency {
   path: string
@@ -23,6 +24,11 @@ export interface BrowserCheckProps extends CheckProps {
    * expiration. For example, 'app.checklyhq.com'.
    */
   sslCheckDomain?: string
+  /**
+   * A valid playwright config object, same format and keys as you would use on
+   * playwright.config.ts
+   */
+  playwrightConfig?: PlaywrightConfig,
 }
 
 /**
@@ -42,6 +48,7 @@ export class BrowserCheck extends Check {
   // The `snapshots` field is set later (with a `key`) after these are uploaded to storage.
   rawSnapshots?: Array<{ absolutePath: string, path: string }>
   snapshots?: Array<Snapshot>
+  playwrightConfig?: PlaywrightConfig
 
   /**
    * Constructs the Browser Check instance
@@ -57,6 +64,7 @@ export class BrowserCheck extends Check {
     BrowserCheck.applyDefaultBrowserCheckConfig(props)
     super(logicalId, props)
     this.sslCheckDomain = props.sslCheckDomain
+    this.playwrightConfig = props.playwrightConfig
     if ('content' in props.code) {
       const script = props.code.content
       this.script = script
@@ -144,6 +152,7 @@ export class BrowserCheck extends Check {
       dependencies: this.dependencies,
       sslCheckDomain: this.sslCheckDomain || null, // empty string is converted to null
       snapshots: this.snapshots,
+      playwrightConfig: this.playwrightConfig,
     }
   }
 }

--- a/packages/cli/src/constructs/browser-defaults.ts
+++ b/packages/cli/src/constructs/browser-defaults.ts
@@ -31,9 +31,16 @@ export type Use = {
     bypassCSP?: boolean,
 }
 
+export type Expect = {
+    timeout?: number
+}
+
 export type PlaywrightConfig = {
     use?: Use,
+    expect?: Expect,
+    timeout?: number
 }
+
 export interface BrowserPlaywrightDefaults extends CheckProps {
     playwrightConfig?: PlaywrightConfig
 }

--- a/packages/cli/src/constructs/browser-defaults.ts
+++ b/packages/cli/src/constructs/browser-defaults.ts
@@ -1,0 +1,39 @@
+import { CheckProps } from './check'
+
+export type Use = {
+    baseURL?: string,
+    colorScheme?: string,
+    geolocation?: {
+        longitude?: number,
+        latitude?: number
+    },
+    locale?: string,
+    permissions?: string[],
+    timezoneId?: string,
+    viewport?: {
+        width?: number,
+        height?: number,
+    },
+    deviceScaleFactor?: number,
+    hasTouch?: boolean,
+    isMobile?: boolean,
+    javaScriptEnabled?: boolean,
+    acceptDownloads?: boolean,
+    extraHTTPHeaders?: object,
+    httpCredentials?: object,
+    ignoreHTTPSErrors?: boolean,
+    offline?: boolean,
+    actionTimeout?: number,
+    navigationTimeout?: number,
+    testIdAttribute?: string,
+    launchOptions?: object,
+    contextOptions?: object,
+    bypassCSP?: boolean,
+}
+
+export type PlaywrightConfig = {
+    use?: Use,
+}
+export interface BrowserPlaywrightDefaults extends CheckProps {
+    playwrightConfig?: PlaywrightConfig
+}

--- a/packages/cli/src/services/checkly-config-loader.ts
+++ b/packages/cli/src/services/checkly-config-loader.ts
@@ -6,10 +6,15 @@ import { Session } from '../constructs'
 import { Construct } from '../constructs/construct'
 import type { Region } from '..'
 import { ReporterType } from '../reporters/reporter'
+import { BrowserPlaywrightDefaults } from '../constructs/browser-defaults'
 
 export type CheckConfigDefaults = Pick<CheckProps, 'activated' | 'muted' | 'doubleCheck'
   | 'shouldFail' | 'runtimeId' | 'locations' | 'tags' | 'frequency' | 'environmentVariables'
-  | 'alertChannels' | 'privateLocations' | 'retryStrategy' | 'runParallel'>
+  | 'alertChannels' | 'privateLocations' | 'retryStrategy'>
+
+export type BrowserCheckDefaults = Pick<BrowserPlaywrightDefaults, 'activated' | 'muted' | 'doubleCheck'
+  | 'shouldFail' | 'runtimeId' | 'locations' | 'tags' | 'frequency' | 'environmentVariables'
+  | 'alertChannels' | 'privateLocations' | 'retryStrategy' | 'playwrightConfig' >
 
 export type ChecklyConfig = {
   /**
@@ -39,7 +44,7 @@ export type ChecklyConfig = {
     /**
      * Browser checks default configuration properties.
      */
-    browserChecks?: CheckConfigDefaults & {
+    browserChecks?: BrowserCheckDefaults & {
       /**
        * Glob pattern where the CLI looks for Playwright test files, i.e. all `.spec.ts` files
        */


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer

Add support for playwright config on browser check
Used [RFC](https://github.com/checkly/checkly-cli/issues/806) as reference for parameters supported

