### PR TITLE
feat: resolve declaration files (e.g. `.d.ts`) as a last resort [sc-23313]

### DIFF
--- a/packages/cli/src/services/check-parser/package-files/extension.ts
+++ b/packages/cli/src/services/check-parser/package-files/extension.ts
@@ -9,12 +9,20 @@ type CoreExtensionMapping = {
 }
 
 /**
+ * Unlike TypeScript's native lookup order, our lookup order prefers
+ * implementation files to declaration files.
+ *
+ * Why include declaration files at all? Some of our users use manually
+ * created declaration files as essentially shared header files without a
+ * corresponding implementation file, and the declaration is the only thing
+ * we'll be able to find. Otherwise we'd complain about a missing dependency.
+ *
  * @see https://www.typescriptlang.org/docs/handbook/modules/reference.html#file-extension-substitution
  */
 export const tsCoreExtensionLookupOrder: CoreExtensionMapping = {
-  '.js': ['.ts', '.tsx', '.js', '.jsx'],
-  '.mjs': ['.mts', '.mjs'],
-  '.cjs': ['.cts', '.cjs'],
+  '.js': ['.ts', '.tsx', '.js', '.jsx', '.d.ts'],
+  '.mjs': ['.mts', '.mjs', '.d.mts'],
+  '.cjs': ['.cts', '.cjs', '.d.cts'],
   '.json': ['.json'],
 }
 


### PR DESCRIPTION
It seems that some users are using declaration files as shared header files and there is nothing else to resolve. During normal transpilation, any such imports would get removed and the declaration file would not be part of the dist bundle. Since we transpile on the runner, it would be nice to have the file available there even though it's not technically even required. More importantly however this change makes the parser not complain about missing dependencies if it encounters imports that can only be resolved to a declaration file.

I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
