### PR TITLE
feat: optionally bypass runtime dependency checks [sc-22475]

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -55,6 +55,12 @@ export default class Deploy extends AuthCommand {
       char: 'c',
       description: commonMessages.configFile,
     }),
+    'verify-runtime-dependencies': Flags.boolean({
+      description: '[default: true] Return an error if checks import dependencies that are not supported by the selected runtime.',
+      default: true,
+      allowNo: true,
+      env: 'CHECKLY_VERIFY_RUNTIME_DEPENDENCIES',
+    }),
   }
 
   async run (): Promise<void> {
@@ -66,6 +72,7 @@ export default class Deploy extends AuthCommand {
       'schedule-on-deploy': scheduleOnDeploy,
       output,
       config: configFilename,
+      'verify-runtime-dependencies': verifyRuntimeDependencies,
     } = flags
     const { configDirectory, configFilenames } = splitConfigFilePath(configFilename)
     const {
@@ -88,6 +95,7 @@ export default class Deploy extends AuthCommand {
         acc[runtime.name] = runtime
         return acc
       }, <Record<string, Runtime>> {}),
+      verifyRuntimeDependencies,
       checklyConfigConstructs,
     })
     const repoInfo = getGitInformation(project.repoUrl)

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -104,6 +104,12 @@ export default class Test extends AuthCommand {
     retries: Flags.integer({
       description: `[default: 0, max: ${MAX_RETRIES}] How many times to retry a failing test run.`,
     }),
+    'verify-runtime-dependencies': Flags.boolean({
+      description: '[default: true] Return an error if checks import dependencies that are not supported by the selected runtime.',
+      default: true,
+      allowNo: true,
+      env: 'CHECKLY_VERIFY_RUNTIME_DEPENDENCIES',
+    }),
   }
 
   static args = {
@@ -137,6 +143,7 @@ export default class Test extends AuthCommand {
       'test-session-name': testSessionName,
       'update-snapshots': updateSnapshots,
       retries,
+      'verify-runtime-dependencies': verifyRuntimeDependencies,
     } = flags
     const filePatterns = argv as string[]
 
@@ -169,6 +176,7 @@ export default class Test extends AuthCommand {
         acc[runtime.name] = runtime
         return acc
       }, <Record<string, Runtime>> {}),
+      verifyRuntimeDependencies,
       checklyConfigConstructs,
     })
     const checks = Object.entries(project.data.check)

