### PR TITLE
feat: support `node:` prefix for built-in modules [sc-22633]

### DIFF
--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/builtin-with-node-prefix/entrypoint.ts
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/builtin-with-node-prefix/entrypoint.ts
@@ -1,0 +1,3 @@
+import {} from 'node:path'
+import {} from 'node:url'
+import {} from 'crypto'

--- a/packages/cli/src/services/check-parser/__tests__/check-parser.spec.ts
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser.spec.ts
@@ -233,6 +233,14 @@ describe('dependency-parser - parser()', () => {
     ])
   })
 
+  it('should handle node: prefix for built-ins', () => {
+    const toAbsolutePath = (...filepath: string[]) => path.join(__dirname, 'check-parser-fixtures', 'builtin-with-node-prefix', ...filepath)
+    const parser = new Parser({
+      supportedNpmModules: defaultNpmModules,
+    })
+    parser.parse(toAbsolutePath('entrypoint.ts'))
+  })
+
   /*
    * There is an unhandled edge-case when require() is reassigned.
    * Even though the check might execute fine, we throw an error for a missing dependency.

--- a/packages/cli/src/services/check-parser/package-files/paths.ts
+++ b/packages/cli/src/services/check-parser/package-files/paths.ts
@@ -260,3 +260,11 @@ export function isLocalPath (importPath: string) {
 
   return false
 }
+
+export function isBuiltinPath (importPath: string) {
+  if (importPath.startsWith('node:')) {
+    return true
+  }
+
+  return false
+}

--- a/packages/cli/src/services/check-parser/package-files/resolver.ts
+++ b/packages/cli/src/services/check-parser/package-files/resolver.ts
@@ -6,7 +6,7 @@ import { SourceFile } from './source-file'
 import { PackageJsonFile } from './package-json-file'
 import { TSConfigFile } from './tsconfig-json-file'
 import { JSConfigFile } from './jsconfig-json-file'
-import { isLocalPath, PathResult } from './paths'
+import { isBuiltinPath, isLocalPath, PathResult } from './paths'
 import { FileLoader, LoadFile } from './loader'
 import { JsonSourceFile } from './json-source-file'
 import { LookupContext } from './lookup'
@@ -248,6 +248,13 @@ export class PackageFilesResolver {
 
     resolve:
     for (const importPath of dependencies) {
+      if (isBuiltinPath(importPath)) {
+        resolved.external.push({
+          importPath,
+        })
+        continue resolve
+      }
+
       if (isLocalPath(importPath)) {
         const relativeDepPath = path.resolve(dirname, importPath)
         const sourceFile = this.cache.sourceFile(relativeDepPath, context)

--- a/packages/cli/src/services/check-parser/parser.ts
+++ b/packages/cli/src/services/check-parser/parser.ts
@@ -21,8 +21,21 @@ type SupportedFileExtension = '.js' | '.mjs' | '.ts'
 const PACKAGE_EXTENSION = `${path.sep}package.json`
 
 const supportedBuiltinModules = [
-  'assert', 'buffer', 'crypto', 'dns', 'fs', 'path', 'querystring', 'readline ', 'stream', 'string_decoder',
-  'timers', 'tls', 'url', 'util', 'zlib',
+  'node:assert',
+  'node:buffer',
+  'node:crypto',
+  'node:dns',
+  'node:fs',
+  'node:path',
+  'node:querystring',
+  'node:readline',
+  'node:stream',
+  'node:string_decoder',
+  'node:timers',
+  'node:tls',
+  'node:url',
+  'node:util',
+  'node:zlib',
 ]
 
 function validateEntrypoint (entrypoint: string): {extension: SupportedFileExtension, content: string} {
@@ -87,6 +100,18 @@ export class Parser {
     this.checkUnsupportedModules = options.checkUnsupportedModules ?? true
   }
 
+  supportsModule (importPath: string) {
+    if (this.supportedModules.has(importPath)) {
+      return true
+    }
+
+    if (this.supportedModules.has('node:' + importPath)) {
+      return true
+    }
+
+    return false
+  }
+
   parse (entrypoint: string) {
     const { content } = validateEntrypoint(entrypoint)
 
@@ -130,7 +155,7 @@ export class Parser {
 
       if (this.checkUnsupportedModules) {
         const unsupportedDependencies = resolvedDependencies.external.flatMap(dep => {
-          if (!this.supportedModules.has(dep.importPath)) {
+          if (!this.supportsModule(dep.importPath)) {
             return [dep.importPath]
           } else {
             return []


### PR DESCRIPTION
This PR makes both `import 'node:path'` and `import 'path'` equivalent.
 
Also fixes a typo in the supported dependency list: `'readline '` had a trailing space.

I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
