### PR TITLE
chore: allow testing multiple prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,18 @@ jobs:
           regex: '^\d+\.\d+\.\d+$'
       - run: echo "Please create tag for release with format like 4.0.1" && exit 1
         if: ${{ steps.tag-match.outputs.match == '' }}
+      # Old create-checkly versions still look for the tag with a `v` prefix.
+      # We can automatically push the necessary tag to keep those working.
+      - name: Create tag for old create-checkly versions
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/v${{ github.event.release.tag_name }}',
+              sha: context.sha
+            })
 
   # Build package and publish a prerelease
   prerelease:
@@ -32,13 +44,15 @@ jobs:
       # Ensure that the README is published with the package
       - run: rm -f packages/cli/README.md && cp README.md packages/cli
       - run: npm ci
+      - name: Add SHORT_SHA env property with commit short sha
+        run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: Set version and publish prerelease for 'cli' package
         run: |
-          npm --no-git-tag-version version ${{ github.event.release.tag_name }}-prerelease --workspace packages/cli
+          npm --no-git-tag-version version ${{ github.event.release.tag_name }}-prerelease-${{ env.SHORT_SHA }} --workspace packages/cli
           npm publish --provenance --workspace packages/cli --tag prerelease
       - name: Set version and publish prerelease for 'create-cli' package
         run: |
-          npm --no-git-tag-version version ${{ github.event.release.tag_name }}-prerelease --workspace packages/create-cli
+          npm --no-git-tag-version version ${{ github.event.release.tag_name }}-prerelease-${{ env.SHORT_SHA }} --workspace packages/create-cli
           npm publish --provenance --workspace packages/create-cli --tag prerelease
       - name: Output prerelease packages versions
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,14 @@ To release packages to NPM:
 
 1. Publish a Github Release with a valid tag `#.#.#` and click the `Generate release notes` button to auto-generate notes following format defined [here](https://github.com/checkly/checkly-cli/blob/main/.github/release.yml) 
 2. When release is published the Github action is triggered. It builds and publishes `#.#.#-prerelease` prereleases (for both packages).
-3. A `production` deployment will be waiting for approval. After it's approved, the `#.#.#` version will be published and set as `latest`
+3. Test the prerelease version to make sure that it's working.
+4. A `production` deployment will be waiting for approval. After it's approved, the `#.#.#` version will be published and set as `latest`
+
+### Catching issues in prerelease
+
+If you notice an issue when testing the prerelease you can still roll everything back. Simply delete the GitHub release, and delete the corresponding tags from the GitHub UI (both `#.#.#` and `v#.#.#`).
+
+After resolving the issues, you can create another Github release and go through the process again.
 
 ## Style Guide
 


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [ ] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer

The release.yml job already pushes pre-releases to NPM so that we can do some extra testing. The problem is that if we find an issue, it's hard to reset everything: NPM doesn't allow us to unpublish the prerelease and we can't overwrite it either.

This PR adds the commit SHA to the prerelease version. If we detect an issue in the prerelease phase, we can delete the Github release, fix the issue, and trigger another release.

This PR will also automatically push the `v` tag with the release, since that has been causing issues for old `create-checkly` versions.