### PR TITLE
feat: support wildcard exports when parsing dependency tree [sc-22632]

### DIFF
--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/common-esm-example/dep5.mjs
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/common-esm-example/dep5.mjs
@@ -1,0 +1,1 @@
+export * from './dep6' // wildcard export

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/common-esm-example/dep6.mjs
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/common-esm-example/dep6.mjs
@@ -1,0 +1,1 @@
+export const value = 'Hello World'

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/common-esm-example/entrypoint.mjs
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/common-esm-example/entrypoint.mjs
@@ -2,6 +2,7 @@ import dep2 from './dep2'
 import { dep3 } from './dep3'
 export { value } from './dep1'
 export { dep4 } from './dep4.mjs'
+export { value as otherValue } from './dep5.mjs'
 
 /* eslint-disable no-console */
 console.log('Received ', dep2, dep3)

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/common-esm-example/unreachable.mjs
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/common-esm-example/unreachable.mjs
@@ -1,0 +1,4 @@
+// This file is intentionally not reachable from the entrypoint and should
+// not appear in the list of dependencies.
+
+export const unreachable = true

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/esmodules-example/dep5.js
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/esmodules-example/dep5.js
@@ -1,0 +1,1 @@
+export * from './dep6' // wildcard export

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/esmodules-example/dep6.js
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/esmodules-example/dep6.js
@@ -1,0 +1,1 @@
+export const value = 'Hello World'

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/esmodules-example/entrypoint.js
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/esmodules-example/entrypoint.js
@@ -1,6 +1,7 @@
 import dep2 from './dep2'
 import { dep3 } from './dep3'
 export { value } from './dep1'
+export { value as otherValue } from './dep5'
 
 /* eslint-disable no-console */
 console.log('Received ', dep2, dep3)

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/esmodules-example/unreachable.js
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/esmodules-example/unreachable.js
@@ -1,0 +1,4 @@
+// This file is intentionally not reachable from the entrypoint and should
+// not appear in the list of dependencies.
+
+export const unreachable = true

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/simple-example/unreachable.js
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/simple-example/unreachable.js
@@ -1,0 +1,4 @@
+// This file is intentionally not reachable from the entrypoint and should
+// not appear in the list of dependencies.
+
+export const unreachable = true

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/typescript-example/dep5.ts
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/typescript-example/dep5.ts
@@ -1,0 +1,1 @@
+export * from './dep6' // wildcard export

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/typescript-example/dep6.ts
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/typescript-example/dep6.ts
@@ -1,0 +1,1 @@
+export const value = 'Hello World'

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/typescript-example/entrypoint.ts
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/typescript-example/entrypoint.ts
@@ -7,6 +7,7 @@ import * as moduleImport from './module'
 import * as modulePackage from './module-package'
 import { ExternalFirstPage } from './pages/external.first.page.js'
 import { ExternalSecondPage } from './pages/external.second.page'
+export { value } from './dep5' // named export
 
 export function doMath (num: number): number {
   return add(num, subtract(10, 7))

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/typescript-example/unreachable.ts
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/typescript-example/unreachable.ts
@@ -1,0 +1,4 @@
+// This file is intentionally not reachable from the entrypoint and should
+// not appear in the list of dependencies.
+
+export const value = 'Hello World'

--- a/packages/cli/src/services/check-parser/__tests__/check-parser.spec.ts
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser.spec.ts
@@ -116,6 +116,8 @@ describe('dependency-parser - parser()', () => {
       toAbsolutePath('dep2.ts'),
       toAbsolutePath('dep3.ts'),
       toAbsolutePath('dep4.js'),
+      toAbsolutePath('dep5.ts'),
+      toAbsolutePath('dep6.ts'),
       toAbsolutePath('module-package', 'main.js'),
       toAbsolutePath('module-package', 'package.json'),
       toAbsolutePath('module', 'index.ts'),
@@ -135,6 +137,8 @@ describe('dependency-parser - parser()', () => {
       toAbsolutePath('dep1.js'),
       toAbsolutePath('dep2.js'),
       toAbsolutePath('dep3.js'),
+      toAbsolutePath('dep5.js'),
+      toAbsolutePath('dep6.js'),
     ])
   })
 
@@ -149,6 +153,8 @@ describe('dependency-parser - parser()', () => {
       toAbsolutePath('dep2.mjs'),
       toAbsolutePath('dep3.mjs'),
       toAbsolutePath('dep4.mjs'),
+      toAbsolutePath('dep5.mjs'),
+      toAbsolutePath('dep6.mjs'),
     ])
   })
 

--- a/packages/cli/src/services/check-parser/parser.ts
+++ b/packages/cli/src/services/check-parser/parser.ts
@@ -251,6 +251,11 @@ export class Parser {
         if (node.source.type !== 'Literal') return
         Parser.registerDependency(node.source.value, localDependencies, npmDependencies)
       },
+      ExportAllDeclaration (node: any) {
+        if (node.source === null) return
+        if (node.source.type !== 'Literal') return
+        Parser.registerDependency(node.source.value, localDependencies, npmDependencies)
+      },
     }
   }
 
@@ -264,7 +269,13 @@ export class Parser {
       ExportNamedDeclaration (node: TSESTree.ExportNamedDeclaration) {
       // The statement isn't importing another dependency
         if (node.source === null) return
-        // For now, we only support literal strings in the import statement
+        // For now, we only support literal strings in the export statement
+        if (node.source.type !== tsParser.TSESTree.AST_NODE_TYPES.Literal) return
+        Parser.registerDependency(node.source.value, localDependencies, npmDependencies)
+      },
+      ExportAllDeclaration (node: TSESTree.ExportAllDeclaration) {
+        if (node.source === null) return
+        // For now, we only support literal strings in the export statement
         if (node.source.type !== tsParser.TSESTree.AST_NODE_TYPES.Literal) return
         Parser.registerDependency(node.source.value, localDependencies, npmDependencies)
       },


### PR DESCRIPTION
This PR makes the project parser compatible with wildcard exports such as `export * from './file'`. Previously, only named exports such as `export { Thing } from './file'` were supported. The end result was that the file being referred to in the export would not be added to the dependency tree.

I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [x] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
