### PR TITLE
fix: allow mqtt client to reconnect if it gets disconnected

### DIFF
--- a/packages/cli/src/services/socket-client.ts
+++ b/packages/cli/src/services/socket-client.ts
@@ -28,7 +28,7 @@ export class SocketClient {
     const accountId = config.getAccountId()
     const apiKey = config.getApiKey()
     const options: mqtt.IClientOptions = {
-      reconnectPeriod: 0,
+      reconnectPeriod: 100,
       username: accountId,
       password: apiKey,
     }


### PR DESCRIPTION
MQTT client reconnections were disabled for seemingly no reason. Combined with the fact that the SocketClient's various error and disconnection events were completely ignored, a random disconnection before the expected final message was received would almost certainly cause the CLI to essentially hang, doing nothing until the failsafe timeout (currently 10m) hit.

There is an additional edge case which is not covered by this change. Even now that reconnections are enabled, in the unlucky case that the final message is distributed when our client is not connected (i.e. in the process waiting to reconnect, or actively reconnecting), then we'll still miss it and hang the same way. To reduce the odds of this edge condition happening, the reconnect wait timeout was reduced to 100ms from the default of 1000ms.

To invoke the reconnection behavior (and to try to figure out whether there was any reason why reconnections were originally disabled), I wrote a simple HTTP proxy that acts like a normal HTTP proxy but disconnects all connections after a configurable duration. Then I ran the CLI with the `https_proxy` environment variable and confirmed that reconnections were successful when the proxy closed connections.

I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
