### PR TITLE
feat: add support for test retries [sc-20570]

### DIFF
--- a/packages/cli/e2e/__tests__/deploy.spec.ts
+++ b/packages/cli/e2e/__tests__/deploy.spec.ts
@@ -125,7 +125,11 @@ describe('deploy', () => {
       apiKey: config.get('apiKey'),
       accountId: config.get('accountId'),
       directory: path.join(__dirname, 'fixtures', 'deploy-project'),
-      env: { PROJECT_LOGICAL_ID: projectLogicalId, PRIVATE_LOCATION_SLUG_NAME: privateLocationSlugname },
+      env: {
+        PROJECT_LOGICAL_ID: projectLogicalId,
+        PRIVATE_LOCATION_SLUG_NAME: privateLocationSlugname,
+        CHECKLY_CLI_VERSION: undefined,
+      },
     })
     expect(stderr).toBe('')
     // expect the version to be overriden with latest from NPM

--- a/packages/cli/e2e/__tests__/fixtures/retry-project/checkly.config.ts
+++ b/packages/cli/e2e/__tests__/fixtures/retry-project/checkly.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'checkly'
+
+const config = defineConfig({
+  projectName: 'Test Project',
+  logicalId: 'test-project',
+  repoUrl: 'https://github.com/checkly/checkly-cli',
+  checks: {
+    locations: ['us-east-1', 'eu-west-1'],
+    tags: ['mac'],
+    runtimeId: '2023.09',
+    checkMatch: '**/*.check.ts',
+    browserChecks: {
+      // using .test.ts suffix (no .spec.ts) to avoid '@playwright/test not found error' when Jest transpile the spec.ts
+      testMatch: '**/__checks__/*.test.ts',
+    },
+  },
+  cli: {
+    runLocation: 'us-east-1',
+  },
+})
+
+export default config

--- a/packages/cli/e2e/__tests__/fixtures/retry-project/src/__checks__/group.check.ts
+++ b/packages/cli/e2e/__tests__/fixtures/retry-project/src/__checks__/group.check.ts
@@ -15,7 +15,7 @@ const group = new CheckGroup('check-group-1', {
   },
 })
 
-const browserCheck = new BrowserCheck('group-browser-check-1', {
+new BrowserCheck('group-browser-check-1', {
   name: 'Check with group',
   activated: false,
   groupId: group.ref(),

--- a/packages/cli/e2e/__tests__/fixtures/retry-project/src/__checks__/group.check.ts
+++ b/packages/cli/e2e/__tests__/fixtures/retry-project/src/__checks__/group.check.ts
@@ -1,0 +1,25 @@
+import { CheckGroup, BrowserCheck } from 'checkly/constructs'
+
+const group = new CheckGroup('check-group-1', {
+  name: 'Group',
+  activated: true,
+  muted: false,
+  locations: ['us-east-1', 'eu-west-1'],
+  tags: ['mac', 'group'],
+  environmentVariables: [],
+  apiCheckDefaults: {},
+  alertChannels: [],
+  browserChecks: {
+    // using .test.ts suffix (no .spec.ts) to avoid '@playwright/test not found error' when Jest transpile the spec.ts
+    testMatch: '**/*.test.ts',
+  },
+})
+
+const browserCheck = new BrowserCheck('group-browser-check-1', {
+  name: 'Check with group',
+  activated: false,
+  groupId: group.ref(),
+  code: {
+    content: 'throw new Error("Failing Check Result")',
+  },
+})

--- a/packages/cli/e2e/__tests__/test.spec.ts
+++ b/packages/cli/e2e/__tests__/test.spec.ts
@@ -191,4 +191,17 @@ describe('test', () => {
       fs.rmSync(snapshotDir, { recursive: true })
     }
   })
+
+  it('Should execute retries', async () => {
+    const result = await runChecklyCli({
+      args: ['test', '--retries=3'],
+      apiKey: config.get('apiKey'),
+      accountId: config.get('accountId'),
+      directory: path.join(__dirname, 'fixtures', 'retry-project'),
+      timeout: 120000, // 2 minutes
+    })
+    // The failing check result will have "Failing Check Result" in the output.
+    // We expect the check to be run 4 times.
+    expect(result.stdout.match(/Failing Check Result/g)).toHaveLength(4)
+  })
 })

--- a/packages/cli/e2e/run-checkly.ts
+++ b/packages/cli/e2e/run-checkly.ts
@@ -33,7 +33,9 @@ export function runChecklyCli (options: {
         CHECKLY_API_KEY: apiKey,
         CHECKLY_ACCOUNT_ID: accountId,
         CHECKLY_ENV: process.env.CHECKLY_ENV,
-        CHECKLY_CLI_VERSION: cliVersion,
+        // We need the CLI to report 4.8.0 or greater in order for the backend to use the new MQTT topic format.
+        // Once 4.8.0 has been released, we can remove the 4.8.0 fallback here.
+        CHECKLY_CLI_VERSION: cliVersion ?? '4.8.0',
         CHECKLY_E2E_PROMPTS_INJECTIONS: promptsInjection?.length ? JSON.stringify(promptsInjection) : undefined,
         ...env,
       },

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -282,7 +282,8 @@ export default class Test extends AuthCommand {
           sourceFile: check.getSourceFile(),
           ...result,
         }, testResultId, links))
-    })
+      })
+
     runner.on(Events.CHECK_FAILED, (sequenceId: SequenceId, check, message: string) => {
       reporters.forEach(r => r.onCheckEnd(sequenceId, {
         ...check,

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -102,7 +102,7 @@ export default class Test extends AuthCommand {
       default: false,
     }),
     retries: Flags.integer({
-      description: 'How many times to retry a failing test run.',
+      description: `[default: 0, max: ${MAX_RETRIES}] How many times to retry a failing test run.`,
     }),
   }
 

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -271,16 +271,17 @@ export default class Test extends AuthCommand {
       }, links))
     })
 
