### PR TITLE
feat: add alertSettings.parallelRunFailureTreshold to CLI [sc-19200]

### DIFF
--- a/packages/cli/src/constructs/alert-escalation-policy.ts
+++ b/packages/cli/src/constructs/alert-escalation-policy.ts
@@ -9,6 +9,11 @@ export type Reminders = {
   interval?: number
 }
 
+export type ParallelRunFailureThreshold = {
+  enabled?: boolean,
+  percentage?: number,
+}
+
 export interface AlertEscalation {
   escalationType?: AlertEscalationType,
   runBasedEscalation?: {
@@ -18,31 +23,43 @@ export interface AlertEscalation {
     minutesFailingThreshold?: number
   },
   reminders?: Reminders
+  parallelRunFailureThreshold?: ParallelRunFailureThreshold
 }
 
-export type AlertEscalationOptions = Pick<AlertEscalation, 'runBasedEscalation' | 'timeBasedEscalation' | 'reminders'>
+export type AlertEscalationOptions = Pick<AlertEscalation, 'runBasedEscalation' | 'timeBasedEscalation' | 'reminders' | 'parallelRunFailureThreshold'>
 
 export class AlertEscalationBuilder {
   private static DEFAULT_RUN_BASED_ESCALATION = { failedRunThreshold: 1 }
   private static DEFAULT_TIME_BASED_ESCALATION = { minutesFailingThreshold: 5 }
   private static DEFAULT_REMINDERS = { amount: 0, interval: 5 }
+  private static DEFAULT_PARALLEL_RUN_FAILURE_THRESHOLD = { enabled: false, percentage: 10 }
 
-  static runBasedEscalation (failedRunThreshold: number, reminders?: Reminders) {
+  static runBasedEscalation (
+    failedRunThreshold: number,
+    reminders?: Reminders,
+    parallelRunFailureThreshold?: ParallelRunFailureThreshold,
+  ) {
     const options: AlertEscalationOptions = {
       runBasedEscalation: {
         failedRunThreshold,
       },
       reminders,
+      parallelRunFailureThreshold,
     }
     return this.alertEscalation(AlertEscalationType.RUN, options)
   }
 
-  static timeBasedEscalation (minutesFailingThreshold: number, reminders?: Reminders) {
+  static timeBasedEscalation (
+    minutesFailingThreshold: number,
+    reminders?: Reminders,
+    parallelRunFailureThreshold?: ParallelRunFailureThreshold,
+  ) {
     const options: AlertEscalationOptions = {
       timeBasedEscalation: {
         minutesFailingThreshold,
       },
       reminders,
+      parallelRunFailureThreshold,
     }
     return this.alertEscalation(AlertEscalationType.TIME, options)
   }
@@ -54,6 +71,7 @@ export class AlertEscalationBuilder {
       runBasedEscalation: options.runBasedEscalation ?? this.DEFAULT_RUN_BASED_ESCALATION,
       timeBasedEscalation: options.timeBasedEscalation ?? this.DEFAULT_TIME_BASED_ESCALATION,
       reminders: options.reminders ?? this.DEFAULT_REMINDERS,
+      parallelRunFailureThreshold: options.parallelRunFailureThreshold ?? this.DEFAULT_PARALLEL_RUN_FAILURE_THRESHOLD,
     }
   }
 }


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Add new alert settings options:

```
alertEscalationPolicy: {
    parallelRunFailureThreshold: {
      enabled: true,
      percentage: 100,
    }
  }
```