### PR TITLE
fix: print session url on all reporters

### DIFF
--- a/packages/cli/src/reporters/ci.ts
+++ b/packages/cli/src/reporters/ci.ts
@@ -14,6 +14,7 @@ export default class CiReporter extends AbstractListReporter {
   onEnd () {
     printLn('Finished running all checks:', 2)
     this._printSummary()
+    this._printTestSessionsUrl()
   }
 
   onCheckEnd (checkRunId: CheckRunId, checkResult: any) {

--- a/packages/cli/src/reporters/dot.ts
+++ b/packages/cli/src/reporters/dot.ts
@@ -11,6 +11,7 @@ export default class DotReporter extends AbstractListReporter {
 
   onEnd () {
     this._printBriefSummary()
+    this._printTestSessionsUrl()
   }
 
   onCheckEnd (checkRunId: CheckRunId, checkResult: any) {


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Not all the reporters were printing the test session url

Resolves [#918](https://github.com/checkly/checkly-cli/issues/918)