--- a/packages/cli/src/constructs/api-check.ts
+++ b/packages/cli/src/constructs/api-check.ts
@@ -352,7 +352,10 @@ export class ApiCheck extends Check {
     if (!runtime) {
       throw new Error(`${runtimeId} is not supported`)
     }
-    const parser = new Parser(Object.keys(runtime.dependencies))
+    const parser = new Parser({
+      supportedNpmModules: Object.keys(runtime.dependencies),
+      checkUnsupportedModules: Session.verifyRuntimeDependencies,
+    })
     const parsed = parser.parse(absoluteEntrypoint)
     // Maybe we can get the parsed deps with the content immediately
 

--- a/packages/cli/src/constructs/browser-check.ts
+++ b/packages/cli/src/constructs/browser-check.ts
@@ -120,7 +120,10 @@ export class BrowserCheck extends Check {
     if (!runtime) {
       throw new Error(`${runtimeId} is not supported`)
     }
-    const parser = new Parser(Object.keys(runtime.dependencies))
+    const parser = new Parser({
+      supportedNpmModules: Object.keys(runtime.dependencies),
+      checkUnsupportedModules: Session.verifyRuntimeDependencies,
+    })
     const parsed = parser.parse(entry)
     // Maybe we can get the parsed deps with the content immediately
 

--- a/packages/cli/src/constructs/multi-step-check.ts
+++ b/packages/cli/src/constructs/multi-step-check.ts
@@ -104,7 +104,10 @@ export class MultiStepCheck extends Check {
     if (!runtime) {
       throw new Error(`${runtimeId} is not supported`)
     }
-    const parser = new Parser(Object.keys(runtime.dependencies))
+    const parser = new Parser({
+      supportedNpmModules: Object.keys(runtime.dependencies),
+      checkUnsupportedModules: Session.verifyRuntimeDependencies,
+    })
     const parsed = parser.parse(entry)
     // Maybe we can get the parsed deps with the content immediately
 

--- a/packages/cli/src/constructs/project.ts
+++ b/packages/cli/src/constructs/project.ts
@@ -142,6 +142,7 @@ export class Session {
   static checkFilePath?: string
   static checkFileAbsolutePath?: string
   static availableRuntimes: Record<string, Runtime>
+  static verifyRuntimeDependencies = true
   static loadingChecklyConfigFile: boolean
   static checklyConfigFileConstructs?: Construct[]
   static privateLocations: PrivateLocationApi[]

--- a/packages/cli/src/services/project-parser.ts
+++ b/packages/cli/src/services/project-parser.ts
@@ -23,7 +23,7 @@ type ProjectParseOpts = {
   checkDefaults?: CheckConfigDefaults,
   browserCheckDefaults?: CheckConfigDefaults,
   availableRuntimes: Record<string, Runtime>,
-  verifyRuntimeDependencies: boolean,
+  verifyRuntimeDependencies?: boolean,
   checklyConfigConstructs?: Construct[],
 }
 
@@ -59,7 +59,7 @@ export async function parseProject (opts: ProjectParseOpts): Promise<Project> {
   Session.checkDefaults = Object.assign({}, BASE_CHECK_DEFAULTS, checkDefaults)
   Session.browserCheckDefaults = browserCheckDefaults
   Session.availableRuntimes = availableRuntimes
-  Session.verifyRuntimeDependencies = verifyRuntimeDependencies
+  Session.verifyRuntimeDependencies = verifyRuntimeDependencies ?? true
 
   // TODO: Do we really need all of the ** globs, or could we just put node_modules?
   const ignoreDirectories = ['**/node_modules/**', '**/.git/**', ...ignoreDirectoriesMatch]

--- a/packages/cli/src/services/project-parser.ts
+++ b/packages/cli/src/services/project-parser.ts
@@ -23,6 +23,7 @@ type ProjectParseOpts = {
   checkDefaults?: CheckConfigDefaults,
   browserCheckDefaults?: CheckConfigDefaults,
   availableRuntimes: Record<string, Runtime>,
+  verifyRuntimeDependencies: boolean,
   checklyConfigConstructs?: Construct[],
 }
 
@@ -43,6 +44,7 @@ export async function parseProject (opts: ProjectParseOpts): Promise<Project> {
     checkDefaults = {},
     browserCheckDefaults = {},
     availableRuntimes,
+    verifyRuntimeDependencies,
     checklyConfigConstructs,
   } = opts
   const project = new Project(projectLogicalId, {
@@ -57,6 +59,7 @@ export async function parseProject (opts: ProjectParseOpts): Promise<Project> {
   Session.checkDefaults = Object.assign({}, BASE_CHECK_DEFAULTS, checkDefaults)
   Session.browserCheckDefaults = browserCheckDefaults
   Session.availableRuntimes = availableRuntimes
+  Session.verifyRuntimeDependencies = verifyRuntimeDependencies
 
   // TODO: Do we really need all of the ** globs, or could we just put node_modules?
   const ignoreDirectories = ['**/node_modules/**', '**/.git/**', ...ignoreDirectoriesMatch]


### PR DESCRIPTION
Introduces a new option called `--[no-]verify-runtime-dependencies` for the `test` and `deploy` commands, which is `true` by default and matches current behavior. Should the user decide that they know the available dependencies better than we do, they can run the commands with the `--no-verify-runtime-dependencies` flag set, or they can use the equivalent `CHECKLY_VERIFY_RUNTIME_DEPENDENCIES=0` environment variable.

Specifically, this feature makes it possible to use custom dependencies that have been added to a customized private location runtime (contact your Account Executive to learn how).

I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [x] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
