### PR TITLE
feat: add assertion and connection error reporters to TCP checks [sc-23082]

### DIFF
--- a/packages/cli/e2e/__tests__/fixtures/tcp-check-failures/checkly.config.ts
+++ b/packages/cli/e2e/__tests__/fixtures/tcp-check-failures/checkly.config.ts
@@ -1,0 +1,6 @@
+const config = {
+  projectName: 'TCP Check Failures',
+  logicalId: process.env.PROJECT_LOGICAL_ID,
+  repoUrl: 'https://github.com/checkly/checkly-cli',
+}
+export default config

--- a/packages/cli/e2e/__tests__/fixtures/tcp-check-failures/tcp.check.ts
+++ b/packages/cli/e2e/__tests__/fixtures/tcp-check-failures/tcp.check.ts
@@ -1,0 +1,72 @@
+/* eslint-disable no-new */
+import { TcpCheck, TcpAssertionBuilder } from 'checkly/constructs'
+
+new TcpCheck('tcp-check-dns-failure-ipv4', {
+  name: 'TCP check with DNS lookup failure (IPv4)',
+  activated: true,
+  request: {
+    hostname: 'does-not-exist.checklyhq.com',
+    port: 443,
+  },
+})
+
+new TcpCheck('tcp-check-dns-failure-ipv6', {
+  name: 'TCP check with DNS lookup failure (IPv6)',
+  activated: true,
+  request: {
+    hostname: 'does-not-exist.checklyhq.com',
+    port: 443,
+    ipFamily: 'IPv6',
+  },
+})
+
+new TcpCheck('tcp-check-connection-refused', {
+  name: 'TCP check for connection that gets refused',
+  activated: true,
+  request: {
+    hostname: '127.0.0.1',
+    port: 12345,
+  },
+})
+
+new TcpCheck('tcp-check-connection-refused-2', {
+  name: 'TCP check for connection that gets refused #2',
+  activated: true,
+  request: {
+    hostname: '0.0.0.0',
+    port: 12345,
+  },
+})
+
+new TcpCheck('tcp-check-timed-out', {
+  name: 'TCP check for connection that times out',
+  activated: true,
+  request: {
+    hostname: 'api.checklyhq.com',
+    port: 9999,
+  },
+})
+
+new TcpCheck('tcp-check-failing-assertions', {
+  name: 'TCP check with failing assertions',
+  activated: true,
+  request: {
+    hostname: 'api.checklyhq.com',
+    port: 80,
+    data: 'GET / HTTP/1.1\r\nHost: api.checklyhq.com\r\nConnection: close\r\n\r\n',
+    assertions: [
+      TcpAssertionBuilder.responseData().contains('NEVER_PRESENT'),
+      TcpAssertionBuilder.responseTime().lessThan(1),
+    ],
+  },
+})
+
+new TcpCheck('tcp-check-wrong-ip-family', {
+  name: 'TCP check with wrong IP family',
+  activated: true,
+  request: {
+    hostname: 'ipv4.google.com',
+    port: 80,
+    ipFamily: 'IPv6',
+  },
+})


### PR DESCRIPTION
This PR adds reporter support for TCP check assertion and connection errors.

I added a new fixture folder with TCP checks that at least currently are able to trigger various error scenarios. However, I am undecided as to whether such checks are stable enough to use in e2e checks, so the fixtures are currently unused.
 
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
