### PR TITLE
chore!: update node engine requirement to >=18 [sc-23291]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18788,7 +18788,7 @@
         "typescript": "5.3.3"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "packages/cli/node_modules/ansi-styles": {
@@ -18938,6 +18938,9 @@
         "ts-jest": "29.2.4",
         "ts-node": "10.9.1",
         "typescript": "5.3.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "packages/create-cli/node_modules/@types/prompts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,7 @@
     "./constructs": "./dist/constructs/index.js"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "clean": "rimraf ./dist",

--- a/packages/create-cli/package.json
+++ b/packages/create-cli/package.json
@@ -5,6 +5,9 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "private": false,
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "scripts": {
     "clean": "rimraf ./dist",
     "prepack": "echo \"Warning: no oclif manifest configured\"",


### PR DESCRIPTION
The reason for this change is that new versions of many of our dependencies now require Node 18 or later, meaning we cannot update them without breaking compatibility. Bumping our Node version in a major release makes that possible again.

This is a breaking change (despite probably no one using Node 16 anymore), so a new major version is required.

I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [x] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
