### PR TITLE
feat: add test retries to examples

### DIFF
--- a/examples/advanced-project-js/checkly.config.js
+++ b/examples/advanced-project-js/checkly.config.js
@@ -49,6 +49,8 @@ const config = defineConfig({
     runLocation: 'eu-west-1',
     /* An array of default reporters to use when a reporter is not specified with the "--reporter" flag */
     reporters: ['list'],
+    /* How many times to retry a failing test run when running `npx checkly test` or `npx checkly trigger` (max. 3) */
+    retries: 0,
   },
 });
 

--- a/examples/advanced-project/checkly.config.ts
+++ b/examples/advanced-project/checkly.config.ts
@@ -51,6 +51,8 @@ const config = defineConfig({
     runLocation: 'eu-west-1',
     /* An array of default reporters to use when a reporter is not specified with the "--reporter" flag */
     reporters: ['list'],
+    /* How many times to retry a failing test run when running `npx checkly test` or `npx checkly trigger` (max. 3) */
+    retries: 0,
   },
 })
 

--- a/examples/boilerplate-project-js/checkly.config.js
+++ b/examples/boilerplate-project-js/checkly.config.js
@@ -40,6 +40,8 @@ const config = defineConfig({
     runLocation: 'eu-west-1',
     /* An array of default reporters to use when a reporter is not specified with the "--reporter" flag */
     reporters: ['list'],
+    /* How many times to retry a failing test run when running `npx checkly test` or `npx checkly trigger` (max. 3) */
+    retries: 0,
   },
 })
 

--- a/examples/boilerplate-project/checkly.config.ts
+++ b/examples/boilerplate-project/checkly.config.ts
@@ -40,6 +40,8 @@ const config = defineConfig({
     runLocation: 'eu-west-1',
     /* An array of default reporters to use when a reporter is not specified with the "--reporter" flag */
     reporters: ['list'],
+    /* How many times to retry a failing test run when running `npx checkly test` or `npx checkly trigger` (max. 3) */
+    retries: 0,
   },
 })
 


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [ ] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Test retry support was added in https://github.com/checkly/checkly-cli/pull/952. Retries can be set using the `--retries` flag or adding `retries` in the `checkly.config.ts`, and the `--retries` flag takes precedence. This PR adds `retries` to the example projects.