### PR TITLE
feat: compress large JSON requests [sc-22310]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10927,6 +10927,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stream-stringify": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/json-stream-stringify/-/json-stream-stringify-3.1.6.tgz",
+      "integrity": "sha512-x7fpwxOkbhFCaJDJ8vb1fBY3DdSa4AlITaz+HHILQJzdPMnHEFjxPwVUi1ALIbcIxDE0PNe/0i7frnY8QnBQog==",
+      "engines": {
+        "node": ">=7.10.1"
+      }
+    },
     "node_modules/json-stringify-nice": {
       "version": "1.1.4",
       "dev": true,
@@ -18740,6 +18748,7 @@
         "git-repo-info": "2.1.1",
         "glob": "10.3.1",
         "indent-string": "4.0.0",
+        "json-stream-stringify": "3.1.6",
         "json5": "2.2.3",
         "jwt-decode": "3.1.2",
         "log-symbols": "4.1.0",
@@ -22943,6 +22952,7 @@
         "glob": "10.3.1",
         "indent-string": "4.0.0",
         "jest": "29.6.2",
+        "json-stream-stringify": "3.1.6",
         "json5": "2.2.3",
         "jwt-decode": "3.1.2",
         "log-symbols": "4.1.0",
@@ -26834,6 +26844,11 @@
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "dev": true
+    },
+    "json-stream-stringify": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/json-stream-stringify/-/json-stream-stringify-3.1.6.tgz",
+      "integrity": "sha512-x7fpwxOkbhFCaJDJ8vb1fBY3DdSa4AlITaz+HHILQJzdPMnHEFjxPwVUi1ALIbcIxDE0PNe/0i7frnY8QnBQog=="
     },
     "json-stringify-nice": {
       "version": "1.1.4",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -84,6 +84,7 @@
     "git-repo-info": "2.1.1",
     "glob": "10.3.1",
     "indent-string": "4.0.0",
+    "json-stream-stringify": "3.1.6",
     "json5": "2.2.3",
     "jwt-decode": "3.1.2",
     "log-symbols": "4.1.0",

--- a/packages/cli/src/rest/projects.ts
+++ b/packages/cli/src/rest/projects.ts
@@ -1,5 +1,6 @@
 import type { AxiosInstance } from 'axios'
 import type { GitInformation } from '../services/util'
+import { compressJSONPayload } from './util'
 
 export interface Project {
   name: string
@@ -60,6 +61,7 @@ class Projects {
     return this.api.post<ProjectDeployResponse>(
       `/next-v2/projects/deploy?dryRun=${dryRun}&scheduleOnDeploy=${scheduleOnDeploy}`,
       resources,
+      { transformRequest: compressJSONPayload },
     )
   }
 }

--- a/packages/cli/src/rest/test-sessions.ts
+++ b/packages/cli/src/rest/test-sessions.ts
@@ -1,6 +1,7 @@
 import type { AxiosInstance } from 'axios'
 import { GitInformation } from '../services/util'
 import { RetryStrategy } from '../constructs'
+import { compressJSONPayload } from './util'
 
 type RunTestSessionRequest = {
   name: string,
@@ -38,7 +39,9 @@ class TestSessions {
   }
 
   run (payload: RunTestSessionRequest) {
-    return this.api.post('/next/test-sessions/run', payload)
+    return this.api.post('/next/test-sessions/run', payload, {
+      transformRequest: compressJSONPayload,
+    })
   }
 
   trigger (payload: TriggerTestSessionRequest) {

--- a/packages/cli/src/rest/util.ts
+++ b/packages/cli/src/rest/util.ts
@@ -1,0 +1,14 @@
+import zlib from 'node:zlib'
+
+import { AxiosRequestHeaders } from 'axios'
+import { JsonStreamStringify } from 'json-stream-stringify'
+
+export function compressJSONPayload (data: any, headers: AxiosRequestHeaders) {
+  headers['Content-Type'] = 'application/json'
+  headers['Content-Encoding'] = 'gzip'
+
+  const zipper = zlib.createGzip()
+  const streamer = new JsonStreamStringify(data)
+
+  return streamer.pipe(zipper)
+}


### PR DESCRIPTION
When you deploy or test a project, a potentially very large JSON payload is sent to the API server. In large projects, the time to upload the payload can be quite significant (depending on connection speed). This PR introduces gzip compression to payloads sent to relevant endpoints, which should make the payload easier to upload.

Additionally, those large payloads were stringified fully in memory, causing unnecessarily high memory usage. This PR changes the payload to be stringified and streamed with json-stream-stringify instead, which should decrease memory usage. This change only applies to requests that are now also getting compressed.

I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->

- `json-stream-stringify`: This package is dependency-free, and perhaps the only package providing the needed functionality to stream JSON payloads.