### PR TITLE
fix: allow disabling smart retries [gh-943]

### DIFF
--- a/packages/cli/src/constructs/check-group.ts
+++ b/packages/cli/src/constructs/check-group.ts
@@ -110,7 +110,7 @@ export interface CheckGroupProps {
   /**
    * Sets a retry policy for the group. Use RetryStrategyBuilder to create a retry policy.
    */
-  retryStrategy?: RetryStrategy
+  retryStrategy?: RetryStrategy | null
   /**
    * Determines whether the checks in the group should run on all selected locations in parallel or round-robin.
    * See https://www.checklyhq.com/docs/monitoring/global-locations/ to learn more about scheduling strategies.
@@ -143,7 +143,7 @@ export class CheckGroup extends Construct {
   apiCheckDefaults: ApiCheckDefaultConfig
   browserChecks?: BrowserCheckConfig
   multiStepChecks?: MultiStepCheckConfig
-  retryStrategy?: RetryStrategy
+  retryStrategy?: RetryStrategy | null
   runParallel?: boolean
   alertSettings?: AlertEscalation
   useGlobalAlertSettings?: boolean
@@ -163,7 +163,6 @@ export class CheckGroup extends Construct {
     this.name = props.name
     this.activated = props.activated
     this.muted = props.muted
-    this.doubleCheck = props.doubleCheck
     this.tags = props.tags
     this.runtimeId = props.runtimeId
     this.locations = props.locations
@@ -185,6 +184,11 @@ export class CheckGroup extends Construct {
     this.alertChannels = props.alertChannels ?? []
     this.localSetupScript = props.localSetupScript
     this.localTearDownScript = props.localTearDownScript
+    // When `retryStrategy: null` and `doubleCheck: undefined`, we want to let the user disable all retries.
+    // The backend has a Joi default of `doubleCheck: true`, though, so we need special handling for this case.
+    this.doubleCheck = props.doubleCheck === undefined && props.retryStrategy === null
+      ? false
+      : props.doubleCheck
     this.retryStrategy = props.retryStrategy
     this.runParallel = props.runParallel
     // `browserChecks` is not a CheckGroup resource property. Not present in synthesize()

--- a/packages/cli/src/constructs/check.ts
+++ b/packages/cli/src/constructs/check.ts
@@ -92,7 +92,7 @@ export interface CheckProps {
   /**
    * Sets a retry policy for the check. Use RetryStrategyBuilder to create a retry policy.
    */
-  retryStrategy?: RetryStrategy
+  retryStrategy?: RetryStrategy | null
   /**
    * Determines whether the check should run on all selected locations in parallel or round-robin.
    * See https://www.checklyhq.com/docs/monitoring/global-locations/ to learn more about scheduling strategies.
@@ -117,7 +117,7 @@ export abstract class Check extends Construct {
   groupId?: Ref
   alertChannels?: Array<AlertChannel>
   testOnly?: boolean
-  retryStrategy?: RetryStrategy
+  retryStrategy?: RetryStrategy | null
   alertSettings?: AlertEscalation
   useGlobalAlertSettings?: boolean
   runParallel?: boolean
@@ -135,7 +135,6 @@ export abstract class Check extends Construct {
     this.name = props.name
     this.activated = props.activated
     this.muted = props.muted
-    this.doubleCheck = props.doubleCheck
     this.shouldFail = props.shouldFail
     this.locations = props.locations
     this.privateLocations = props.privateLocations
@@ -156,6 +155,11 @@ export abstract class Check extends Construct {
     // alertSettings, useGlobalAlertSettings, groupId, groupOrder
 
     this.testOnly = props.testOnly ?? false
+    // When `retryStrategy: null` and `doubleCheck: undefined`, we want to let the user disable all retries.
+    // The backend has a Joi default of `doubleCheck: true`, though, so we need special handling for this case.
+    this.doubleCheck = props.doubleCheck === undefined && props.retryStrategy === null
+      ? false
+      : props.doubleCheck
     this.retryStrategy = props.retryStrategy
     this.alertSettings = props.alertEscalationPolicy
     this.useGlobalAlertSettings = !this.alertSettings

--- a/packages/cli/src/constructs/retry-strategy.ts
+++ b/packages/cli/src/constructs/retry-strategy.ts
@@ -55,6 +55,10 @@ export class RetryStrategyBuilder {
     return RetryStrategyBuilder.retryStrategy('EXPONENTIAL', options)
   }
 
+  static noRetries (): null {
+    return null
+  }
+
   private static retryStrategy (type: RetryStrategyType, options?: RetryStrategyOptions): RetryStrategy {
     return {
       type,

--- a/packages/cli/src/constructs/retry-strategy.ts
+++ b/packages/cli/src/constructs/retry-strategy.ts
@@ -55,6 +55,9 @@ export class RetryStrategyBuilder {
     return RetryStrategyBuilder.retryStrategy('EXPONENTIAL', options)
   }
 
+  /**
+   * No retries are performed.
+   */
   static noRetries (): null {
     return null
   }

--- a/packages/cli/src/constructs/retry-strategy.ts
+++ b/packages/cli/src/constructs/retry-strategy.ts
@@ -1,4 +1,4 @@
-export type RetryStrategyType = 'LINEAR' | 'EXPONENTIAL' | 'FIXED'
+export type RetryStrategyType = 'LINEAR' | 'EXPONENTIAL' | 'FIXED' | 'NO_RETRIES'
 
 export interface RetryStrategy {
   type: RetryStrategyType,
@@ -58,8 +58,8 @@ export class RetryStrategyBuilder {
   /**
    * No retries are performed.
    */
-  static noRetries (): null {
-    return null
+  static noRetries (): RetryStrategy {
+    return RetryStrategyBuilder.retryStrategy('NO_RETRIES')
   }
 
   private static retryStrategy (type: RetryStrategyType, options?: RetryStrategyOptions): RetryStrategy {


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Resolves #943 
 
Currently it's not straightforward to disable smart retries. Setting `retryStrategy: null` for a check gives a type error when using TypeScript (`type 'null' is not assignable to type 'RetryStrategy | undefined'`). When using JS, the [backend Joi default of `doubleCheck: true`](https://github.com/checkly/checkly-backend/blob/cd20f50db575b121052eb016d57b894f9a67f77b/api/src/modules/public-api/checkly-cli-schema.js#L317-L320) shows in the UI as a linear retry strategy. Currently to disable all retries you need to set both `retryStrategy: null` and `doubleCheck: false`.

This PR makes it simpler to disable smart retries. To disable smart retries, the user can just set `retryStrategy: null` on a check or a group - there's no need to also set `doubleCheck: false`. When a user sets `retryStrategy: null` and doesn't set `doubleCheck`, the CLI will set `doubleCheck: false` to avoid the Joi default.

This approach of fixing the issue on the CLI side should minimize the breaking changes for users. The only breaking change is that any users that had `retryStrategy: null` and that weren't setting explicitly setting `doubleCheck` will have their retries disabled when upgrading to the new CLI version (since the `doubleCheck: true` default is removed). This shouldn't really have an impact, though.

The PR also adds a `RetryStrategyBuilder.noRetries()` method to make it more clear/explicit how to disable retries.