### PR TITLE
fix: updates wrong links to correct url. [sc-00]

### DIFF
--- a/packages/cli/src/constructs/api-check.ts
+++ b/packages/cli/src/constructs/api-check.ts
@@ -287,7 +287,7 @@ export class ApiCheck extends Check {
    * @param logicalId unique project-scoped resource name identification
    * @param props check configuration properties
    *
-   * {@link https://checklyhq.com/docs/cli/constructs/#apicheck Read more in the docs}
+   * {@link https://checklyhq.com/docs/cli/constructs-reference/#apicheck Read more in the docs}
    */
 
   constructor (logicalId: string, props: ApiCheckProps) {

--- a/packages/cli/src/constructs/browser-check.ts
+++ b/packages/cli/src/constructs/browser-check.ts
@@ -55,7 +55,7 @@ export class BrowserCheck extends Check {
    *
    * @param logicalId unique project-scoped resource name identification
    * @param props check configuration properties
-   * {@link https://checklyhq.com/docs/cli/constructs/#browsercheck Read more in the docs}
+   * {@link https://checklyhq.com/docs/cli/constructs-reference/#browsercheck Read more in the docs}
    */
   constructor (logicalId: string, props: BrowserCheckProps) {
     if (props.group) {

--- a/packages/cli/src/constructs/check-group.ts
+++ b/packages/cli/src/constructs/check-group.ts
@@ -156,7 +156,7 @@ export class CheckGroup extends Construct {
    * @param logicalId unique project-scoped resource name identification
    * @param props CheckGroup configuration properties
    *
-   * {@link https://checklyhq.com/docs/cli/constructs/#checkgroup Read more in the docs}
+   * {@link https://checklyhq.com/docs/cli/constructs-reference/#checkgroup Read more in the docs}
    */
   constructor (logicalId: string, props: CheckGroupProps) {
     super(CheckGroup.__checklyType, logicalId)

--- a/packages/cli/src/constructs/dashboard.ts
+++ b/packages/cli/src/constructs/dashboard.ts
@@ -138,7 +138,7 @@ export class Dashboard extends Construct {
    * @param logicalId unique project-scoped resource name identification
    * @param props dashboard configuration properties
    *
-   * {@link https://checklyhq.com/docs/cli/constructs/#dashboard Read more in the docs}
+   * {@link https://checklyhq.com/docs/cli/constructs-reference/#dashboard Read more in the docs}
    */
   constructor (logicalId: string, props: DashboardProps) {
     super(Dashboard.__checklyType, logicalId)

--- a/packages/cli/src/constructs/email-alert-channel.ts
+++ b/packages/cli/src/constructs/email-alert-channel.ts
@@ -22,7 +22,7 @@ export class EmailAlertChannel extends AlertChannel {
    *
    * @param logicalId unique project-scoped resource name identification
    * @param props email alert channel configuration properties
-   * {@link https://checklyhq.com/docs/cli/constructs/#emailalertchannel Read more in the docs}
+   * {@link https://checklyhq.com/docs/cli/constructs-reference/#emailalertchannel Read more in the docs}
    */
   constructor (logicalId: string, props: EmailAlertChannelProps) {
     super(logicalId, props)

--- a/packages/cli/src/constructs/heartbeat-check.ts
+++ b/packages/cli/src/constructs/heartbeat-check.ts
@@ -66,7 +66,7 @@ export class HeartbeatCheck extends Check {
    *
    * @param logicalId unique project-scoped resource name identification
    * @param props heartbeat check configuration properties
-   * {@link https://checklyhq.com/docs/cli/constructs/#heartbeat Read more in the docs}
+   * {@link https://checklyhq.com/docs/cli/constructs-reference/#heartbeat Read more in the docs}
    */
   constructor (logicalId: string, props: HeartbeatCheckProps) {
     super(logicalId, props)

--- a/packages/cli/src/constructs/maintenance-window.ts
+++ b/packages/cli/src/constructs/maintenance-window.ts
@@ -60,7 +60,7 @@ export class MaintenanceWindow extends Construct {
    * @param logicalId unique project-scoped resource name identification
    * @param props maintenance window configuration properties
    *
-   * {@link https://checklyhq.com/docs/cli/constructs/#maintenancewindow Read more in the docs}
+   * {@link https://checklyhq.com/docs/cli/constructs-reference/#maintenancewindow Read more in the docs}
    */
   constructor (logicalId: string, props: MaintenanceWindowProps) {
     super(MaintenanceWindow.__checklyType, logicalId)

--- a/packages/cli/src/constructs/multi-step-check.ts
+++ b/packages/cli/src/constructs/multi-step-check.ts
@@ -36,7 +36,7 @@ export class MultiStepCheck extends Check {
    *
    * @param logicalId unique project-scoped resource name identification
    * @param props check configuration properties
-   * {@link https://checklyhq.com/docs/cli/constructs/#multistepcheck Read more in the docs}
+   * {@link https://checklyhq.com/docs/cli/constructs-reference/#multistepcheck Read more in the docs}
    */
   constructor (logicalId: string, props: MultiStepCheckProps) {
     if (props.group) {

--- a/packages/cli/src/constructs/opsgenie-alert-channel.ts
+++ b/packages/cli/src/constructs/opsgenie-alert-channel.ts
@@ -43,7 +43,7 @@ export class OpsgenieAlertChannel extends AlertChannel {
    * @param logicalId unique project-scoped resource name identification
    * @param props Opsgenie alert channel configuration properties
    *
-   * {@link https://checklyhq.com/docs/cli/constructs/#opsgeniealertchannel Read more in the docs}
+   * {@link https://checklyhq.com/docs/cli/constructs-reference/#opsgeniealertchannel Read more in the docs}
    */
   constructor (logicalId: string, props: OpsgenieAlertChannelProps) {
     super(logicalId, props)

--- a/packages/cli/src/constructs/pagerduty-alert-channel.ts
+++ b/packages/cli/src/constructs/pagerduty-alert-channel.ts
@@ -35,7 +35,7 @@ export class PagerdutyAlertChannel extends AlertChannel {
    * @param logicalId unique project-scoped resource name identification
    * @param props Pagerduty alert channel configuration properties
    *
-   * {@link https://checklyhq.com/docs/cli/constructs/#pagerdutyalertchannel Read more in the docs}
+   * {@link https://checklyhq.com/docs/cli/constructs-reference/#pagerdutyalertchannel Read more in the docs}
    */
   constructor (logicalId: string, props: PagerdutyAlertChannelProps) {
     super(logicalId, props)

--- a/packages/cli/src/constructs/private-location.ts
+++ b/packages/cli/src/constructs/private-location.ts
@@ -56,11 +56,13 @@ class PrivateLocationWrapper extends Construct {
 }
 
 /**
- * Creates an Private Location
+ * Creates a Private Location
  *
  * @remarks
  *
  * This class make use of the Private Location endpoints.
+ *
+ * {@link https://www.checklyhq.com/docs/cli/constructs-reference/#privatelocation Read more in the docs}
  */
 export class PrivateLocation extends Construct {
   name: string

--- a/packages/cli/src/constructs/slack-alert-channel.ts
+++ b/packages/cli/src/constructs/slack-alert-channel.ts
@@ -22,7 +22,7 @@ export class SlackAlertChannel extends AlertChannel {
    * @param logicalId unique project-scoped resource name identification
    * @param props Slack alert channel configuration properties
    *
-   * {@link https://checklyhq.com/docs/cli/constructs-reference/#smsalertchannel Read more in the docs}
+   * {@link https://checklyhq.com/docs/cli/constructs-reference/#slackalertchannel Read more in the docs}
    */
   constructor (logicalId: string, props: SlackAlertChannelProps) {
     super(logicalId, props)

--- a/packages/cli/src/constructs/sms-alert-channel.ts
+++ b/packages/cli/src/constructs/sms-alert-channel.ts
@@ -28,7 +28,7 @@ export class SmsAlertChannel extends AlertChannel {
    * @param logicalId unique project-scoped resource name identification
    * @param props SMS alert channel configuration properties
    *
-   * {@link https://checklyhq.com/docs/cli/constructs/#smsalertchannel Read more in the docs}
+   * {@link https://checklyhq.com/docs/cli/constructs-reference/#smsalertchannel Read more in the docs}
    */
   constructor (logicalId: string, props: SmsAlertChannelProps) {
     super(logicalId, props)

--- a/packages/cli/src/constructs/webhook-alert-channel.ts
+++ b/packages/cli/src/constructs/webhook-alert-channel.ts
@@ -63,7 +63,7 @@ export class WebhookAlertChannel extends AlertChannel {
    * @param logicalId unique project-scoped resource name identification
    * @param props Webhook alert channel configuration properties
    *
-   * {@link https://checklyhq.com/docs/cli/constructs/#webhookalertchannel Read more in the docs}
+   * {@link https://checklyhq.com/docs/cli/constructs-reference/#webhookalertchannel Read more in the docs}
    */
   constructor (logicalId: string, props: WebhookAlertChannelProps) {
     super(logicalId, props)


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

## Notes for the Reviewer
Some @link JS docs were pointing to an old URL which triggered a redirect, losing the anchor.
