### PR TITLE
fix: fix broken and flaky e2e test

### DIFF
--- a/packages/cli/e2e/__tests__/deploy.spec.ts
+++ b/packages/cli/e2e/__tests__/deploy.spec.ts
@@ -234,7 +234,29 @@ Update and Unchanged:
     })
     expect(resultOne.status).toBe(0)
     expect(resultTwo.status).toBe(0)
-    expect(resultOne.stdout).not.toEqual(resultTwo.stdout)
+    expect(resultOne.stdout).toContain(
+`Create:
+    ApiCheck: api-check
+    ApiCheck: api-check-high-freq
+    HeartbeatCheck: heartbeat-check-1
+    BrowserCheck: homepage-browser-check
+    CheckGroup: my-group-1
+    Dashboard: dashboard-1
+    MaintenanceWindow: maintenance-window-1
+    PrivateLocation: private-location-1
+`)
+    expect(resultTwo.stdout).toContain(
+`Create:
+    ApiCheck: api-check
+    ApiCheck: api-check-high-freq
+    HeartbeatCheck: heartbeat-check-1
+    BrowserCheck: homepage-browser-check
+    BrowserCheck: snapshot-test.test.ts
+    CheckGroup: my-group-1
+    Dashboard: dashboard-1
+    MaintenanceWindow: maintenance-window-1
+    PrivateLocation: private-location-1
+`)
   })
 
   it('Should terminate when no resources are found', async () => {

--- a/packages/cli/e2e/__tests__/fixtures/deploy-project/snapshot-test.test.ts
+++ b/packages/cli/e2e/__tests__/fixtures/deploy-project/snapshot-test.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from '@playwright/test'
+
+test.use({ actionTimeout: 10000 })
+
+test('Danube Snapshot Test', async ({ page }) => {
+  await page.goto('https://danube-web.shop')
+  await expect(page).toHaveScreenshot({ maxDiffPixels: 10000 })
+})

--- a/packages/cli/e2e/run-checkly.ts
+++ b/packages/cli/e2e/run-checkly.ts
@@ -37,6 +37,7 @@ export function runChecklyCli (options: {
         // Once 4.8.0 has been released, we can remove the 4.8.0 fallback here.
         CHECKLY_CLI_VERSION: cliVersion ?? '4.8.0',
         CHECKLY_E2E_PROMPTS_INJECTIONS: promptsInjection?.length ? JSON.stringify(promptsInjection) : undefined,
+        CHECKLY_E2E_DISABLE_FANCY_OUTPUT: '1',
         ...env,
       },
       cwd: directory ?? process.cwd(),

--- a/packages/cli/src/commands/baseCommand.ts
+++ b/packages/cli/src/commands/baseCommand.ts
@@ -10,6 +10,7 @@ export type BaseCommandClass = typeof Command & {
 export abstract class BaseCommand extends Command {
   static coreCommand = false
   static hidden = true
+  fancy = true
 
   protected async init (): Promise<void> {
     let version = process.env.CHECKLY_CLI_VERSION ?? this.config.version
@@ -33,6 +34,10 @@ export abstract class BaseCommand extends Command {
       } catch {
         process.stderr.write('Error parsing CHECKLY_E2E_PROMPTS_INJECTIONS environment variable for injections.')
       }
+    }
+
+    if (process.env.CHECKLY_E2E_DISABLE_FANCY_OUTPUT) {
+      this.fancy = false
     }
 
     return super.init()

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -74,7 +74,9 @@ export default class Deploy extends AuthCommand {
   }
 
   async run (): Promise<void> {
-    ux.action.start('Parsing your project', undefined, { stdout: true })
+    if (this.fancy) {
+      ux.action.start('Parsing your project', undefined, { stdout: true })
+    }
     const { flags } = await this.parse(Deploy)
     const {
       force,
@@ -113,7 +115,10 @@ export default class Deploy extends AuthCommand {
       checklyConfigConstructs,
     })
     const repoInfo = getGitInformation(project.repoUrl)
-    ux.action.stop()
+
+    if (this.fancy) {
+      ux.action.stop()
+    }
 
     if (!preview) {
       for (const check of Object.values(project.data.check)) {

--- a/packages/cli/src/commands/sync-playwright.ts
+++ b/packages/cli/src/commands/sync-playwright.ts
@@ -12,7 +12,9 @@ export default class SyncPlaywright extends BaseCommand {
   static description = 'Copy Playwright config into the Checkly config file.'
 
   async run (): Promise<void> {
-    ux.action.start('Syncing Playwright config to the Checkly config file', undefined, { stdout: true })
+    if (this.fancy) {
+      ux.action.start('Syncing Playwright config to the Checkly config file', undefined, { stdout: true })
+    }
 
     const config = await loadPlaywrightConfig()
     if (!config) {
@@ -40,13 +42,17 @@ export default class SyncPlaywright extends BaseCommand {
     const dir = path.resolve(path.dirname(configFile.fileName))
     this.reWriteChecklyConfigFile(checklyConfigData, configFile.fileName, dir)
 
-    ux.action.stop('✅ ')
+    if (this.fancy) {
+      ux.action.stop('✅ ')
+    }
     this.log('Successfully updated Checkly config file')
     this.exit(0)
   }
 
   private handleError (message: string) {
-    ux.action.stop('❌')
+    if (this.fancy) {
+      ux.action.stop('❌')
+    }
     this.log(message)
     this.exit(1)
   }

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -124,7 +124,9 @@ export default class Test extends AuthCommand {
   static strict = false
 
   async run (): Promise<void> {
-    ux.action.start('Parsing your project', undefined, { stdout: true })
+    if (this.fancy) {
+      ux.action.start('Parsing your project', undefined, { stdout: true })
+    }
 
     const { flags, argv } = await this.parse(Test)
     const {
@@ -228,7 +230,9 @@ export default class Test extends AuthCommand {
       check.snapshots = await uploadSnapshots(check.rawSnapshots)
     }
 
-    ux.action.stop()
+    if (this.fancy) {
+      ux.action.stop()
+    }
 
     if (!checks.length) {
       this.log(`Unable to find checks to run${filePatterns[0] !== '.*' ? ' using [FILEARGS]=\'' + filePatterns + '\'' : ''}.`)


### PR DESCRIPTION
Also makes it so that fancy output (or some of it anyway) is now disabled for E2E tests because it's annoying and hid this particular issue.

I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [ ] CLI
* [ ] Create CLI
* [x] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
