### PR TITLE
chore: bump runtimeId to latest (2024.09) in examples

### DIFF
--- a/examples/advanced-project-js/checkly.config.js
+++ b/examples/advanced-project-js/checkly.config.js
@@ -24,7 +24,7 @@ const config = defineConfig({
     /** The Checkly Runtime identifier, determining npm packages and the Node.js version available at runtime.
      * See https://www.checklyhq.com/docs/cli/npm-packages/
      */
-    runtimeId: '2024.02',
+    runtimeId: '2024.09',
     /* Failed check runs will be retried before triggering alerts */
     retryStrategy: RetryStrategyBuilder.fixedStrategy({ baseBackoffSeconds: 60, maxRetries: 4, sameRegion: true }),
     /* A glob pattern that matches the Checks inside your repo, see https://www.checklyhq.com/docs/cli/using-check-test-match/ */

--- a/examples/advanced-project-js/src/__checks__/multi-step-spacex.check.js
+++ b/examples/advanced-project-js/src/__checks__/multi-step-spacex.check.js
@@ -13,7 +13,7 @@ const alertChannels = [smsChannel, emailChannel]
 // We can define multiple checks in a single *.check.js file.
 new MultiStepCheck('spacex-multistep-check', {
   name: 'SpaceX MS',
-  runtimeId: '2024.02',
+  runtimeId: '2024.09',
   alertChannels,
   code: {
     entrypoint: path.join(__dirname, 'spacex-requests.spec.js')

--- a/examples/advanced-project-js/src/__checks__/website-group.check.js
+++ b/examples/advanced-project-js/src/__checks__/website-group.check.js
@@ -17,7 +17,7 @@ const websiteGroup = new CheckGroup('website-check-group-1', {
   name: 'Website Group',
   activated: true,
   muted: false,
-  runtimeId: '2024.02',
+  runtimeId: '2024.09',
   locations: ['us-east-1', 'eu-west-1'],
   tags: ['mac', 'group'],
   environmentVariables: [],

--- a/examples/advanced-project/checkly.config.ts
+++ b/examples/advanced-project/checkly.config.ts
@@ -24,7 +24,7 @@ const config = defineConfig({
     /** The Checkly Runtime identifier, determining npm packages and the Node.js version available at runtime.
      * See https://www.checklyhq.com/docs/cli/npm-packages/
      */
-    runtimeId: '2024.02',
+    runtimeId: '2024.09',
     /* Failed check runs will be retried before triggering alerts */
     retryStrategy: RetryStrategyBuilder.fixedStrategy({ baseBackoffSeconds: 60, maxRetries: 4, sameRegion: true }),
     /* All checks will have this alert escalation policy defined */

--- a/examples/advanced-project/src/__checks__/multi-step-spacex.check.ts
+++ b/examples/advanced-project/src/__checks__/multi-step-spacex.check.ts
@@ -13,7 +13,7 @@ const alertChannels = [smsChannel, emailChannel]
 // We can define multiple checks in a single *.check.ts file.
 new MultiStepCheck('spacex-multistep-check', {
   name: 'SpaceX MS',
-  runtimeId: '2024.02',
+  runtimeId: '2024.09',
   alertChannels,
   code: {
     entrypoint: path.join(__dirname, 'spacex-requests.spec.ts')

--- a/examples/advanced-project/src/__checks__/website-group.check.ts
+++ b/examples/advanced-project/src/__checks__/website-group.check.ts
@@ -17,7 +17,7 @@ export const websiteGroup = new CheckGroup('website-check-group-1', {
   name: 'Website Group',
   activated: true,
   muted: false,
-  runtimeId: '2024.02',
+  runtimeId: '2024.09',
   locations: ['us-east-1', 'eu-west-1'],
   tags: ['mac', 'group'],
   environmentVariables: [],

--- a/examples/boilerplate-project-js/checkly.config.js
+++ b/examples/boilerplate-project-js/checkly.config.js
@@ -23,7 +23,7 @@ const config = defineConfig({
     /** The Checkly Runtime identifier, determining npm packages and the Node.js version available at runtime.
      * See https://www.checklyhq.com/docs/cli/npm-packages/
      */
-    runtimeId: '2024.02',
+    runtimeId: '2024.09',
     /* A glob pattern that matches the Checks inside your repo, see https://www.checklyhq.com/docs/cli/using-check-test-match/ */
     checkMatch: '**/__checks__/**/*.check.js',
     /* Global configuration option for Playwright-powered checks. See https://www.checklyhq.com/docs/browser-checks/playwright-test/#global-configuration */

--- a/examples/boilerplate-project/checkly.config.ts
+++ b/examples/boilerplate-project/checkly.config.ts
@@ -23,7 +23,7 @@ const config = defineConfig({
     /** The Checkly Runtime identifier, determining npm packages and the Node.js version available at runtime.
      * See https://www.checklyhq.com/docs/cli/npm-packages/
      */
-    runtimeId: '2024.02',
+    runtimeId: '2024.09',
     /* A glob pattern that matches the Checks inside your repo, see https://www.checklyhq.com/docs/cli/using-check-test-match/ */
     checkMatch: '**/__checks__/**/*.check.ts',
     /* Global configuration option for Playwright-powered checks. See https://www.checklyhq.com/docs/browser-checks/playwright-test/#global-configuration */


### PR DESCRIPTION
2024.09 is the latest `CURRENT` version. 2024.02 is still the latest `STABLE` but we are bumping anyway.

I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [ ] CLI
* [x] Create CLI
* [ ] Test
* [ ] Docs
* [x] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
