### PR TITLE
feat: allow users to choose ipv4 or ipv6 for api checks [sc-0]

### DIFF
--- a/packages/cli/src/constructs/api-check.ts
+++ b/packages/cli/src/constructs/api-check.ts
@@ -194,6 +194,7 @@ export type HttpRequestMethod =
   | 'delete' | 'DELETE'
   | 'options' | 'OPTIONS'
 
+export type IPFamily = 'IPv4' | 'IPv6'
 export interface BasicAuth {
   username: string
   password: string
@@ -209,6 +210,7 @@ export type ApiCheckDefaultConfig = {
 export interface Request {
   url: string,
   method: HttpRequestMethod,
+  ipFamily?: IPFamily,
   followRedirects?: boolean,
   skipSSL?: boolean,
   /**


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Add IPv4 or IPv6 option to api checks