### PR TITLE
fix: correctly track check state for checkly-trigger

### DIFF
--- a/packages/cli/src/commands/trigger.ts
+++ b/packages/cli/src/commands/trigger.ts
@@ -126,6 +126,9 @@ export default class Trigger extends AuthCommand {
     runner.on(Events.RUN_STARTED,
       (checks: Array<{ check: any, checkRunId: CheckRunId, testResultId?: string }>, testSessionId: string) =>
         reporters.forEach(r => r.onBegin(checks, testSessionId)))
+    runner.on(Events.CHECK_INPROGRESS, (check: any, checkRunId: CheckRunId) => {
+      reporters.forEach(r => r.onCheckInProgress(check, checkRunId))
+    })
     runner.on(Events.CHECK_SUCCESSFUL, (checkRunId, _, result, links?: TestResultsShortLinks) => {
       if (result.hasFailures) {
         process.exitCode = 1


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [ ] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
When running `npx checkly trigger`, the summary always lists the checks as "scheduling" even when they're completed. The root cause is that the CLI isn't calling the reporter on the `CHECK_INPROGRESS` event to mark the check is started. This is already correctly set for the `npx checkly test` command:

https://github.com/checkly/checkly-cli/blob/440b8513ae260f60864a8600613d4e99a7a0a200/packages/cli/src/commands/test.ts#L251-L253

