### PR TITLE
feat: support arrays of glob patterns

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -167,7 +167,7 @@ export default class Deploy extends AuthCommand {
         PrivateLocationGroupAssignment.__checklyType,
       ].some(t => t === type)) {
         // Don't report changes to alert channel subscriptions or private location assignments.
-        // User's don't create these directly, so it's more intuitive to consider it as part of the check.
+        // Users don't create these directly, so it's more intuitive to consider it as part of the check.
         continue
       }
       const construct = project.data[type as keyof ProjectData][logicalId]

--- a/packages/cli/src/constructs/check-group.ts
+++ b/packages/cli/src/constructs/check-group.ts
@@ -30,14 +30,14 @@ type BrowserCheckConfig = CheckConfigDefaults & {
   /**
    * Glob pattern to include multiple files, i.e. all `.spec.ts` files
    */
-  testMatch: string,
+  testMatch: string | string[],
 }
 
 type MultiStepCheckConfig = CheckConfigDefaults & {
   /**
    * Glob pattern to include multiple files, i.e. all `.spec.ts` files
    */
-  testMatch: string,
+  testMatch: string | string[],
 }
 
 export interface CheckGroupProps {
@@ -191,7 +191,7 @@ export class CheckGroup extends Construct {
     this.__addPrivateLocationGroupAssignments()
   }
 
-  private __addChecks (fileAbsolutePath: string, testMatch: string) {
+  private __addChecks (fileAbsolutePath: string, testMatch: string|string[]) {
     const parent = path.dirname(fileAbsolutePath)
     const matched = glob.sync(testMatch, { nodir: true, cwd: parent })
     for (const match of matched) {

--- a/packages/cli/src/services/__tests__/project-parser-fixtures/multiple-glob-patterns-project/__checks1__/__nested-checks__/nested.spec.js
+++ b/packages/cli/src/services/__tests__/project-parser-fixtures/multiple-glob-patterns-project/__checks1__/__nested-checks__/nested.spec.js
@@ -1,0 +1,4 @@
+import { test } from '@playwright/test'
+test('nested', async () => {
+  // Go to https://example.com/
+})

--- a/packages/cli/src/services/__tests__/project-parser-fixtures/multiple-glob-patterns-project/__checks1__/__nested-checks__/test.check.js
+++ b/packages/cli/src/services/__tests__/project-parser-fixtures/multiple-glob-patterns-project/__checks1__/__nested-checks__/test.check.js
@@ -1,0 +1,15 @@
+/* eslint-disable no-new */
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { BrowserCheck } = require('../../../../../../constructs')
+
+new BrowserCheck('nested', {
+  name: 'nested',
+  runtimeId: '2022.10',
+  locations: ['eu-central-1'],
+  frequency: 10,
+  environmentVariables: [],
+  alertChannels: [],
+  code: {
+    content: 'console.log(1)',
+  },
+})

--- a/packages/cli/src/services/__tests__/project-parser-fixtures/multiple-glob-patterns-project/__checks1__/check1.spec.js
+++ b/packages/cli/src/services/__tests__/project-parser-fixtures/multiple-glob-patterns-project/__checks1__/check1.spec.js
@@ -1,0 +1,4 @@
+import { test } from '@playwright/test'
+test('check 1', async () => {
+  // Go to https://example.com/
+})

--- a/packages/cli/src/services/__tests__/project-parser-fixtures/multiple-glob-patterns-project/__checks1__/test.check.js
+++ b/packages/cli/src/services/__tests__/project-parser-fixtures/multiple-glob-patterns-project/__checks1__/test.check.js
@@ -1,0 +1,15 @@
+/* eslint-disable no-new */
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { BrowserCheck } = require('../../../../../constructs')
+
+new BrowserCheck('check1', {
+  name: 'check1',
+  runtimeId: '2022.10',
+  locations: ['eu-central-1'],
+  frequency: 10,
+  environmentVariables: [],
+  alertChannels: [],
+  code: {
+    content: 'console.log(1)',
+  },
+})

--- a/packages/cli/src/services/__tests__/project-parser-fixtures/multiple-glob-patterns-project/__checks2__/check2.spec.js
+++ b/packages/cli/src/services/__tests__/project-parser-fixtures/multiple-glob-patterns-project/__checks2__/check2.spec.js
@@ -1,0 +1,4 @@
+import { test } from '@playwright/test'
+test('check 2', async () => {
+  // Go to https://example.com/
+})

--- a/packages/cli/src/services/__tests__/project-parser-fixtures/multiple-glob-patterns-project/__checks2__/test.check.js
+++ b/packages/cli/src/services/__tests__/project-parser-fixtures/multiple-glob-patterns-project/__checks2__/test.check.js
@@ -1,0 +1,15 @@
+/* eslint-disable no-new */
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { BrowserCheck } = require('../../../../../constructs')
+
+new BrowserCheck('check2', {
+  name: 'check3',
+  runtimeId: '2022.10',
+  locations: ['eu-central-1'],
+  frequency: 10,
+  environmentVariables: [],
+  alertChannels: [],
+  code: {
+    content: 'console.log(1)',
+  },
+})

--- a/packages/cli/src/services/__tests__/project-parser.spec.ts
+++ b/packages/cli/src/services/__tests__/project-parser.spec.ts
@@ -133,6 +133,31 @@ describe('parseProject()', () => {
     })
   })
 
+  it('should parse a project with multiple glob patterns and deduplicate overlapping patterns', async () => {
+    const globProjectPath = path.join(__dirname, 'project-parser-fixtures', 'multiple-glob-patterns-project')
+    const project = await parseProject({
+      directory: globProjectPath,
+      projectLogicalId: 'glob-project-id',
+      projectName: 'glob project',
+      availableRuntimes: runtimes,
+      checkMatch: ['**/__checks1__/*.check.js', '**/__checks2__/*.check.js', '**/__nested-checks__/*.check.js'],
+      browserCheckMatch: ['**/__checks1__/*.spec.js', '**/__checks2__/*.spec.js', '**/__nested-checks__/*.spec.js'],
+    })
+    expect(project.synthesize()).toMatchObject({
+      project: {
+        logicalId: 'glob-project-id',
+      },
+      resources: [
+        { type: 'check', logicalId: 'nested' },
+        { type: 'check', logicalId: 'check1' },
+        { type: 'check', logicalId: 'check2' },
+        { type: 'check', logicalId: '__checks1__/__nested-checks__/nested.spec.js' },
+        { type: 'check', logicalId: '__checks1__/check1.spec.js' },
+        { type: 'check', logicalId: '__checks2__/check2.spec.js' },
+      ],
+    })
+  })
+
   it('should throw error for empty browser-check script', async () => {
     try {
       const projectPath = path.join(__dirname, 'project-parser-fixtures', 'empty-script-project')

--- a/packages/cli/src/services/checkly-config-loader.ts
+++ b/packages/cli/src/services/checkly-config-loader.ts
@@ -36,7 +36,7 @@ export type ChecklyConfig = {
     /**
      * Glob pattern where the CLI looks for files containing Check constructs, i.e. all `.checks.ts` files
      */
-    checkMatch?: string,
+    checkMatch?: string | string[],
     /**
      * List of glob patterns with directories to ignore.
      */
@@ -48,7 +48,7 @@ export type ChecklyConfig = {
       /**
        * Glob pattern where the CLI looks for Playwright test files, i.e. all `.spec.ts` files
        */
-      testMatch?: string,
+      testMatch?: string | string[],
     },
   },
   /**

--- a/packages/cli/src/services/project-parser.ts
+++ b/packages/cli/src/services/project-parser.ts
@@ -16,8 +16,8 @@ type ProjectParseOpts = {
   projectLogicalId: string,
   projectName: string,
   repoUrl?: string,
-  checkMatch?: string,
-  browserCheckMatch?: string,
+  checkMatch?: string | string[],
+  browserCheckMatch?: string | string[],
   ignoreDirectoriesMatch?: string[],
   checkDefaults?: CheckConfigDefaults,
   browserCheckDefaults?: CheckConfigDefaults,
@@ -69,7 +69,7 @@ export async function parseProject (opts: ProjectParseOpts): Promise<Project> {
 
 async function loadAllCheckFiles (
   directory: string,
-  checkFilePattern: string,
+  checkFilePattern: string | string[],
   ignorePattern: string[],
 ): Promise<void> {
   const checkFiles = await findFilesWithPattern(directory, checkFilePattern, ignorePattern)
@@ -94,7 +94,7 @@ async function loadAllCheckFiles (
 
 async function loadAllBrowserChecks (
   directory: string,
-  browserCheckFilePattern: string | undefined,
+  browserCheckFilePattern: string | string[] | undefined,
   ignorePattern: string[],
   project: Project,
 ): Promise<void> {
@@ -186,7 +186,7 @@ async function loadAllPrivateLocationsSlugNames (
 
 async function findFilesWithPattern (
   directory: string,
-  pattern: string,
+  pattern: string | string[],
   ignorePattern: string[],
 ): Promise<string[]> {
   // The files are sorted to make sure that the processing order is deterministic.


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [x] Test
* [ ] Docs
* [ ] Examples
* [ ] Other


## Notes for the Reviewer
- allows `string[]` for all glob patterns.
- adds tests to showcase that all heavy lifting (deduplications etc.) is done by the underlying glob library

## How to test this?

For instance, you can just add arrays to the `checkly.config.ts` i.e.

```
    checkMatch: ['**/__checks__/**/*.check.ts', '**/more-checks/**/*.check.ts'],
    browserChecks: {
      testMatch: ['**/__checks__/**/*.spec.ts', 'other-tests/**/*.spec.ts'],
```

Even with nested folders, the glob library will return a set of paths and checks that matches the expectations, e.g. no duplicates in overlapping glob definitions.

> Resolves #[911]
