### PR TITLE
feat: add assertions to CheckGroup's API check defaults [sc-23331]

### DIFF
--- a/packages/cli/src/constructs/api-check.ts
+++ b/packages/cli/src/constructs/api-check.ts
@@ -73,6 +73,7 @@ export type ApiCheckDefaultConfig = {
   headers?: Array<HttpHeader>
   queryParameters?: Array<QueryParam>
   basicAuth?: BasicAuth
+  assertions?: Array<Assertion>
 }
 
 export interface Request {


### PR DESCRIPTION
This PR adds support for the `assertions` property of `apiCheckDefaults` which is already output by the UI's code generator. It can be used with `AssertionBuilder`.

I verified locally that the property is now getting sent to the backend and gets reflected correctly in the UI.

I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f)

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
