### PR TITLE
feat: check constructs against account default runtime if not given [sc-22843]

### DIFF
--- a/packages/cli/e2e/__tests__/switch.spec.ts
+++ b/packages/cli/e2e/__tests__/switch.spec.ts
@@ -11,6 +11,7 @@ describe('switch', () => {
       promptsInjection: [{
         id: config.get('accountId') as string,
         name: accountName,
+        runtimeId: '2024.02', // Not important for this command.
       }],
       timeout: 5000,
     })

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -159,6 +159,7 @@ export default class Test extends AuthCommand {
     })
     const verbose = this.prepareVerboseFlag(verboseFlag, checklyConfig.cli?.verbose)
     const reporterTypes = this.prepareReportersTypes(reporterFlag as ReporterType, checklyConfig.cli?.reporters)
+    const { data: account } = await api.accounts.get(config.getAccountId())
     const { data: availableRuntimes } = await api.runtimes.getAll()
 
     const project = await parseProject({
@@ -176,6 +177,7 @@ export default class Test extends AuthCommand {
         acc[runtime.name] = runtime
         return acc
       }, <Record<string, Runtime>> {}),
+      defaultRuntimeId: account.runtimeId,
       verifyRuntimeDependencies,
       checklyConfigConstructs,
     })

--- a/packages/cli/src/constructs/__tests__/browser-check.spec.ts
+++ b/packages/cli/src/constructs/__tests__/browser-check.spec.ts
@@ -31,6 +31,84 @@ describe('BrowserCheck', () => {
     })
   })
 
