### PR TITLE
fix typo in example repos readmes

### DIFF
--- a/examples/advanced-project-js/README.md
+++ b/examples/advanced-project-js/README.md
@@ -17,7 +17,7 @@ This project has examples of all Checkly check types and showcases some advanced
 
 - Running `npx checkly test` will look for `.check.js` files and `.spec.js` in `__checks__` directories and execute them in a dry run.
 
-- Running `npx check deploy` will deploy your checks to Checkly, attach alert channels, and run them on a 10m schedule in the 
+- Running `npx checkly deploy` will deploy your checks to Checkly, attach alert channels, and run them on a 10m schedule in the 
 region `us-east-1` and `eu-west-1`
 
 - An example GitHub Actions workflow is in the `.github/workflow.yml` file. It triggers all the checks in the project and deploys

--- a/examples/advanced-project/README.md
+++ b/examples/advanced-project/README.md
@@ -17,7 +17,7 @@ This project has examples of all Checkly check types and showcases some advanced
 
 - Running `npx checkly test` will look for `.check.ts` files and `.spec.ts` in `__checks__` directories and execute them in a dry run.
 
-- Running `npx check deploy` will deploy your checks to Checkly, attach alert channels, and run them on a 10m schedule in the 
+- Running `npx checkly deploy` will deploy your checks to Checkly, attach alert channels, and run them on a 10m schedule in the 
 region `us-east-1` and `eu-west-1`
 
 - An example GitHub Actions workflow is in the `.github/workflow.yml` file. It triggers all the checks in the project and deploys

--- a/examples/boilerplate-project-js/README.md
+++ b/examples/boilerplate-project-js/README.md
@@ -26,7 +26,7 @@ This project has the basic boilerplate files needed to get you started.
 
 - Running `npx checkly test` will look for `.check.js` files and `.spec.js` in `__checks__` directories and execute them in a dry run.
 
-- Running `npx check deploy` will deploy your checks to Checkly, attach alert channels, and run them on a 10m schedule in the 
+- Running `npx checkly deploy` will deploy your checks to Checkly, attach alert channels, and run them on a 10m schedule in the 
 region `us-east-1` and `eu-west-1`
 
 ## CLI Commands

--- a/examples/boilerplate-project/README.md
+++ b/examples/boilerplate-project/README.md
@@ -26,7 +26,7 @@ This project has the basic boilerplate files needed to get you started.
 
 - Running `npx checkly test` will look for `.check.ts` files and `.spec.ts` in `__checks__` directories and execute them in a dry run.
 
-- Running `npx check deploy` will deploy your checks to Checkly, attach alert channels, and run them on a 10m schedule in the 
+- Running `npx checkly deploy` will deploy your checks to Checkly, attach alert channels, and run them on a 10m schedule in the 
 region `us-east-1` and `eu-west-1`
 
 ## CLI Commands


### PR DESCRIPTION
 Replace `npx check deploy` with `npx checkly deploy` in all examples' READMEs. 

## Affected Components
* [x] Examples
