### PR TITLE
fix: send runtimeId to the BE [gh-909]

### DIFF
--- a/packages/cli/src/constructs/check-group.ts
+++ b/packages/cli/src/constructs/check-group.ts
@@ -268,6 +268,7 @@ export class CheckGroup extends Construct {
       doubleCheck: this.doubleCheck,
       tags: this.tags,
       locations: this.locations,
+      runtimeId: this.runtimeId,
 
       // private-location instances are assigned with loadAllPrivateLocations()
       privateLocations: undefined,


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Send runtimeId with the group construct

Resolves #909 