+  it('should fail to bundle if runtime is not specified and default runtime is not set', () => {
+    const getFilePath = (filename: string) => path.join(__dirname, 'fixtures', 'api-check', filename)
+    const bundle = () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const _bundle = BrowserCheck.bundle(getFilePath('entrypoint.js'), undefined)
+    }
+
+    Session.basePath = __dirname
+    Session.availableRuntimes = runtimes
+    Session.defaultRuntimeId = undefined
+    expect(bundle).toThrowError('runtime is not set')
+    delete Session.basePath
+    delete Session.defaultRuntimeId
+  })
+
+  it('should successfully bundle if runtime is not specified but default runtime is set', () => {
+    const getFilePath = (filename: string) => path.join(__dirname, 'fixtures', 'api-check', filename)
+    const bundle = () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const _bundle = BrowserCheck.bundle(getFilePath('entrypoint.js'), undefined)
+    }
+
+    Session.basePath = __dirname
+    Session.availableRuntimes = runtimes
+    Session.defaultRuntimeId = '2022.10'
+    expect(bundle).not.toThrowError('is not supported')
+    delete Session.basePath
+    delete Session.defaultRuntimeId
+  })
+
+  it('should fail to bundle if runtime is not supported even if default runtime is set', () => {
+    const getFilePath = (filename: string) => path.join(__dirname, 'fixtures', 'api-check', filename)
+    const bundle = () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const _bundle = BrowserCheck.bundle(getFilePath('entrypoint.js'), '9999.99')
+    }
+
+    Session.basePath = __dirname
+    Session.availableRuntimes = runtimes
+    Session.defaultRuntimeId = '2022.02'
+    expect(bundle).toThrowError('9999.99 is not supported')
+    delete Session.basePath
+    delete Session.defaultRuntimeId
+  })
+
+  it('should not synthesize runtime if not specified even if default runtime is set', () => {
+    Session.project = new Project('project-id', {
+      name: 'Test Project',
+      repoUrl: 'https://github.com/checkly/checkly-cli',
+    })
+    Session.availableRuntimes = runtimes
+    Session.defaultRuntimeId = '2022.02'
+    const browserCheck = new BrowserCheck('test-check', {
+      name: 'Test Check',
+      code: { content: 'console.log("test check")' },
+    })
+    const payload = browserCheck.synthesize()
+    expect(payload.runtimeId).toBeUndefined()
+    delete Session.defaultRuntimeId
+  })
+
+  it('should synthesize runtime if specified', () => {
+    Session.project = new Project('project-id', {
+      name: 'Test Project',
+      repoUrl: 'https://github.com/checkly/checkly-cli',
+    })
+    Session.availableRuntimes = runtimes
+    Session.defaultRuntimeId = '2022.02'
+    const browserCheck = new BrowserCheck('test-check', {
+      name: 'Test Check',
+      runtimeId: '2022.02',
+      code: { content: 'console.log("test check")' },
+    })
+    const payload = browserCheck.synthesize()
+    expect(payload.runtimeId).toEqual('2022.02')
+    delete Session.defaultRuntimeId
+  })
+
   it('should apply default check settings', () => {
     Session.project = new Project('project-id', {
       name: 'Test Project',

--- a/packages/cli/src/constructs/api-check.ts
+++ b/packages/cli/src/constructs/api-check.ts
@@ -295,7 +295,7 @@ export class ApiCheck extends Check {
 
     if (props.setupScript) {
       if ('entrypoint' in props.setupScript) {
-        const { script, scriptPath, dependencies } = ApiCheck.bundle(props.setupScript.entrypoint, this.runtimeId!)
+        const { script, scriptPath, dependencies } = ApiCheck.bundle(props.setupScript.entrypoint, this.runtimeId)
         this.localSetupScript = script
         this.setupScriptPath = scriptPath
         this.setupScriptDependencies = dependencies
@@ -314,7 +314,7 @@ export class ApiCheck extends Check {
 
     if (props.tearDownScript) {
       if ('entrypoint' in props.tearDownScript) {
-        const { script, scriptPath, dependencies } = ApiCheck.bundle(props.tearDownScript.entrypoint, this.runtimeId!)
+        const { script, scriptPath, dependencies } = ApiCheck.bundle(props.tearDownScript.entrypoint, this.runtimeId)
         this.localTearDownScript = script
         this.tearDownScriptPath = scriptPath
         this.tearDownScriptDependencies = dependencies
@@ -337,7 +337,7 @@ export class ApiCheck extends Check {
     this.addPrivateLocationCheckAssignments()
   }
 
-  static bundle (entrypoint: string, runtimeId: string) {
+  static bundle (entrypoint: string, runtimeId?: string) {
     let absoluteEntrypoint = null
     if (path.isAbsolute(entrypoint)) {
       absoluteEntrypoint = entrypoint
@@ -348,7 +348,7 @@ export class ApiCheck extends Check {
       absoluteEntrypoint = path.join(path.dirname(Session.checkFileAbsolutePath), entrypoint)
     }
 
-    const runtime = Session.availableRuntimes[runtimeId]
+    const runtime = Session.getRuntime(runtimeId)
     if (!runtime) {
       throw new Error(`${runtimeId} is not supported`)
     }

--- a/packages/cli/src/constructs/browser-check.ts
+++ b/packages/cli/src/constructs/browser-check.ts
@@ -79,8 +79,7 @@ export class BrowserCheck extends Check {
         }
         absoluteEntrypoint = path.join(path.dirname(Session.checkFileAbsolutePath), entrypoint)
       }
-      // runtimeId will always be set by check or browser check defaults so it is safe to use ! operator
-      const bundle = BrowserCheck.bundle(absoluteEntrypoint, this.runtimeId!)
+      const bundle = BrowserCheck.bundle(absoluteEntrypoint, this.runtimeId)
       if (!bundle.script) {
         throw new Error(`Browser check "${logicalId}" is not allowed to be empty`)
       }
@@ -115,8 +114,8 @@ export class BrowserCheck extends Check {
     }
   }
 
-  static bundle (entry: string, runtimeId: string) {
-    const runtime = Session.availableRuntimes[runtimeId]
+  static bundle (entry: string, runtimeId?: string) {
+    const runtime = Session.getRuntime(runtimeId)
     if (!runtime) {
       throw new Error(`${runtimeId} is not supported`)
     }

--- a/packages/cli/src/constructs/multi-step-check.ts
+++ b/packages/cli/src/constructs/multi-step-check.ts
@@ -47,7 +47,7 @@ export class MultiStepCheck extends Check {
 
     this.playwrightConfig = props.playwrightConfig
 
-    if (!Session.availableRuntimes[this.runtimeId!]?.multiStepSupport) {
+    if (!Session.getRuntime(this.runtimeId)?.multiStepSupport) {
       throw new Error('This runtime does not support multi step checks.')
     }
     if ('content' in props.code) {
@@ -65,7 +65,7 @@ export class MultiStepCheck extends Check {
         absoluteEntrypoint = path.join(path.dirname(Session.checkFileAbsolutePath), entrypoint)
       }
       // runtimeId will always be set by check or multi-step check defaults so it is safe to use ! operator
-      const bundle = MultiStepCheck.bundle(absoluteEntrypoint, this.runtimeId!)
+      const bundle = MultiStepCheck.bundle(absoluteEntrypoint, this.runtimeId)
       if (!bundle.script) {
         throw new Error(`Multi-Step check "${logicalId}" is not allowed to be empty`)
       }
@@ -99,8 +99,8 @@ export class MultiStepCheck extends Check {
     }
   }
 
-  static bundle (entry: string, runtimeId: string) {
-    const runtime = Session.availableRuntimes[runtimeId]
+  static bundle (entry: string, runtimeId?: string) {
+    const runtime = Session.getRuntime(runtimeId)
     if (!runtime) {
       throw new Error(`${runtimeId} is not supported`)
     }

--- a/packages/cli/src/constructs/project.ts
+++ b/packages/cli/src/constructs/project.ts
@@ -142,6 +142,7 @@ export class Session {
   static checkFilePath?: string
   static checkFileAbsolutePath?: string
   static availableRuntimes: Record<string, Runtime>
+  static defaultRuntimeId?: string
   static verifyRuntimeDependencies = true
   static loadingChecklyConfigFile: boolean
   static checklyConfigFileConstructs?: Construct[]
@@ -153,7 +154,7 @@ export class Session {
     } else if (Session.loadingChecklyConfigFile && construct.allowInChecklyConfig()) {
       Session.checklyConfigFileConstructs!.push(construct)
     } else {
-      throw new Error('Internal Error: Session is not properly configured for using a construct. Please contact Checkly support on support@checklyhq.com')
+      throw new Error('Internal Error: Session is not properly configured for using a construct. Please contact Checkly support at support@checklyhq.com.')
     }
   }
 
@@ -181,5 +182,13 @@ export class Session {
       Session.privateLocations = privateLocations
     }
     return Session.privateLocations
+  }
+
+  static getRuntime (runtimeId?: string): Runtime | undefined {
+    const effectiveRuntimeId = runtimeId ?? Session.defaultRuntimeId
+    if (effectiveRuntimeId === undefined) {
+      throw new Error('Internal Error: Account default runtime is not set. Please contact Checkly support at support@checklyhq.com.')
+    }
+    return Session.availableRuntimes[effectiveRuntimeId]
   }
 }

--- a/packages/cli/src/rest/accounts.ts
+++ b/packages/cli/src/rest/accounts.ts
@@ -3,6 +3,7 @@ import type { AxiosInstance } from 'axios'
 export interface Account {
   id: string
   name: string
+  runtimeId: string
 }
 
 class Accounts {

--- a/packages/cli/src/services/__tests__/project-parser.spec.ts
+++ b/packages/cli/src/services/__tests__/project-parser.spec.ts
@@ -33,6 +33,7 @@ describe('parseProject()', () => {
       projectName: 'project name',
       repoUrl: 'https://github.com/checkly/checkly-cli',
       availableRuntimes: runtimes,
+      defaultRuntimeId: '2024.02',
     })
     const synthesizedProject = project.synthesize()
     expect(synthesizedProject).toMatchObject({
@@ -67,6 +68,7 @@ describe('parseProject()', () => {
       projectName: 'project name',
       repoUrl: 'https://github.com/checkly/checkly-cli',
       availableRuntimes: runtimes,
+      defaultRuntimeId: '2024.02',
     })
     const synthesizedProject = project.synthesize()
     expect(synthesizedProject).toMatchObject({
@@ -123,6 +125,7 @@ describe('parseProject()', () => {
       projectName: 'ts project',
       repoUrl: 'https://github.com/checkly/checkly-cli',
       availableRuntimes: runtimes,
+      defaultRuntimeId: '2024.02',
     })
     expect(project.synthesize()).toMatchObject({
       project: {
@@ -143,6 +146,7 @@ describe('parseProject()', () => {
       availableRuntimes: runtimes,
       checkMatch: ['**/__checks1__/*.check.js', '**/__checks2__/*.check.js', '**/__nested-checks__/*.check.js'],
       browserCheckMatch: ['**/__checks1__/*.spec.js', '**/__checks2__/*.spec.js', '**/__nested-checks__/*.spec.js'],
+      defaultRuntimeId: '2024.02',
     })
     expect(project.synthesize()).toMatchObject({
       project: {
@@ -170,6 +174,7 @@ describe('parseProject()', () => {
         availableRuntimes: runtimes,
         checkMatch: '**/*.foobar.js', // don't match .check.js files used for a different test
         browserCheckMatch: '**/*.spec.js',
+        defaultRuntimeId: '2024.02',
       })
       // shouldn't reach this point
       expect(true).toBe(false)
@@ -187,6 +192,7 @@ describe('parseProject()', () => {
         projectName: 'empty script project',
         repoUrl: 'https://github.com/checkly/checkly-cli',
         availableRuntimes: runtimes,
+        defaultRuntimeId: '2024.02',
         browserCheckMatch: '**/*.foobar.js', // don't match .spec.js files used for a different test
       })
       // shouldn't reach this point
@@ -203,6 +209,7 @@ describe('parseProject()', () => {
       projectLogicalId: 'glob-project-id',
       projectName: 'glob project',
       availableRuntimes: runtimes,
+      defaultRuntimeId: '2024.02',
       checkMatch: [],
       browserCheckMatch: ['**/__checks__/browser/*.spec.js'],
       multiStepCheckMatch: ['**/__checks__/multistep/*.spec.js'],

--- a/packages/cli/src/services/project-parser.ts
+++ b/packages/cli/src/services/project-parser.ts
@@ -23,12 +23,12 @@ type ProjectParseOpts = {
   checkDefaults?: CheckConfigDefaults,
   browserCheckDefaults?: CheckConfigDefaults,
   availableRuntimes: Record<string, Runtime>,
+  defaultRuntimeId: string,
   verifyRuntimeDependencies?: boolean,
   checklyConfigConstructs?: Construct[],
 }
 
 const BASE_CHECK_DEFAULTS = {
-  runtimeId: '2024.02',
 }
 
 export async function parseProject (opts: ProjectParseOpts): Promise<Project> {
@@ -44,6 +44,7 @@ export async function parseProject (opts: ProjectParseOpts): Promise<Project> {
     checkDefaults = {},
     browserCheckDefaults = {},
     availableRuntimes,
+    defaultRuntimeId,
     verifyRuntimeDependencies,
     checklyConfigConstructs,
   } = opts
@@ -59,6 +60,7 @@ export async function parseProject (opts: ProjectParseOpts): Promise<Project> {
   Session.checkDefaults = Object.assign({}, BASE_CHECK_DEFAULTS, checkDefaults)
   Session.browserCheckDefaults = browserCheckDefaults
   Session.availableRuntimes = availableRuntimes
+  Session.defaultRuntimeId = defaultRuntimeId
   Session.verifyRuntimeDependencies = verifyRuntimeDependencies ?? true
 
   // TODO: Do we really need all of the ** globs, or could we just put node_modules?


### PR DESCRIPTION
The CLI had a hardcoded default runtime value of `2024.02`, which became the effective value if no runtime was set at check or project level. Now, the account's default runtime is used instead. Additionally, if the account's default runtime is used, then we leave `runtimeId` undefined when synthesizing resources. This allows the user to have their checks always use the current account default runtime if they wish. If they do not wish to have such behavior, they should set a default runtime at project level as usual.

Technically speaking this is a potentially breaking change if a user has something other than `2024.02` set as their default account runtime, and have never set a runtime at project or check level. When they next deploy their checks (or run `checkly test`), a different runtime will be used. However, this kind of usage should be rare, and the user may simply change their default account runtime or define the runtime in the CLI project to restore the previous runtime, if needed.

I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [x] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
