### PR TITLE
Chrislample/update version override

### DIFF
--- a/packages/cli/src/commands/baseCommand.ts
+++ b/packages/cli/src/commands/baseCommand.ts
@@ -15,10 +15,10 @@ export abstract class BaseCommand extends Command {
     let version = process.env.CHECKLY_CLI_VERSION ?? this.config.version
 
     // use latest version from NPM if it's running from the local environment or E2E
-    if (version === '0.0.1-dev') {
+    if (version === '0.0.1-dev' || version?.startsWith('0.0.0')) {
       try {
         const { data: packageInformation } = await axios.get('https://registry.npmjs.org/checkly/latest')
-        this.log(`\nNotice: replacing version '${version}' with latest '${packageInformation.version}'.\n`)
+        this.log(`\nNotice: replacing version '${version}' with latest '${packageInformation.version}'. If you wish to test with a different version, please pass the CHECKLY_CLI_VERSION environment variable.\n`)
         version = packageInformation.version
       } catch { }
     }


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [ ] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
The backend now has different behavior depending on the CLI version that's used (in particular, the MQTT WebSocket topic format with https://github.com/checkly/checkly-cli/pull/952).

We have automatic version setting for local development testing. Experimental CLI releases created with the [release-canary.yml action](https://github.com/checkly/checkly-cli/blob/c9bd0b2da5d4d89ff4fd8a6ed14015e9b685df34/.github/workflows/release-canary.yml#L23) have a version with the format `0.0.0-pr.<PR number>.<commit hash>`, though, so our automatic version setting didn't work. This PR does a quick update of that.


