### PR TITLE
fix: error messages are passed using error key

### DIFF
--- a/packages/cli/src/services/test-runner.ts
+++ b/packages/cli/src/services/test-runner.ts
@@ -75,7 +75,7 @@ export default class TestRunner extends AbstractCheckRunner {
         .map(([checkRunId, check]) => ({ check, checkRunId, testResultId: testResultIds?.[check.logicalId] }))
       return { testSessionId, checks }
     } catch (err: any) {
-      throw new Error(err.response?.data?.message ?? err.message)
+      throw new Error(err.response?.data?.message ?? err.response?.data?.error ?? err.message)
     }
   }
 


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [ ] CLI
* [ ] Create CLI
* [x] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
We are using `error` key  [on the api ](https://github.com/checkly/checkly-backend/blob/main/api/src/modules/public-api/test-sessions/PublicTestSessionsController.js#L141)for populating the error message when triggering test on the CLI

