### PR TITLE
feat: increase test session timeout

### DIFF
--- a/packages/cli/src/commands/trigger.ts
+++ b/packages/cli/src/commands/trigger.ts
@@ -7,7 +7,7 @@ import { loadChecklyConfig } from '../services/checkly-config-loader'
 import { splitConfigFilePath, getEnvs, getGitInformation, getCiInformation } from '../services/util'
 import type { Region } from '..'
 import TriggerRunner, { NoMatchingChecksError } from '../services/trigger-runner'
-import { RunLocation, Events, PrivateRunLocation, CheckRunId } from '../services/abstract-check-runner'
+import { RunLocation, Events, PrivateRunLocation, CheckRunId, DEFAULT_CHECK_RUN_TIMEOUT_SECONDS } from '../services/abstract-check-runner'
 import config from '../services/config'
 import { createReporters, ReporterType } from '../reporters/reporter'
 import { TestResultsShortLinks } from '../rest/test-sessions'
@@ -42,7 +42,7 @@ export default class Trigger extends AuthCommand {
       description: 'The Checkly CLI config filename.',
     }),
     timeout: Flags.integer({
-      default: 240,
+      default: DEFAULT_CHECK_RUN_TIMEOUT_SECONDS,
       description: 'A timeout (in seconds) to wait for checks to complete.',
     }),
     verbose: Flags.boolean({

--- a/packages/cli/src/services/abstract-check-runner.ts
+++ b/packages/cli/src/services/abstract-check-runner.ts
@@ -33,7 +33,7 @@ export type RunLocation = PublicRunLocation | PrivateRunLocation
 
 export type CheckRunId = string
 
-export const DEFAULT_CHECK_RUN_TIMEOUT_SECONDS = 300
+export const DEFAULT_CHECK_RUN_TIMEOUT_SECONDS = 600
 
 const DEFAULT_SCHEDULING_DELAY_EXCEEDED_MS = 20000
 


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [ ] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Currently both `npx checkly test` and `npx checkly trigger` support a `--timeout` flag. This is a fallback timeout to make sure that if the Checkly backend doesn't respond with a check result for some reason, the user's CI doesn't become stuck indefinitely.

When it was originally added, there were few users of the CLI and checks ran on AWS Lambda which was able to run all checks concurrently. Now, users have very large test suites which can take longer, and have sometimes bumped into the default 300 second timeout. We'll also be adding test retries which will further increase the time tests take.

This PR simply bumps the default timeout to 10 minutes so that users are less likely to run into it.