### PR TITLE
feat: added TS types for http proxy - `[sc-22386]`

### DIFF
--- a/packages/cli/src/constructs/playwright-config.ts
+++ b/packages/cli/src/constructs/playwright-config.ts
@@ -1,5 +1,14 @@
 import { CheckProps } from './check'
 
+/**
+ * Ref: https://playwright.dev/docs/network#http-proxy
+ */
+type HttpProxy = {
+    server: string,
+    username?: string,
+    password?: string,
+}
+
 export type Use = {
     baseURL?: string,
     colorScheme?: string,
@@ -31,6 +40,7 @@ export type Use = {
     contextOptions?: object,
     bypassCSP?: boolean,
     userAgent?: string,
+    proxy?: HttpProxy,
 }
 
 export type Expect = {


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [ ] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [x] Other

## Notes for the Reviewer
* Adds the TypeScript type for `HttpProxy` that complies with Playwright documentation [here](https://playwright.dev/docs/network#http-proxy).