### PR TITLE
docs: adds playwrightConfig options to examples [sc-00]

### DIFF
--- a/examples/advanced-project-js/checkly.config.js
+++ b/examples/advanced-project-js/checkly.config.js
@@ -29,6 +29,14 @@ const config = defineConfig({
     retryStrategy: RetryStrategyBuilder.fixedStrategy({ baseBackoffSeconds: 60, maxRetries: 4, sameRegion: true }),
     /* A glob pattern that matches the Checks inside your repo, see https://www.checklyhq.com/docs/cli/using-check-test-match/ */
     checkMatch: '**/__checks__/**/*.check.js',
+    /* Global configuration option for Playwright-powered checks. See https://docs/browser-checks/playwright-test/#global-configuration */
+    playwrightConfig: {
+      timeout: 30000,
+      use: {
+        baseURL: 'https://www.danube-webshop.com',
+        viewport: { width: 1280, height: 720 },
+      }
+    },
     browserChecks: {
       /* A glob pattern matches any Playwright .spec.js files and automagically creates a Browser Check. This way, you
        * can just write native Playwright code. See https://www.checklyhq.com/docs/cli/using-check-test-match/

--- a/examples/advanced-project-js/src/__checks__/homepage.spec.js
+++ b/examples/advanced-project-js/src/__checks__/homepage.spec.js
@@ -1,12 +1,7 @@
-const { defaults } = require('../defaults');
 const { test, expect } = require('@playwright/test');
 
-// You can override the default Playwright test timeout of 30s
-// test.setTimeout(60000);
-
-test('webshop homepage', async ({ page }) => {
-  await page.setViewportSize(defaults.playwright.viewportSize);
-  const response = await page.goto(defaults.pageUrl);
+test('webshop homepage', async ({ page, baseURL }) => {
+  const response = await page.goto(baseURL);
 
   expect(response?.status()).toBeLessThan(400);
   await expect(page).toHaveTitle(/Danube WebShop/);

--- a/examples/advanced-project-js/src/__checks__/login.spec.js
+++ b/examples/advanced-project-js/src/__checks__/login.spec.js
@@ -1,9 +1,8 @@
 const { test } = require('@playwright/test');
-const { defaults } = require('../defaults.js')
 
-test('login', async ({ page }) => {
+test('login', async ({ page, baseURL }) => {
   // navigate to our target web page
-  await page.goto(defaults.pageUrl);
+  await page.goto(baseURL);
 
   // click on the login button and go through the login procedure
   await page.click('#login');

--- a/examples/advanced-project-js/src/defaults.js
+++ b/examples/advanced-project-js/src/defaults.js
@@ -1,6 +1,0 @@
-export const defaults = {
-  pageUrl: process.env.ENVIRONMENT_URL || 'https://danube-web.shop', // the pageUrl can be replaced by urls from a preview / staging environment.
-  playwright: {
-    viewportSize: { width: 1920, height: 1080 },
-  },
-};

--- a/examples/advanced-project/checkly.config.ts
+++ b/examples/advanced-project/checkly.config.ts
@@ -31,6 +31,14 @@ const config = defineConfig({
     alertEscalationPolicy: AlertEscalationBuilder.runBasedEscalation(1),
     /* A glob pattern that matches the Checks inside your repo, see https://www.checklyhq.com/docs/cli/using-check-test-match/ */
     checkMatch: '**/__checks__/**/*.check.ts',
+    /* Global configuration option for Playwright-powered checks. See https://docs/browser-checks/playwright-test/#global-configuration */
+    playwrightConfig: {
+      timeout: 30000,
+      use: {
+        baseURL: 'https://www.danube-webshop.com',
+        viewport: { width: 1280, height: 720 },
+      }
+    },
     browserChecks: {
       /* A glob pattern matches any Playwright .spec.ts files and automagically creates a Browser Check. This way, you
       * can just write native Playwright code. See https://www.checklyhq.com/docs/cli/using-check-test-match/

--- a/examples/advanced-project/src/__checks__/homepage.spec.ts
+++ b/examples/advanced-project/src/__checks__/homepage.spec.ts
@@ -1,12 +1,7 @@
 import { test, expect } from '@playwright/test'
-import { defaults } from '../defaults'
 
-// You can override the default Playwright test timeout of 30s
-// test.setTimeout(60_000)
-
-test('webshop homepage', async ({ page }) => {
-  await page.setViewportSize(defaults.playwright.viewportSize)
-  const response = await page.goto(defaults.pageUrl)
+test('webshop homepage', async ({ page, baseURL }) => {
+  const response = await page.goto(baseURL)
 
   expect(response?.status()).toBeLessThan(400)
   await expect(page).toHaveTitle(/Danube WebShop/)

--- a/examples/advanced-project/src/__checks__/login.spec.ts
+++ b/examples/advanced-project/src/__checks__/login.spec.ts
@@ -1,9 +1,8 @@
-import { defaults } from '../defaults'
 import { test } from '@playwright/test'
 
-test('login', async ({ page }) => {
+test('login', async ({ page, baseURL }) => {
   // navigate to our target web page
-  await page.goto(defaults.pageUrl)
+  await page.goto(baseURL)
 
   // click on the login button and go through the login procedure
   await page.click('#login')

--- a/examples/advanced-project/src/defaults.ts
+++ b/examples/advanced-project/src/defaults.ts
@@ -1,6 +1,0 @@
-export const defaults = {
-  pageUrl: process.env.ENVIRONMENT_URL || 'https://danube-web.shop', // the pageUrl can be replaced by urls from a preview / staging environment.
-  playwright: {
-    viewportSize: { width: 1920, height: 1080 },
-  },
-}

--- a/examples/boilerplate-project-js/checkly.config.js
+++ b/examples/boilerplate-project-js/checkly.config.js
@@ -26,6 +26,8 @@ const config = defineConfig({
     runtimeId: '2023.09',
     /* A glob pattern that matches the Checks inside your repo, see https://www.checklyhq.com/docs/cli/using-check-test-match/ */
     checkMatch: '**/__checks__/**/*.check.js',
+    /* Global configuration option for Playwright-powered checks. See https://docs/browser-checks/playwright-test/#global-configuration */
+    playwrightConfig: {},
     browserChecks: {
       /* A glob pattern matches any Playwright .spec.js files and automagically creates a Browser Check. This way, you
       * can just write native Playwright code. See https://www.checklyhq.com/docs/cli/using-check-test-match/

--- a/examples/boilerplate-project/checkly.config.ts
+++ b/examples/boilerplate-project/checkly.config.ts
@@ -26,6 +26,8 @@ const config = defineConfig({
     runtimeId: '2023.09',
     /* A glob pattern that matches the Checks inside your repo, see https://www.checklyhq.com/docs/cli/using-check-test-match/ */
     checkMatch: '**/__checks__/**/*.check.ts',
+    /* Global configuration option for Playwright-powered checks. See https://docs/browser-checks/playwright-test/#global-configuration */
+    playwrightConfig: {},
     browserChecks: {
       /* A glob pattern matches any Playwright .spec.ts files and automagically creates a Browser Check. This way, you
       * can just write native Playwright code. See https://www.checklyhq.com/docs/cli/using-check-test-match/


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [ ] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [x] Examples
* [ ] Other

## Notes for the Reviewer
- adds `playwrightConfig` section to examples.
- adds actual usage of that section to advanced example and removes the `defaults` file that actually served this function.