-    runner.on(Events.CHECK_SUCCESSFUL, (sequenceId: SequenceId, check, result, links?: TestResultsShortLinks) => {
-      if (result.hasFailures) {
-        process.exitCode = 1
-      }
+    runner.on(Events.CHECK_SUCCESSFUL,
+      (sequenceId: SequenceId, check, result, testResultId, links?: TestResultsShortLinks) => {
+        if (result.hasFailures) {
+          process.exitCode = 1
+        }
 
-      reporters.forEach(r => r.onCheckEnd(sequenceId, {
-        logicalId: check.logicalId,
-        sourceFile: check.getSourceFile(),
-        ...result,
-      }, links))
+        reporters.forEach(r => r.onCheckEnd(sequenceId, {
+          logicalId: check.logicalId,
+          sourceFile: check.getSourceFile(),
+          ...result,
+        }, testResultId, links))
     })
     runner.on(Events.CHECK_FAILED, (sequenceId: SequenceId, check, message: string) => {
       reporters.forEach(r => r.onCheckEnd(sequenceId, {

--- a/packages/cli/src/commands/trigger.ts
+++ b/packages/cli/src/commands/trigger.ts
@@ -143,12 +143,13 @@ export default class Trigger extends AuthCommand {
     runner.on(Events.CHECK_ATTEMPT_RESULT, (sequenceId: SequenceId, check, result, links?: TestResultsShortLinks) => {
       reporters.forEach(r => r.onCheckAttemptResult(sequenceId, result, links))
     })
-    runner.on(Events.CHECK_SUCCESSFUL, (sequenceId: SequenceId, _, result, links?: TestResultsShortLinks) => {
-      if (result.hasFailures) {
-        process.exitCode = 1
-      }
-      reporters.forEach(r => r.onCheckEnd(sequenceId, result, links))
-    })
+    runner.on(Events.CHECK_SUCCESSFUL,
+      (sequenceId: SequenceId, _, result, testResultId, links?: TestResultsShortLinks) => {
+        if (result.hasFailures) {
+          process.exitCode = 1
+        }
+        reporters.forEach(r => r.onCheckEnd(sequenceId, result, testResultId, links))
+      })
     runner.on(Events.CHECK_FAILED, (sequenceId: SequenceId, check, message: string) => {
       reporters.forEach(r => r.onCheckEnd(sequenceId, {
         ...check,

--- a/packages/cli/src/commands/trigger.ts
+++ b/packages/cli/src/commands/trigger.ts
@@ -83,7 +83,7 @@ export default class Trigger extends AuthCommand {
       description: 'A name to use when storing results in Checkly with --record.',
     }),
     retries: Flags.integer({
-      description: 'How many times to retry a check run.',
+      description: `[default: 0, max: ${MAX_RETRIES}] How many times to retry a check run.`,
     }),
   }
 

--- a/packages/cli/src/commands/trigger.ts
+++ b/packages/cli/src/commands/trigger.ts
@@ -7,13 +7,15 @@ import { loadChecklyConfig } from '../services/checkly-config-loader'
 import { splitConfigFilePath, getEnvs, getGitInformation, getCiInformation } from '../services/util'
 import type { Region } from '..'
 import TriggerRunner, { NoMatchingChecksError } from '../services/trigger-runner'
-import { RunLocation, Events, PrivateRunLocation, CheckRunId } from '../services/abstract-check-runner'
+import { RunLocation, Events, PrivateRunLocation, SequenceId } from '../services/abstract-check-runner'
 import config from '../services/config'
 import { createReporters, ReporterType } from '../reporters/reporter'
+import { printLn } from '../reporters/util'
 import { TestResultsShortLinks } from '../rest/test-sessions'
-import { Session } from '../constructs'
+import { Session, RetryStrategyBuilder } from '../constructs'
 
 const DEFAULT_REGION = 'eu-central-1'
+const MAX_RETRIES = 3
 
 export default class Trigger extends AuthCommand {
   static coreCommand = true
@@ -74,6 +76,9 @@ export default class Trigger extends AuthCommand {
       char: 'n',
       description: 'A name to use when storing results in Checkly with --record.',
     }),
+    retries: Flags.integer({
+      description: 'How many times to retry a check run.',
+    }),
   }
 
   async run (): Promise<void> {
@@ -90,6 +95,7 @@ export default class Trigger extends AuthCommand {
       env,
       'env-file': envFile,
       'test-session-name': testSessionName,
+      retries,
     } = flags
     const envVars = await getEnvs(envFile, env)
     const { configDirectory, configFilenames } = splitConfigFilePath(configFilename)
@@ -106,6 +112,7 @@ export default class Trigger extends AuthCommand {
     const verbose = this.prepareVerboseFlag(verboseFlag, checklyConfig?.cli?.verbose)
     const reporterTypes = this.prepareReportersTypes(reporterFlag as ReporterType, checklyConfig?.cli?.reporters)
     const reporters = createReporters(reporterTypes, location, verbose)
+    const testRetryStrategy = this.prepareTestRetryStrategy(retries, checklyConfig?.cli?.retries)
 
     const repoInfo = getGitInformation()
     const ciInfo = getCiInformation()
@@ -121,19 +128,23 @@ export default class Trigger extends AuthCommand {
       repoInfo,
       ciInfo.environment,
       testSessionName,
+      testRetryStrategy,
     )
     // TODO: This is essentially the same for `checkly test`. Maybe reuse code.
     runner.on(Events.RUN_STARTED,
-      (checks: Array<{ check: any, checkRunId: CheckRunId, testResultId?: string }>, testSessionId: string) =>
+      (checks: Array<{ check: any, sequenceId: SequenceId }>, testSessionId: string) =>
         reporters.forEach(r => r.onBegin(checks, testSessionId)))
-    runner.on(Events.CHECK_SUCCESSFUL, (checkRunId, _, result, links?: TestResultsShortLinks) => {
+    runner.on(Events.CHECK_ATTEMPT_RESULT, (sequenceId: SequenceId, check, result, links?: TestResultsShortLinks) => {
+      reporters.forEach(r => r.onCheckAttemptResult(sequenceId, result, links))
+    })
+    runner.on(Events.CHECK_SUCCESSFUL, (sequenceId: SequenceId, _, result, links?: TestResultsShortLinks) => {
       if (result.hasFailures) {
         process.exitCode = 1
       }
-      reporters.forEach(r => r.onCheckEnd(checkRunId, result, links))
+      reporters.forEach(r => r.onCheckEnd(sequenceId, result, links))
     })
-    runner.on(Events.CHECK_FAILED, (checkRunId, check, message: string) => {
-      reporters.forEach(r => r.onCheckEnd(checkRunId, {
+    runner.on(Events.CHECK_FAILED, (sequenceId: SequenceId, check, message: string) => {
+      reporters.forEach(r => r.onCheckEnd(sequenceId, {
         ...check,
         hasFailures: true,
         runError: message,
@@ -205,5 +216,18 @@ export default class Trigger extends AuthCommand {
       return [isCI ? 'ci' : 'list']
     }
     return reporterFlag ? [reporterFlag] : cliReporters
+  }
+
+  prepareTestRetryStrategy (retries?: number, configRetries?: number) {
+    const numRetries = retries ?? configRetries ?? 0
+    if (numRetries > MAX_RETRIES) {
+      printLn(`Defaulting to the maximum of ${MAX_RETRIES} retries.`)
+    }
+    return numRetries
+      ? RetryStrategyBuilder.fixedStrategy({
+        maxRetries: Math.min(numRetries, MAX_RETRIES),
+        baseBackoffSeconds: 0,
+      })
+      : null
   }
 }

--- a/packages/cli/src/reporters/__tests__/__snapshots__/json-builder.spec.ts.snap
+++ b/packages/cli/src/reporters/__tests__/__snapshots__/json-builder.spec.ts.snap
@@ -13,7 +13,8 @@ exports[`JsonBuilder renders JSON markdown output with assets & links: json-with
       "durationMilliseconds": 6522,
       "filename": "src/__checks__/folder/browser.check.ts",
       "link": "https://app.checklyhq.com/test-sessions/0c4c64b3-79c5-44a6-ae07-b580ce73f328/results/702961fd-7e2c-45f0-97be-1aa9eabd4d82",
-      "runError": "Run error"
+      "runError": "Run error",
+      "retries": 0
     },
     {
       "result": "Pass",
@@ -22,7 +23,8 @@ exports[`JsonBuilder renders JSON markdown output with assets & links: json-with
       "durationMilliseconds": 1234,
       "filename": "src/some-other-folder/api.check.ts",
       "link": "https://app.checklyhq.com/test-sessions/0c4c64b3-79c5-44a6-ae07-b580ce73f328/results/1c0be612-a5ec-432e-ac1c-837d2f70c010",
-      "runError": "Run error"
+      "runError": "Run error",
+      "retries": 0
     }
   ]
 }"
@@ -40,7 +42,8 @@ exports[`JsonBuilder renders basic JSON output with no assets & links: json-basi
       "durationMilliseconds": 6522,
       "filename": "src/__checks__/folder/browser.check.ts",
       "link": null,
-      "runError": null
+      "runError": null,
+      "retries": 0
     },
     {
       "result": "Pass",
@@ -49,7 +52,8 @@ exports[`JsonBuilder renders basic JSON output with no assets & links: json-basi
       "durationMilliseconds": 1234,
       "filename": "src/some-other-folder/api.check.ts",
       "link": null,
-      "runError": null
+      "runError": null,
+      "retries": 0
     }
   ]
 }"
@@ -67,7 +71,8 @@ exports[`JsonBuilder renders basic JSON output with run errors: json-basic 1`] =
       "durationMilliseconds": 6522,
       "filename": "src/__checks__/folder/browser.check.ts",
       "link": null,
-      "runError": "Run error"
+      "runError": "Run error",
+      "retries": 0
     },
     {
       "result": "Pass",
@@ -76,7 +81,8 @@ exports[`JsonBuilder renders basic JSON output with run errors: json-basic 1`] =
       "durationMilliseconds": 1234,
       "filename": "src/some-other-folder/api.check.ts",
       "link": null,
-      "runError": "Run error"
+      "runError": "Run error",
+      "retries": 0
     }
   ]
 }"

--- a/packages/cli/src/reporters/__tests__/fixtures/api-check-result.ts
+++ b/packages/cli/src/reporters/__tests__/fixtures/api-check-result.ts
@@ -5,6 +5,7 @@ export const apiCheckResult = {
   sourceInfo: {
     checkRunId: '4f20dfa7-8c66-4a15-8c43-5dc24f6206c6',
     checkRunSuiteId: '6390a87e-89c7-4295-b6f8-b23e87922ef3',
+    sequenceId: '72c5d10f-fc68-4361-a779-8543575336ae',
     ephemeral: true,
   },
   checkRunId: '1c0be612-a5ec-432e-ac1c-837d2f70c010',

--- a/packages/cli/src/reporters/__tests__/fixtures/browser-check-result.ts
+++ b/packages/cli/src/reporters/__tests__/fixtures/browser-check-result.ts
@@ -4,6 +4,7 @@ export const browserCheckResult = {
   sourceInfo: {
     checkRunId: 'ebefe140-29bf-4650-9e89-6e36a5c092ef',
     checkRunSuiteId: '2b938869-e38b-4599-b3b0-901aeea4bbef',
+    sequenceId: 'd2ec2faa-a7de-4dc1-8b56-2f4ee9248dc6',
     ephemeral: true,
   },
   checkRunId: '702961fd-7e2c-45f0-97be-1aa9eabd4d82',

--- a/packages/cli/src/reporters/__tests__/helpers.ts
+++ b/packages/cli/src/reporters/__tests__/helpers.ts
@@ -1,6 +1,7 @@
 import { checkFilesMap } from '../abstract-list'
 import { browserCheckResult } from './fixtures/browser-check-result'
 import { apiCheckResult } from './fixtures/api-check-result'
+import { SequenceId } from '../../services/abstract-check-runner'
 
 export function generateMapAndTestResultIds ({ includeTestResultIds = true, includeRunErrors = false }) {
   if (includeRunErrors) {
@@ -9,18 +10,36 @@ export function generateMapAndTestResultIds ({ includeTestResultIds = true, incl
   }
   const checkFilesMapFixture: checkFilesMap = new Map([
     ['folder/browser.check.ts', new Map([
-      [browserCheckResult.checkRunId, {
+      [browserCheckResult.sourceInfo.sequenceId as SequenceId, {
         result: browserCheckResult as any,
         titleString: browserCheckResult.name,
         // TODO: We shouldn't reuse the checkRunId as the testResultId in the test. This isn't how it actually works.
         testResultId: includeTestResultIds ? browserCheckResult.checkRunId : undefined,
+        numRetries: 0,
+        links: includeTestResultIds
+          ? {
+              testResultLink: 'https://app.checklyhq.com/test-sessions/0c4c64b3-79c5-44a6-ae07-b580ce73f328/results/702961fd-7e2c-45f0-97be-1aa9eabd4d82',
+              testTraceLinks: [],
+              videoLinks: [],
+              screenshotLinks: [],
+            }
+          : undefined,
       }],
     ])],
     ['folder/api.check.ts', new Map([
-      [apiCheckResult.checkRunId, {
+      [apiCheckResult.sourceInfo.sequenceId as SequenceId, {
         result: apiCheckResult as any,
         titleString: apiCheckResult.name,
         testResultId: includeTestResultIds ? apiCheckResult.checkRunId : undefined,
+        numRetries: 0,
+        links: includeTestResultIds
+          ? {
+              testResultLink: 'https://app.checklyhq.com/test-sessions/0c4c64b3-79c5-44a6-ae07-b580ce73f328/results/1c0be612-a5ec-432e-ac1c-837d2f70c010',
+              testTraceLinks: [],
+              videoLinks: [],
+              screenshotLinks: [],
+            }
+          : undefined,
       }],
     ])],
   ])

--- a/packages/cli/src/reporters/abstract-list.ts
+++ b/packages/cli/src/reporters/abstract-list.ts
@@ -17,6 +17,7 @@ export type checkFilesMap = Map<string|undefined, Map<SequenceId, {
   result?: any,
   titleString: string,
   checkStatus?: CheckStatus,
+  testResultId?: string,
   links?: TestResultsShortLinks,
   numRetries: number,
 }>>
@@ -80,10 +81,11 @@ export default abstract class AbstractListReporter implements Reporter {
     checkFile.numRetries++
   }
 
-  onCheckEnd (sequenceId: SequenceId, checkResult: any, links?: TestResultsShortLinks) {
+  onCheckEnd (sequenceId: SequenceId, checkResult: any, testResultId?: string, links?: TestResultsShortLinks) {
     const checkStatus = this.checkFilesMap!.get(checkResult.sourceFile)!.get(sequenceId)!
     checkStatus.result = checkResult
     checkStatus.links = links
+    checkStatus.testResultId = testResultId
     checkStatus.checkStatus = checkResult.hasFailures ? CheckStatus.FAILED : CheckStatus.SUCCESSFUL
     checkStatus.titleString = formatCheckTitle(checkStatus.checkStatus, checkResult, {
       includeSourceFile: false,

--- a/packages/cli/src/reporters/ci.ts
+++ b/packages/cli/src/reporters/ci.ts
@@ -2,10 +2,11 @@ import indentString from 'indent-string'
 
 import AbstractListReporter from './abstract-list'
 import { formatCheckTitle, formatCheckResult, CheckStatus, printLn } from './util'
-import { CheckRunId } from '../services/abstract-check-runner'
+import { SequenceId } from '../services/abstract-check-runner'
+import { TestResultsShortLinks } from '../rest/test-sessions'
 
 export default class CiReporter extends AbstractListReporter {
-  onBegin (checks: Array<{ check: any, checkRunId: CheckRunId, testResultId?: string }>, testSessionId?: string) {
+  onBegin (checks: Array<{ check: any, sequenceId: SequenceId }>, testSessionId?: string) {
     super.onBegin(checks, testSessionId)
     printLn(`Running ${this.numChecks} checks in ${this._runLocationString()}:`, 2, 1)
     this._printSummary({ skipCheckCount: true })
@@ -17,8 +18,15 @@ export default class CiReporter extends AbstractListReporter {
     this._printTestSessionsUrl()
   }
 
-  onCheckEnd (checkRunId: CheckRunId, checkResult: any) {
-    super.onCheckEnd(checkRunId, checkResult)
+  onCheckAttemptResult (sequenceId: string, checkResult: any, links?: TestResultsShortLinks): void {
+    super.onCheckAttemptResult(sequenceId, checkResult, links)
+
+    printLn(formatCheckTitle(CheckStatus.RETRIED, checkResult, { printRetryDuration: true }))
+    printLn(indentString(formatCheckResult(checkResult), 4), 2, 1)
+  }
+
+  onCheckEnd (sequenceId: SequenceId, checkResult: any) {
+    super.onCheckEnd(sequenceId, checkResult)
     printLn(formatCheckTitle(checkResult.hasFailures ? CheckStatus.FAILED : CheckStatus.SUCCESSFUL, checkResult))
 
     if (this.verbose || checkResult.hasFailures) {

--- a/packages/cli/src/reporters/dot.ts
+++ b/packages/cli/src/reporters/dot.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk'
 import AbstractListReporter from './abstract-list'
-import { CheckRunId } from '../services/abstract-check-runner'
+import { SequenceId } from '../services/abstract-check-runner'
 import { print, printLn } from './util'
 
 export default class DotReporter extends AbstractListReporter {
-  onBegin (checks: Array<{ check: any, checkRunId: CheckRunId, testResultId?: string }>, testSessionId?: string) {
+  onBegin (checks: Array<{ check: any, sequenceId: SequenceId }>, testSessionId?: string) {
     super.onBegin(checks, testSessionId)
     printLn(`Running ${this.numChecks} checks in ${this._runLocationString()}.`, 2, 1)
   }
@@ -14,8 +14,8 @@ export default class DotReporter extends AbstractListReporter {
     this._printTestSessionsUrl()
   }
 
-  onCheckEnd (checkRunId: CheckRunId, checkResult: any) {
-    super.onCheckEnd(checkRunId, checkResult)
+  onCheckEnd (sequenceId: SequenceId, checkResult: any) {
+    super.onCheckEnd(sequenceId, checkResult)
     if (checkResult.hasFailures) {
       print(`${chalk.red('F')}`)
     } else {

--- a/packages/cli/src/reporters/github.ts
+++ b/packages/cli/src/reporters/github.ts
@@ -63,7 +63,7 @@ export class GithubMdBuilder {
     }
 
     for (const [_, checkMap] of this.checkFilesMap.entries()) {
-      for (const [_, { result, links }] of checkMap.entries()) {
+      for (const [_, { result, testResultId }] of checkMap.entries()) {
         const tableRow: Array<string> = [
           `${result.hasFailures ? '❌ Fail' : '✅ Pass'}`,
           `${result.name}`,
@@ -72,8 +72,8 @@ export class GithubMdBuilder {
           `${formatDuration(result.responseTime)} `,
         ].filter(nonNullable)
 
-        if (links?.testResultLink) {
-          const linkColumn = `[Full test report](${links?.testResultLink})`
+        if (this.testSessionId && testResultId) {
+          const linkColumn = `[Full test report](${getTestSessionUrl(this.testSessionId)}/results/${testResultId})`
           tableRow.push(linkColumn)
         }
 

--- a/packages/cli/src/reporters/github.ts
+++ b/packages/cli/src/reporters/github.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 
 import AbstractListReporter, { checkFilesMap } from './abstract-list'
-import { CheckRunId } from '../services/abstract-check-runner'
+import { SequenceId } from '../services/abstract-check-runner'
 import { formatDuration, printLn, getTestSessionUrl } from './util'
 
 const outputFile = './checkly-github-report.md'
@@ -63,7 +63,7 @@ export class GithubMdBuilder {
     }
 
     for (const [_, checkMap] of this.checkFilesMap.entries()) {
-      for (const [_, { result, testResultId }] of checkMap.entries()) {
+      for (const [_, { result, links }] of checkMap.entries()) {
         const tableRow: Array<string> = [
           `${result.hasFailures ? '❌ Fail' : '✅ Pass'}`,
           `${result.name}`,
@@ -72,8 +72,8 @@ export class GithubMdBuilder {
           `${formatDuration(result.responseTime)} `,
         ].filter(nonNullable)
 
-        if (this.testSessionId && testResultId) {
-          const linkColumn = `[Full test report](${getTestSessionUrl(this.testSessionId)}/results/${testResultId})`
+        if (links?.testResultLink) {
+          const linkColumn = `[Full test report](${links?.testResultLink})`
           tableRow.push(linkColumn)
         }
 
@@ -96,7 +96,7 @@ export class GithubMdBuilder {
 }
 
 export default class GithubReporter extends AbstractListReporter {
-  onBegin (checks: Array<{ check: any, checkRunId: CheckRunId, testResultId?: string }>, testSessionId?: string) {
+  onBegin (checks: Array<{ check: any, sequenceId: SequenceId }>, testSessionId?: string) {
     super.onBegin(checks, testSessionId)
     printLn(`Running ${this.numChecks} checks in ${this._runLocationString()}.`, 2, 1)
   }

--- a/packages/cli/src/reporters/json.ts
+++ b/packages/cli/src/reporters/json.ts
@@ -2,8 +2,8 @@ import * as fs from 'fs'
 import * as path from 'path'
 
 import AbstractListReporter, { checkFilesMap } from './abstract-list'
-import { CheckRunId } from '../services/abstract-check-runner'
-import { printLn, getTestSessionUrl } from './util'
+import { CheckRunId, SequenceId } from '../services/abstract-check-runner'
+import { printLn } from './util'
 
 const outputFile = './checkly-json-report.json'
 
@@ -40,7 +40,7 @@ export class JsonBuilder {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     for (const [_, checkMap] of this.checkFilesMap.entries()) {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      for (const [_, { result, testResultId }] of checkMap.entries()) {
+      for (const [_, { result, links, numRetries }] of checkMap.entries()) {
         const check: any = {
           result: result.hasFailures ? 'Fail' : 'Pass',
           name: result.name,
@@ -49,14 +49,15 @@ export class JsonBuilder {
           filename: null,
           link: null,
           runError: result.runError || null,
+          retries: numRetries,
         }
 
         if (this.hasFilenames) {
           check.filename = result.sourceFile
         }
 
-        if (this.testSessionId && testResultId) {
-          check.link = `${getTestSessionUrl(this.testSessionId)}/results/${testResultId}`
+        if (links?.testResultLink) {
+          check.link = links?.testResultLink
         }
 
         testSessionSummary.checks.push(check)
@@ -68,7 +69,7 @@ export class JsonBuilder {
 }
 
 export default class JsonReporter extends AbstractListReporter {
-  onBegin (checks: Array<{ check: any, checkRunId: CheckRunId, testResultId?: string }>, testSessionId?: string) {
+  onBegin (checks: Array<{ check: any, checkRunId: CheckRunId, sequenceId: SequenceId }>, testSessionId?: string) {
     super.onBegin(checks, testSessionId)
     printLn(`Running ${this.numChecks} checks in ${this._runLocationString()}.`, 2, 1)
   }

--- a/packages/cli/src/reporters/json.ts
+++ b/packages/cli/src/reporters/json.ts
@@ -3,7 +3,7 @@ import * as path from 'path'
 
 import AbstractListReporter, { checkFilesMap } from './abstract-list'
 import { CheckRunId, SequenceId } from '../services/abstract-check-runner'
-import { printLn } from './util'
+import { printLn, getTestSessionUrl } from './util'
 
 const outputFile = './checkly-json-report.json'
 
@@ -40,7 +40,7 @@ export class JsonBuilder {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     for (const [_, checkMap] of this.checkFilesMap.entries()) {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      for (const [_, { result, links, numRetries }] of checkMap.entries()) {
+      for (const [_, { result, testResultId, numRetries }] of checkMap.entries()) {
         const check: any = {
           result: result.hasFailures ? 'Fail' : 'Pass',
           name: result.name,
@@ -56,8 +56,8 @@ export class JsonBuilder {
           check.filename = result.sourceFile
         }
 
-        if (links?.testResultLink) {
-          check.link = links?.testResultLink
+        if (this.testSessionId && testResultId) {
+          check.link = `${getTestSessionUrl(this.testSessionId)}/results/${testResultId}`
         }
 
         testSessionSummary.checks.push(check)

--- a/packages/cli/src/reporters/list.ts
+++ b/packages/cli/src/reporters/list.ts
@@ -53,8 +53,8 @@ export default class ListReporter extends AbstractListReporter {
     this._printSummary()
   }
 
-  onCheckEnd (sequenceId: SequenceId, checkResult: any, links?: TestResultsShortLinks) {
-    super.onCheckEnd(sequenceId, checkResult)
+  onCheckEnd (sequenceId: SequenceId, checkResult: any, testResultId?: string, links?: TestResultsShortLinks) {
+    super.onCheckEnd(sequenceId, checkResult, testResultId, links)
     this._clearSummary()
 
     if (this.verbose) {

--- a/packages/cli/src/reporters/list.ts
+++ b/packages/cli/src/reporters/list.ts
@@ -2,19 +2,19 @@ import indentString from 'indent-string'
 import chalk from 'chalk'
 
 import AbstractListReporter from './abstract-list'
-import { CheckRunId } from '../services/abstract-check-runner'
+import { SequenceId } from '../services/abstract-check-runner'
 import { formatCheckTitle, formatCheckResult, CheckStatus, printLn } from './util'
 import { TestResultsShortLinks } from '../rest/test-sessions'
 
 export default class ListReporter extends AbstractListReporter {
-  onBegin (checks: Array<{ check: any, checkRunId: CheckRunId, testResultId?: string }>, testSessionId?: string) {
+  onBegin (checks: Array<{ check: any, sequenceId: SequenceId }>, testSessionId?: string) {
     super.onBegin(checks, testSessionId)
     printLn(`Running ${this.numChecks} checks in ${this._runLocationString()}.`, 2, 1)
     this._printSummary()
   }
 
-  onCheckInProgress (check: any, checkRunId: CheckRunId) {
-    super.onCheckInProgress(check, checkRunId)
+  onCheckInProgress (check: any, sequenceId: SequenceId) {
+    super.onCheckInProgress(check, sequenceId)
     this._clearSummary()
     this._printSummary()
   }
@@ -31,8 +31,30 @@ export default class ListReporter extends AbstractListReporter {
     this._printTestSessionsUrl()
   }
 
-  onCheckEnd (checkRunId: CheckRunId, checkResult: any, links?: TestResultsShortLinks) {
-    super.onCheckEnd(checkRunId, checkResult)
+  onCheckAttemptResult (sequenceId: string, checkResult: any, links?: TestResultsShortLinks): void {
+    super.onCheckAttemptResult(sequenceId, checkResult)
+    this._clearSummary()
+
+    printLn(formatCheckTitle(CheckStatus.RETRIED, checkResult, { printRetryDuration: true }))
+    printLn(indentString(formatCheckResult(checkResult), 4), 2, 1)
+    if (links) {
+      printLn(indentString('View result: ' + chalk.underline.cyan(`${links.testResultLink}`), 4))
+      if (links.testTraceLinks?.length) {
+        // TODO: print all video files URLs
+        printLn(indentString('View trace : ' + chalk.underline.cyan(links.testTraceLinks.join(', ')), 4))
+      }
+      if (links.videoLinks?.length) {
+        // TODO: print all trace files URLs
+        printLn(indentString('View video : ' + chalk.underline.cyan(`${links.videoLinks.join(', ')}`), 4))
+      }
+      printLn('')
+    }
+
+    this._printSummary()
+  }
+
+  onCheckEnd (sequenceId: SequenceId, checkResult: any, links?: TestResultsShortLinks) {
+    super.onCheckEnd(sequenceId, checkResult)
     this._clearSummary()
 
     if (this.verbose) {

--- a/packages/cli/src/reporters/reporter.ts
+++ b/packages/cli/src/reporters/reporter.ts
@@ -10,7 +10,7 @@ export interface Reporter {
   onBegin(checks: Array<{ check: any, sequenceId: SequenceId }>, testSessionId?: string): void;
   onCheckInProgress(check: any, sequenceId: SequenceId): void;
   onCheckAttemptResult(sequenceId: SequenceId, checkResult: any, links?: TestResultsShortLinks): void;
-  onCheckEnd(sequenceId: SequenceId, checkResult: any, links?: TestResultsShortLinks): void;
+  onCheckEnd(sequenceId: SequenceId, checkResult: any, testResultId?: string, links?: TestResultsShortLinks): void;
   onEnd(): void;
   onError(err: Error): void,
   onSchedulingDelayExceeded(): void

--- a/packages/cli/src/reporters/reporter.ts
+++ b/packages/cli/src/reporters/reporter.ts
@@ -1,5 +1,5 @@
 import { TestResultsShortLinks } from '../rest/test-sessions'
-import { RunLocation, CheckRunId } from '../services/abstract-check-runner'
+import { RunLocation, SequenceId } from '../services/abstract-check-runner'
 import CiReporter from './ci'
 import DotReporter from './dot'
 import GithubReporter from './github'
@@ -7,10 +7,11 @@ import ListReporter from './list'
 import JsonReporter from './json'
 
 export interface Reporter {
-  onBegin(checks: Array<{ check: any, checkRunId: CheckRunId, testResultId?: string }>, testSessionId?: string): void;
-  onCheckInProgress(check: any, checkRunId: CheckRunId): void;
+  onBegin(checks: Array<{ check: any, sequenceId: SequenceId }>, testSessionId?: string): void;
+  onCheckInProgress(check: any, sequenceId: SequenceId): void;
+  onCheckAttemptResult(sequenceId: SequenceId, checkResult: any, links?: TestResultsShortLinks): void;
+  onCheckEnd(sequenceId: SequenceId, checkResult: any, links?: TestResultsShortLinks): void;
   onEnd(): void;
-  onCheckEnd(checkRunId: CheckRunId, checkResult: any, links?: TestResultsShortLinks): void;
   onError(err: Error): void,
   onSchedulingDelayExceeded(): void
 }

--- a/packages/cli/src/reporters/util.ts
+++ b/packages/cli/src/reporters/util.ts
@@ -10,6 +10,7 @@ import { getDefaults } from '../rest/api'
 export enum CheckStatus {
   SCHEDULING,
   RUNNING,
+  RETRIED,
   FAILED,
   SUCCESSFUL,
 }
@@ -22,9 +23,13 @@ export function formatDuration (ms: number): string {
   }
 }
 
-export function formatCheckTitle (status: CheckStatus, check: any, opts: { includeSourceFile?: boolean } = {}) {
+export function formatCheckTitle (
+  status: CheckStatus,
+  check: any,
+  opts: { includeSourceFile?: boolean, printRetryDuration?: boolean } = {},
+) {
   let duration
-  if (check.startedAt && check.stoppedAt) {
+  if ((opts.printRetryDuration || status !== CheckStatus.RETRIED) && check.startedAt && check.stoppedAt) {
     const durationMs = DateTime.fromISO(check.stoppedAt)
       .diff(DateTime.fromISO(check.startedAt))
       .toMillis()
@@ -42,6 +47,9 @@ export function formatCheckTitle (status: CheckStatus, check: any, opts: { inclu
   } else if (status === CheckStatus.SCHEDULING) {
     statusString = '~'
     format = chalk.bold.dim
+  } else if (status === CheckStatus.RETRIED) {
+    statusString = '↺'
+    format = chalk.bold
   } else {
     statusString = '-'
     format = chalk.bold.dim

--- a/packages/cli/src/rest/test-sessions.ts
+++ b/packages/cli/src/rest/test-sessions.ts
@@ -1,5 +1,6 @@
 import type { AxiosInstance } from 'axios'
 import { GitInformation } from '../services/util'
+import { RetryStrategy } from '../constructs'
 
 type RunTestSessionRequest = {
   name: string,
@@ -20,6 +21,7 @@ type TriggerTestSessionRequest = {
   environmentVariables: Array<{ key: string, value: string }>,
   repoInfo: GitInformation | null,
   environment: string | null,
+  testRetryStrategy: RetryStrategy | null,
 }
 
 export type TestResultsShortLinks = {

--- a/packages/cli/src/services/abstract-check-runner.ts
+++ b/packages/cli/src/services/abstract-check-runner.ts
@@ -151,7 +151,7 @@ export default abstract class AbstractCheckRunner extends EventEmitter {
       const links = testResultId && result.hasFailures && await this.getShortLinks(testResultId)
       if (resultType === 'FINAL') {
         this.disableTimeout(sequenceId)
-        this.emit(Events.CHECK_SUCCESSFUL, sequenceId, check, result, links)
+        this.emit(Events.CHECK_SUCCESSFUL, sequenceId, check, result, testResultId, links)
         this.emit(Events.CHECK_FINISHED, check)
       } else if (resultType === 'ATTEMPT') {
         this.emit(Events.CHECK_ATTEMPT_RESULT, sequenceId, check, result, links)

--- a/packages/cli/src/services/abstract-check-runner.ts
+++ b/packages/cli/src/services/abstract-check-runner.ts
@@ -11,6 +11,7 @@ import { TestResultsShortLinks } from '../rest/test-sessions'
 export enum Events {
   CHECK_REGISTERED = 'CHECK_REGISTERED',
   CHECK_INPROGRESS = 'CHECK_INPROGRESS',
+  CHECK_ATTEMPT_RESULT = 'CHECK_ATTEMPT_RESULT',
   CHECK_FAILED = 'CHECK_FAILED',
   CHECK_SUCCESSFUL = 'CHECK_SUCCESSFUL',
   CHECK_FINISHED = 'CHECK_FINISHED',
@@ -32,17 +33,18 @@ export type PublicRunLocation = {
 export type RunLocation = PublicRunLocation | PrivateRunLocation
 
 export type CheckRunId = string
+export type SequenceId = string
 
 export const DEFAULT_CHECK_RUN_TIMEOUT_SECONDS = 300
 
 const DEFAULT_SCHEDULING_DELAY_EXCEEDED_MS = 20000
 
 export default abstract class AbstractCheckRunner extends EventEmitter {
-  checks: Map<CheckRunId, { check: any, testResultId?: string }>
+  checks: Map<SequenceId, { check: any }>
   testSessionId?: string
   // If there's an error in the backend and no check result is sent, the check run could block indefinitely.
   // To avoid this case, we set a per-check timeout.
-  timeouts: Map<CheckRunId, NodeJS.Timeout>
+  timeouts: Map<SequenceId, NodeJS.Timeout>
   schedulingDelayExceededTimeout?: NodeJS.Timeout
   accountId: string
   timeout: number
@@ -66,7 +68,7 @@ export default abstract class AbstractCheckRunner extends EventEmitter {
   abstract scheduleChecks (checkRunSuiteId: string):
     Promise<{
       testSessionId?: string,
-      checks: Array<{ check: any, checkRunId: CheckRunId, testResultId?: string }>,
+      checks: Array<{ check: any, sequenceId: SequenceId }>,
     }>
 
   async run () {
@@ -81,7 +83,7 @@ export default abstract class AbstractCheckRunner extends EventEmitter {
       const { testSessionId, checks } = await this.scheduleChecks(checkRunSuiteId)
       this.testSessionId = testSessionId
       this.checks = new Map(
-        checks.map(({ check, checkRunId, testResultId }) => [checkRunId, { check, testResultId }]),
+        checks.map(({ check, sequenceId }) => [sequenceId, { check }]),
       )
 
       // `processMessage()` assumes that `this.timeouts` always has an entry for non-timed-out checks.
@@ -116,38 +118,47 @@ export default abstract class AbstractCheckRunner extends EventEmitter {
     socketClient.on('message', (topic: string, rawMessage: string|Buffer) => {
       const message = JSON.parse(rawMessage.toString('utf8'))
       const topicComponents = topic.split('/')
-      const checkRunId = topicComponents[4]
-      const subtopic = topicComponents[5]
+      const sequenceId = topicComponents[4]
+      const checkRunId = topicComponents[5]
+      const subtopic = topicComponents[6]
 
-      this.queue.add(() => this.processMessage(checkRunId, subtopic, message))
+      this.queue.add(() => this.processMessage(sequenceId, subtopic, message))
     })
-    await socketClient.subscribe(`account/${this.accountId}/ad-hoc-check-results/${checkRunSuiteId}/+/+`)
+    await socketClient.subscribe(`account/${this.accountId}/ad-hoc-check-results/${checkRunSuiteId}/+/+/+`)
   }
 
-  private async processMessage (checkRunId: string, subtopic: string, message: any) {
-    if (!this.timeouts.has(checkRunId)) {
+  private async processMessage (sequenceId: SequenceId, subtopic: string, message: any) {
+    if (!sequenceId) {
+      // There should always be a sequenceId, but let's have an early return to make forwards-compatibility easier.
+      return
+    }
+
+    if (!this.timeouts.has(sequenceId)) {
       // The check has already timed out. We return early to avoid reporting a duplicate result.
       return
     }
 
-    if (!this.checks.get(checkRunId)) {
-      // The check has no checkRunId associated.
+    if (!this.checks.get(sequenceId)) {
       return
     }
 
-    const { check, testResultId } = this.checks.get(checkRunId)!
+    const { check } = this.checks.get(sequenceId)!
     if (subtopic === 'run-start') {
-      this.emit(Events.CHECK_INPROGRESS, check, checkRunId)
-    } else if (subtopic === 'run-end') {
-      this.disableTimeout(checkRunId)
-      const { result } = message
+      this.emit(Events.CHECK_INPROGRESS, check, sequenceId)
+    } else if (subtopic === 'result') {
+      const { result, testResultId, resultType } = message
       await this.processCheckResult(result)
       const links = testResultId && result.hasFailures && await this.getShortLinks(testResultId)
-      this.emit(Events.CHECK_SUCCESSFUL, checkRunId, check, result, links)
-      this.emit(Events.CHECK_FINISHED, check)
+      if (resultType === 'FINAL') {
+        this.disableTimeout(sequenceId)
+        this.emit(Events.CHECK_SUCCESSFUL, sequenceId, check, result, links)
+        this.emit(Events.CHECK_FINISHED, check)
+      } else if (resultType === 'ATTEMPT') {
+        this.emit(Events.CHECK_ATTEMPT_RESULT, sequenceId, check, result, links)
+      }
     } else if (subtopic === 'error') {
-      this.disableTimeout(checkRunId)
-      this.emit(Events.CHECK_FAILED, checkRunId, check, message)
+      this.disableTimeout(sequenceId)
+      this.emit(Events.CHECK_FAILED, sequenceId, check, message)
       this.emit(Events.CHECK_FINISHED, check)
     }
   }
@@ -181,16 +192,16 @@ export default abstract class AbstractCheckRunner extends EventEmitter {
   }
 
   private setAllTimeouts () {
-    Array.from(this.checks.entries()).forEach(([checkRunId, { check }]) =>
-      this.timeouts.set(checkRunId, setTimeout(() => {
-        this.timeouts.delete(checkRunId)
+    Array.from(this.checks.entries()).forEach(([sequenceId, { check }]) =>
+      this.timeouts.set(sequenceId, setTimeout(() => {
+        this.timeouts.delete(sequenceId)
         let errorMessage = `Reached timeout of ${this.timeout} seconds waiting for check result.`
         // Checkly should always report a result within 240s.
         // If the default timeout was used, we should point the user to the status page and support email.
         if (this.timeout === DEFAULT_CHECK_RUN_TIMEOUT_SECONDS) {
           errorMessage += ' Checkly may be experiencing problems. Please check https://is.checkly.online or reach out to support@checklyhq.com.'
         }
-        this.emit(Events.CHECK_FAILED, checkRunId, check, errorMessage)
+        this.emit(Events.CHECK_FAILED, sequenceId, check, errorMessage)
         this.emit(Events.CHECK_FINISHED, check)
       }, this.timeout * 1000),
       ))

--- a/packages/cli/src/services/checkly-config-loader.ts
+++ b/packages/cli/src/services/checkly-config-loader.ts
@@ -68,6 +68,7 @@ export type ChecklyConfig = {
     privateRunLocation?: string,
     verbose?: boolean,
     reporters?: ReporterType[],
+    retries?: number,
   }
 }
 


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [ ] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
This PR adds support for retrying failed tests with `npx checkly test` and `npx checkly trigger`. Users can configure retries by either passing the `--retries=<numRetries>` flag or by setting `retries` in their Checkly config file.

### Check state changes

Previously the CLI tracked the state of a check run by using the `CheckRunId`. When MQTT/WebSocket updates were received, the CLI would look up which check it was for based on the `CheckRunId`. 
 
 Since we now have retries, the `CheckRunId` can be different with each retry of a check. In order to track the check state, this PR switches the CLI to use `SequenceId`. This is stable across all retries. `CheckRunId` can then be used to track the progress of a particular run.
 
 In `abstract-check-runner.js` this means that the PR switches to looking up the `sequenceId` for incoming MQTT messages and using this for tracking the check state. The `abstract-list.ts` reporter is also updated to track check state using `sequenceId`.
 
This PR also introduces a new check state `CheckStatus.RETRIED` for indicating that a check is being retried. When a check is retried, we leave it in the `CheckStatus.RETRIED` state rather than switching it back to `CheckStatus.SCHEDULING`/`CheckStatus.RUNNING`. The lifecycle of a check that's retried will then look like: `SCHEDULING` -> `RUNNING` -> `RETRIED` -> `FAILED`/`SUCCESSFUL`.
 
 ### Reporters
 
 #### GitHub reporter
No changes are made to the GitHub reporter. It will simply show the same pass/fail data that it normally does. We could include the number of retries, but there isn't so much horizontal screen space in the GitHub UI to add another column.
 
 #### Dot reporter
 No changes. Will just indicate passed/failed after all retries are finished.
 
 #### Json reporter
 Includes the results for the last check run. Will also include the number of retries. 
 
 #### CI + List Reporter
Prints out info from any retry attempts and shows retrying checks in the summary. Basically following the Notion doc spec. Will add a video to the PR.
 
 ### Running
 
The retry support depends on https://github.com/checkly/checkly-runners/pull/1877. For now, it's only possible to run locally. When running, you also need to manually set `CHECKLY_CLI_VERSION=4.8.0` (the planned next version), since the backend relies on this to use the new MQTT topic format.

🟢  It's expected that the tests are failing until the runners PR is released
 
