### PR TITLE
refactor: add missing `mts` ext. support to checkly config

### DIFF
--- a/packages/cli/src/services/__tests__/checkly-config-loader.spec.ts
+++ b/packages/cli/src/services/__tests__/checkly-config-loader.spec.ts
@@ -23,7 +23,7 @@ describe('loadChecklyConfig()', () => {
       await loadChecklyConfig(configDir)
     } catch (e: any) {
       expect(e.message).toContain(`Unable to locate a config at ${configDir} with ${
-        ['checkly.config.ts', 'checkly.config.js', 'checkly.config.mjs'].join(', ')}.`)
+        ['checkly.config.ts', 'checkly.config.js', 'checkly.config.mts', 'checkly.config.mjs'].join(', ')}.`)
     }
   })
   it('config TS file should export an object', async () => {

--- a/packages/cli/src/services/checkly-config-loader.ts
+++ b/packages/cli/src/services/checkly-config-loader.ts
@@ -101,7 +101,7 @@ function isString (obj: any) {
 }
 
 export function getChecklyConfigFile (): {checklyConfig: string, fileName: string} | undefined {
-  const filenames: string[] = ['checkly.config.ts', 'checkly.config.js', 'checkly.config.mjs']
+  const filenames: string[] = ['checkly.config.ts', 'checkly.config.js', 'checkly.config.mts', 'checkly.config.mjs']
   let config
   for (const configFile of filenames) {
     const dir = path.resolve(path.dirname(configFile))
@@ -120,7 +120,7 @@ export function getChecklyConfigFile (): {checklyConfig: string, fileName: strin
   return config
 }
 
-export async function loadChecklyConfig (dir: string, filenames = ['checkly.config.ts', 'checkly.config.js', 'checkly.config.mjs']): Promise<{ config: ChecklyConfig, constructs: Construct[] }> {
+export async function loadChecklyConfig (dir: string, filenames = ['checkly.config.ts', 'checkly.config.js', 'checkly.config.mts', 'checkly.config.mjs']): Promise<{ config: ChecklyConfig, constructs: Construct[] }> {
   let config
   Session.loadingChecklyConfigFile = true
   Session.checklyConfigFileConstructs = []

--- a/packages/create-cli/src/actions/playwright.ts
+++ b/packages/create-cli/src/actions/playwright.ts
@@ -45,7 +45,7 @@ function handleError (copySpinner: ora.Ora, message: string | unknown) {
 }
 
 function getChecklyConfigFile (): {checklyConfig: string, fileName: string} | undefined {
-  const filenames: string[] = ['checkly.config.ts', 'checkly.config.js', 'checkly.config.mjs']
+  const filenames: string[] = ['checkly.config.ts', 'checkly.config.js', 'checkly.config.mts', 'checkly.config.mjs']
   let config
   for (const configFile of filenames) {
     const dir = path.resolve(path.dirname(configFile))


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Currently the CLI is able to read both JS/TS files, or `.mjs` when the app is declared as `commonjs` and needs to be interpreted as a ESM; but is missing the ability to do so when the config is written in TypeScript.

This PR adds the `.mts` extension to the list of candidates to read the config from to allow certain settings like https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax to work while in commonjs apps.
