### PR TITLE
feat: add environment secrets support [sc-21028]

### DIFF
--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -14,7 +14,7 @@ export default class EnvAdd extends AuthCommand {
     }),
     secret: Flags.boolean({
       char: 's',
-      description: 'Indicate that the environment variable will be secret, the value will not be revealed anywhere.',
+      description: 'Indicate that the environment variable will be secret.',
       default: false,
       exclusive: ['locked'],
     }),

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -12,6 +12,12 @@ export default class EnvAdd extends AuthCommand {
       description: 'Indicate that the environment variable will be locked.',
       default: false,
     }),
+    secret: Flags.boolean({
+      char: 's',
+      description: 'Indicate that the environment variable will be secret, the value will not be revealed anywhere.',
+      default: false,
+      exclusive: ['locked'],
+    }),
   }
 
   static args = {
@@ -29,7 +35,7 @@ export default class EnvAdd extends AuthCommand {
 
   async run (): Promise<void> {
     const { flags, args } = await this.parse(EnvAdd)
-    const { locked } = flags
+    const { locked, secret } = flags
 
     const envVariableName = args.key
     let envValue = ''
@@ -40,7 +46,7 @@ export default class EnvAdd extends AuthCommand {
       envValue = await ux.prompt(`What is the value of ${envVariableName}?`, { type: 'mask' })
     }
     try {
-      await api.environmentVariables.add(envVariableName, envValue, locked)
+      await api.environmentVariables.add(envVariableName, envValue, locked, secret)
       this.log(`Environment variable ${envVariableName} added.`)
     } catch (err: any) {
       if (err?.response?.status === 409) {

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -47,7 +47,10 @@ export default class EnvAdd extends AuthCommand {
     }
     try {
       await api.environmentVariables.add(envVariableName, envValue, locked, secret)
-      this.log(`Environment variable ${envVariableName} added.`)
+      this.log(secret
+        ? `Secret environment variable ${envVariableName} added.`
+        : `Environment variable ${envVariableName} added.`,
+      )
     } catch (err: any) {
       if (err?.response?.status === 409) {
         throw new Error(`Environment variable ${envVariableName} already exists.`)

--- a/packages/cli/src/commands/env/update.ts
+++ b/packages/cli/src/commands/env/update.ts
@@ -49,9 +49,14 @@ export default class EnvUpdate extends AuthCommand {
       await api.environmentVariables.update(envVariableName, envValue, locked, secret)
       this.log(`Environment variable ${envVariableName} updated.`)
     } catch (err: any) {
+      if (err?.response?.status === 400 && err?.response?.data?.message) {
+        throw new Error(err.response.data.message)
+      }
+
       if (err?.response?.status === 404) {
         throw new Error(`Environment variable ${envVariableName} not found.`)
       }
+
       throw err
     }
   }

--- a/packages/cli/src/commands/env/update.ts
+++ b/packages/cli/src/commands/env/update.ts
@@ -47,7 +47,10 @@ export default class EnvUpdate extends AuthCommand {
     }
     try {
       await api.environmentVariables.update(envVariableName, envValue, locked, secret)
-      this.log(`Environment variable ${envVariableName} updated.`)
+      this.log(secret
+        ? `Secret environment variable ${envVariableName} updated.`
+        : `Environment variable ${envVariableName} updated.`,
+      )
     } catch (err: any) {
       if (err?.response?.status === 400 && err?.response?.data?.message) {
         throw new Error(err.response.data.message)

--- a/packages/cli/src/commands/env/update.ts
+++ b/packages/cli/src/commands/env/update.ts
@@ -14,7 +14,7 @@ export default class EnvUpdate extends AuthCommand {
     }),
     secret: Flags.boolean({
       char: 's',
-      description: 'Indicate that the environment variable will be secret, the value will not be revealed anywhere.',
+      description: 'Indicate if environment variable is secret.',
       default: false,
       exclusive: ['locked'],
     }),

--- a/packages/cli/src/commands/env/update.ts
+++ b/packages/cli/src/commands/env/update.ts
@@ -12,6 +12,12 @@ export default class EnvUpdate extends AuthCommand {
       description: 'Indicate if environment variable is locked.',
       default: false,
     }),
+    secret: Flags.boolean({
+      char: 's',
+      description: 'Indicate that the environment variable will be secret, the value will not be revealed anywhere.',
+      default: false,
+      exclusive: ['locked'],
+    }),
   }
 
   static args = {
@@ -29,7 +35,7 @@ export default class EnvUpdate extends AuthCommand {
 
   async run (): Promise<void> {
     const { flags, args } = await this.parse(EnvUpdate)
-    const { locked } = flags
+    const { locked, secret } = flags
 
     const envVariableName = args.key
     let envValue = ''
@@ -40,7 +46,7 @@ export default class EnvUpdate extends AuthCommand {
       envValue = await ux.prompt(`What is the value of ${envVariableName}?`, { type: 'mask' })
     }
     try {
-      await api.environmentVariables.update(envVariableName, envValue, locked)
+      await api.environmentVariables.update(envVariableName, envValue, locked, secret)
       this.log(`Environment variable ${envVariableName} updated.`)
     } catch (err: any) {
       if (err?.response?.status === 404) {

--- a/packages/cli/src/constructs/key-value-pair.ts
+++ b/packages/cli/src/constructs/key-value-pair.ts
@@ -2,4 +2,5 @@ export default interface KeyValuePair {
   key: string
   value: string
   locked?: boolean
+  secret?: boolean
 }

--- a/packages/cli/src/rest/environment-variables.ts
+++ b/packages/cli/src/rest/environment-variables.ts
@@ -4,6 +4,7 @@ export interface EnvironmentVariable {
   key: string
   value: string
   locked: boolean
+  secret?: boolean
 }
 
 class EnvironmentVariables {
@@ -20,8 +21,8 @@ class EnvironmentVariables {
     return this.api.delete(`/v1/variables/${environmentVariableKey}`)
   }
 
-  add (environmentVariableKey: string, environmentVariableValue: string, locked: boolean) {
-    return this.api.post('/v1/variables', { key: environmentVariableKey, value: environmentVariableValue, locked })
+  add (environmentVariableKey: string, environmentVariableValue: string, locked = false, secret = false) {
+    return this.api.post('/v1/variables', { key: environmentVariableKey, value: environmentVariableValue, locked, secret })
   }
 
   get (environmentVariableKey: string) {
@@ -29,8 +30,8 @@ class EnvironmentVariables {
   }
 
   // update environment variable with default locked value false
-  update (environmentVariableKey: string, environmentVariableValue: string, locked = false) {
-    return this.api.put(`/v1/variables/${environmentVariableKey}`, { value: environmentVariableValue, locked })
+  update (environmentVariableKey: string, environmentVariableValue: string, locked = false, secret = false) {
+    return this.api.put(`/v1/variables/${environmentVariableKey}`, { value: environmentVariableValue, locked, secret })
   }
 }
 


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
- [x] Add `--secret` support while creating/updating environment variables with `npx checkly env add|update`
- [x] Add `secret: boolean` support for check/group constructs
- [x] Update `npx checkly env pull` to structure the file with regular and secret variables

> [!IMPORTANT]
> Important note: this feature is not available yet, if you have any questions feel free to reach out to our customer support