### PR TITLE
feat: adds degraded state to reporters [sc-00]

### DIFF
--- a/packages/cli/src/reporters/__tests__/__snapshots__/util.spec.ts.snap
+++ b/packages/cli/src/reporters/__tests__/__snapshots__/util.spec.ts.snap
@@ -208,6 +208,8 @@ exports[`formatCheckResult() Browser Check result formats a Browser Check result
 
 exports[`formatCheckResult() Browser Check result formats a basic Browser Check result : browser-check-result-basic-format 1`] = `""`;
 
+exports[`formatCheckTitle() should print a degraded check title: degraded-check-title 1`] = `"⚠ /test/test-file.check.ts > Test Check (11s)"`;
+
 exports[`formatCheckTitle() should print a failed check title: failed-check-title 1`] = `"✖ /test/test-file.check.ts > Test Check (11s)"`;
 
 exports[`formatCheckTitle() should print a passed check title: passed-check-title 1`] = `"✔ /test/test-file.check.ts > Test Check (11s)"`;

--- a/packages/cli/src/reporters/__tests__/util.spec.ts
+++ b/packages/cli/src/reporters/__tests__/util.spec.ts
@@ -1,4 +1,4 @@
-import { formatCheckTitle, formatCheckResult, CheckStatus } from '../util'
+import { formatCheckTitle, formatCheckResult, CheckStatus, resultToCheckStatus } from '../util'
 import { simpleCheckFixture } from './fixtures/simple-check'
 import { apiCheckResult } from './fixtures/api-check-result'
 import { browserCheckResult } from './fixtures/browser-check-result'
@@ -22,6 +22,10 @@ describe('formatCheckTitle()', () => {
   it('should print a passed check title', () => {
     expect(stripAnsi(formatCheckTitle(CheckStatus.SUCCESSFUL, simpleCheckFixture, { includeSourceFile: true })))
       .toMatchSnapshot('passed-check-title')
+  })
+  it('should print a degraded check title', () => {
+    expect(stripAnsi(formatCheckTitle(CheckStatus.DEGRADED, simpleCheckFixture, { includeSourceFile: true })))
+      .toMatchSnapshot('degraded-check-title')
   })
   it('should print a running check title', () => {
     expect(stripAnsi(formatCheckTitle(CheckStatus.RUNNING, simpleCheckFixture, { includeSourceFile: true })))
@@ -83,5 +87,24 @@ describe('formatCheckResult()', () => {
       expect(stripAnsi(formatCheckResult(basicBrowserCheckResult)))
         .toMatchSnapshot('browser-check-result-schedule-error-format')
     })
+  })
+})
+
+describe('resultToCheckStatus()', () => {
+  it('returns a successful status', () => {
+    expect(resultToCheckStatus({ hasFailures: false, isDegraded: false, hasErrors: false }))
+      .toBe(CheckStatus.SUCCESSFUL)
+  })
+  it('returns a failed status', () => {
+    expect(resultToCheckStatus({ hasFailures: true, isDegraded: false, hasErrors: false }))
+      .toBe(CheckStatus.FAILED)
+  })
+  it('returns a failed status when also degraded', () => {
+    expect(resultToCheckStatus({ hasFailures: true, isDegraded: true, hasErrors: false }))
+      .toBe(CheckStatus.FAILED)
+  })
+  it('returns a degraded status', () => {
+    expect(resultToCheckStatus({ hasFailures: false, isDegraded: true, hasErrors: false }))
+      .toBe(CheckStatus.DEGRADED)
   })
 })

--- a/packages/cli/src/reporters/ci.ts
+++ b/packages/cli/src/reporters/ci.ts
@@ -1,7 +1,7 @@
 import indentString from 'indent-string'
 
 import AbstractListReporter from './abstract-list'
-import { formatCheckTitle, formatCheckResult, CheckStatus, printLn } from './util'
+import { formatCheckTitle, formatCheckResult, CheckStatus, printLn, resultToCheckStatus } from './util'
 import { SequenceId } from '../services/abstract-check-runner'
 import { TestResultsShortLinks } from '../rest/test-sessions'
 
@@ -27,7 +27,7 @@ export default class CiReporter extends AbstractListReporter {
 
   onCheckEnd (sequenceId: SequenceId, checkResult: any) {
     super.onCheckEnd(sequenceId, checkResult)
-    printLn(formatCheckTitle(checkResult.hasFailures ? CheckStatus.FAILED : CheckStatus.SUCCESSFUL, checkResult))
+    printLn(formatCheckTitle(resultToCheckStatus(checkResult), checkResult))
 
     if (this.verbose || checkResult.hasFailures) {
       printLn(indentString(formatCheckResult(checkResult), 4), 2, 1)

--- a/packages/cli/src/reporters/dot.ts
+++ b/packages/cli/src/reporters/dot.ts
@@ -18,6 +18,8 @@ export default class DotReporter extends AbstractListReporter {
     super.onCheckEnd(sequenceId, checkResult)
     if (checkResult.hasFailures) {
       print(`${chalk.red('F')}`)
+    } else if (checkResult.isDegraded) {
+      print(`${chalk.yellow('D')}`)
     } else {
       print(`${chalk.green('.')}`)
     }

--- a/packages/cli/src/reporters/github.ts
+++ b/packages/cli/src/reporters/github.ts
@@ -3,7 +3,7 @@ import * as path from 'path'
 
 import AbstractListReporter, { checkFilesMap } from './abstract-list'
 import { SequenceId } from '../services/abstract-check-runner'
-import { formatDuration, printLn, getTestSessionUrl } from './util'
+import { CheckStatus, formatDuration, getTestSessionUrl, printLn, resultToCheckStatus } from './util'
 
 const outputFile = './checkly-github-report.md'
 
@@ -64,8 +64,9 @@ export class GithubMdBuilder {
 
     for (const [_, checkMap] of this.checkFilesMap.entries()) {
       for (const [_, { result, testResultId }] of checkMap.entries()) {
+        const checkStatus = resultToCheckStatus(result)
         const tableRow: Array<string> = [
-          `${result.hasFailures ? '❌ Fail' : '✅ Pass'}`,
+          `${checkStatus === CheckStatus.FAILED ? '❌ Fail' : checkStatus === CheckStatus.DEGRADED ? '⚠️ Degraded' : '✅ Pass'}`,
           `${result.name}`,
           `${result.checkType}`,
           this.hasFilenames ? `\`${result.sourceFile}\`` : undefined,

--- a/packages/cli/src/reporters/json.ts
+++ b/packages/cli/src/reporters/json.ts
@@ -3,7 +3,7 @@ import * as path from 'path'
 
 import AbstractListReporter, { checkFilesMap } from './abstract-list'
 import { CheckRunId, SequenceId } from '../services/abstract-check-runner'
-import { printLn, getTestSessionUrl } from './util'
+import { CheckStatus, getTestSessionUrl, printLn, resultToCheckStatus } from './util'
 
 const outputFile = './checkly-json-report.json'
 
@@ -41,8 +41,9 @@ export class JsonBuilder {
     for (const [_, checkMap] of this.checkFilesMap.entries()) {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       for (const [_, { result, testResultId, numRetries }] of checkMap.entries()) {
+        const checkStatus = resultToCheckStatus(result)
         const check: any = {
-          result: result.hasFailures ? 'Fail' : 'Pass',
+          result: checkStatus === CheckStatus.FAILED ? 'Fail' : checkStatus === CheckStatus.DEGRADED ? 'Degraded' : 'Pass',
           name: result.name,
           checkType: result.checkType,
           durationMilliseconds: result.responseTime ?? null,

--- a/packages/cli/src/reporters/list.ts
+++ b/packages/cli/src/reporters/list.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk'
 
 import AbstractListReporter from './abstract-list'
 import { SequenceId } from '../services/abstract-check-runner'
-import { formatCheckTitle, formatCheckResult, CheckStatus, printLn } from './util'
+import { formatCheckTitle, formatCheckResult, CheckStatus, printLn, resultToCheckStatus } from './util'
 import { TestResultsShortLinks } from '../rest/test-sessions'
 
 export default class ListReporter extends AbstractListReporter {
@@ -58,11 +58,15 @@ export default class ListReporter extends AbstractListReporter {
     this._clearSummary()
 
     if (this.verbose) {
-      printLn(formatCheckTitle(checkResult.hasFailures ? CheckStatus.FAILED : CheckStatus.SUCCESSFUL, checkResult))
+      printLn(formatCheckTitle(resultToCheckStatus(checkResult), checkResult))
       printLn(indentString(formatCheckResult(checkResult), 4), 2, 1)
     } else {
       if (checkResult.hasFailures) {
         printLn(formatCheckTitle(CheckStatus.FAILED, checkResult))
+        printLn(indentString(formatCheckResult(checkResult), 4), 2, 1)
+      }
+      if (checkResult.isDegraded) {
+        printLn(formatCheckTitle(CheckStatus.DEGRADED, checkResult))
         printLn(indentString(formatCheckResult(checkResult), 4), 2, 1)
       }
     }

--- a/packages/cli/src/reporters/util.ts
+++ b/packages/cli/src/reporters/util.ts
@@ -13,6 +13,7 @@ export enum CheckStatus {
   RETRIED,
   FAILED,
   SUCCESSFUL,
+  DEGRADED,
 }
 
 export function formatDuration (ms: number): string {
@@ -44,6 +45,9 @@ export function formatCheckTitle (
   } else if (status === CheckStatus.FAILED) {
     statusString = logSymbols.error
     format = chalk.bold.red
+  } else if (status === CheckStatus.DEGRADED) {
+    statusString = logSymbols.warning
+    format = chalk.bold.yellow
   } else if (status === CheckStatus.SCHEDULING) {
     statusString = '~'
     format = chalk.bold.dim
@@ -438,6 +442,14 @@ function toString (val: any): string {
   } else {
     return val.toString()
   }
+}
+
+export function resultToCheckStatus (checkResult: any): CheckStatus {
+  return checkResult.hasFailures
+    ? CheckStatus.FAILED
+    : checkResult.isDegraded
+      ? CheckStatus.DEGRADED
+      : CheckStatus.SUCCESSFUL
 }
 
 export function print (text: string) {


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [x] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

## Notes for the Reviewer

This PR adds the "degraded" state to all relevant points, mostly in the reporters. Previously all interactions with "degraded" states (e.g. `test` and `trigger`) all reported a "degraded" check as "passed / successful". It reports the "degraded" state with a ⚠️ icon and yellow text. 

- adds to ci, dot, list and github reporters.
- adds to abtract list and summary.
- adds a small helper to not have double ternary statements everywhere.
- adds tests.

![CleanShot 2025-02-17 at 13 44 29](https://github.com/user-attachments/assets/e7f4ab4f-9fc3-4e96-9010-1044a2bc4ccd)

