### PR TITLE
feat: full ESM config support using Jiti

### DIFF
--- a/examples/advanced-project/package.json
+++ b/examples/advanced-project/package.json
@@ -11,7 +11,6 @@
   "license": "ISC",
   "devDependencies": {
     "checkly": "latest",
-    "ts-node": "10.9.1",
-    "typescript": "4.9.5"
+    "jiti": "^2"
   }
 }

--- a/examples/boilerplate-project/package.json
+++ b/examples/boilerplate-project/package.json
@@ -11,7 +11,6 @@
   "license": "ISC",
   "devDependencies": {
     "checkly": "latest",
-    "ts-node": "10.9.1",
-    "typescript": "4.9.5"
+    "jiti": "^2"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10537,6 +10537,16 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jiti": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/jmespath": {
       "version": "0.16.0",
       "dev": true,
@@ -18877,6 +18887,7 @@
         "config": "3.3.9",
         "cross-env": "7.0.3",
         "jest": "29.7.0",
+        "jiti": "2.4.2",
         "nanoid": "3.3.4",
         "oclif": "3.7.3",
         "simple-git-hooks": "2.11.1",
@@ -18886,6 +18897,14 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "jiti": ">=2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
       }
     },
     "packages/cli/node_modules/@oclif/core": {
@@ -19463,6 +19482,7 @@
         "@types/uuid": "9.0.1",
         "config": "3.3.9",
         "jest": "29.7.0",
+        "jiti": "2.4.2",
         "rimraf": "5.0.1",
         "ts-jest": "29.2.4",
         "ts-node": "10.9.1",
@@ -19470,6 +19490,14 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "jiti": ">=2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
       }
     },
     "packages/create-cli/node_modules/@oclif/core": {
@@ -23460,6 +23488,7 @@
         "glob": "10.3.1",
         "indent-string": "4.0.0",
         "jest": "29.7.0",
+        "jiti": "2.4.2",
         "json-stream-stringify": "3.1.6",
         "json5": "2.2.3",
         "jwt-decode": "3.1.2",
@@ -24246,6 +24275,7 @@
         "execa": "5.1.0",
         "giget": "1.1.2",
         "jest": "29.7.0",
+        "jiti": "2.4.2",
         "json5": "2.2.3",
         "ora": "5.4.1",
         "passwd-user": "3.0.0",
@@ -27391,6 +27421,12 @@
           }
         }
       }
+    },
+    "jiti": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "dev": true
     },
     "jmespath": {
       "version": "0.16.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -113,12 +113,21 @@
     "config": "3.3.9",
     "cross-env": "7.0.3",
     "jest": "29.7.0",
+    "jiti": "2.4.2",
     "nanoid": "3.3.4",
     "oclif": "3.7.3",
     "simple-git-hooks": "2.11.1",
     "ts-jest": "29.2.4",
     "ts-node": "10.9.1",
     "typescript": "5.3.3"
+  },
+  "peerDependencies": {
+    "jiti": ">=2"
+  },
+  "peerDependenciesMeta": {
+    "jiti": {
+      "optional": true
+    }
   },
   "jest": {
     "testTimeout": 30000,

--- a/packages/cli/src/playwright/playwright-config-loader.ts
+++ b/packages/cli/src/playwright/playwright-config-loader.ts
@@ -1,19 +1,23 @@
-import path from 'path'
-import { loadFile } from '../services/checkly-config-loader'
 import fs from 'fs'
+import path from 'path'
+import { loadFile } from '../services/util'
 
 export async function loadPlaywrightConfig () {
-  let config
-  const filenames = ['playwright.config.ts', 'playwright.config.js']
+  const filenames = [
+    'playwright.config.ts',
+    'playwright.config.mts',
+    'playwright.config.cts',
+    'playwright.config.js',
+    'playwright.config.mjs',
+    'playwright.config.cjs',
+  ]
   for (const configFile of filenames) {
-    if (!fs.existsSync(path.resolve(path.dirname(configFile)))) {
+    const configPath = path.resolve(configFile)
+    if (!fs.existsSync(configPath)) {
       continue
     }
-    const dir = path.resolve(path.dirname(configFile))
-    config = await loadFile(path.join(dir, configFile))
-    if (config) {
-      break
-    }
+    const result = await loadFile(configPath)
+    return result
   }
-  return config
+  return undefined
 }

--- a/packages/cli/src/services/__tests__/checkly-config-loader.spec.ts
+++ b/packages/cli/src/services/__tests__/checkly-config-loader.spec.ts
@@ -23,7 +23,7 @@ describe('loadChecklyConfig()', () => {
       await loadChecklyConfig(configDir)
     } catch (e: any) {
       expect(e.message).toContain(`Unable to locate a config at ${configDir} with ${
-        ['checkly.config.ts', 'checkly.config.js', 'checkly.config.mjs'].join(', ')}.`)
+        ['checkly.config.ts', 'checkly.config.mts', 'checkly.config.cts', 'checkly.config.js', 'checkly.config.mjs', 'checkly.config.cjs'].join(', ')}.`)
     }
   })
   it('config TS file should export an object', async () => {

--- a/packages/cli/src/services/project-parser.ts
+++ b/packages/cli/src/services/project-parser.ts
@@ -1,6 +1,6 @@
 import { glob } from 'glob'
 import * as path from 'path'
-import { loadJsFile, loadTsFile, pathToPosix } from './util'
+import { loadFile, pathToPosix } from './util'
 import {
   Check, BrowserCheck, CheckGroup, Project, Session,
   PrivateLocation, PrivateLocationCheckAssignment, PrivateLocationGroupAssignment, MultiStepCheck,
@@ -85,15 +85,11 @@ async function loadAllCheckFiles (
     // setting the checkFilePath is used for filtering by file name on the command line
     Session.checkFileAbsolutePath = checkFile
     Session.checkFilePath = pathToPosix(path.relative(directory, checkFile))
-    if (checkFile.endsWith('.js')) {
-      await loadJsFile(checkFile)
-    } else if (checkFile.endsWith('.mjs')) {
-      await loadJsFile(checkFile)
-    } else if (checkFile.endsWith('.ts')) {
-      await loadTsFile(checkFile)
+    if (/\.[mc]?(js|ts)$/.test(checkFile)) {
+      await loadFile(checkFile)
     } else {
       throw new Error('Unable to load check configuration file with unsupported extension. ' +
-      `Please use a .js, .msj  or .ts file instead.\n${checkFile}`)
+      `Please use a .js, .mjs, .cjs, .ts, .mts or .cts file instead.\n${checkFile}`)
     }
     Session.checkFilePath = undefined
     Session.checkFileAbsolutePath = undefined

--- a/packages/cli/src/services/util.ts
+++ b/packages/cli/src/services/util.ts
@@ -9,10 +9,6 @@ import { parse } from 'dotenv'
 import { getProxyForUrl } from 'proxy-from-env'
 import { httpOverHttp, httpsOverHttp, httpOverHttps, httpsOverHttps } from 'tunnel'
 
-// Copied from oclif/core
-// eslint-disable-next-line
-const _importDynamic = new Function('modulePath', 'return import(modulePath)')
-
 export interface GitInformation {
   commitId: string
   repoUrl?: string | null
@@ -54,17 +50,15 @@ export function findFilesRecursively (directory: string, ignoredPaths: Array<str
   return files
 }
 
-export async function loadJsFile (filepath: string): Promise<any> {
+export async function loadFile (filepath: string): Promise<any> {
   try {
-    // There is a Node opened issue related with a segmentation fault using ES6 modules
-    // with jest https://github.com/nodejs/node/issues/35889
-    // As a work around, we check if Jest is running to modify the way to import the module.
-    // TODO: investigate if the issue is fixed to clean up the conditional import
-    let { default: exported } = typeof jest !== 'undefined'
-      ? { default: await require(filepath) }
-      : await _importDynamic(pathToPosix(filepath))
-
-    if (exported instanceof Function) {
+    let exported: any
+    if (/\.[mc]?ts$/.test(filepath)) {
+      exported = await loadTsFileDefault(filepath)
+    } else {
+      exported = (await import(pathToPosix(filepath))).default
+    }
+    if (typeof exported === 'function') {
       exported = await exported()
     }
     return exported
@@ -73,28 +67,63 @@ export async function loadJsFile (filepath: string): Promise<any> {
   }
 }
 
-export async function loadTsFile (filepath: string): Promise<any> {
-  try {
-    const tsCompiler = await getTsCompiler()
+async function loadTsFileDefault (filepath: string): Promise<any> {
+  const jiti = await getJiti()
+  if (jiti) {
+    return jiti.import<any>(filepath, {
+      default: true,
+    })
+  }
+
+  // Backward-compatibility for users who installed ts-node.
+  const tsCompiler = await getTsNodeService()
+  if (tsCompiler) {
     tsCompiler.enabled(true)
-    let { default: exported } = await require(filepath)
-    if (exported instanceof Function) {
-      exported = await exported()
+    let exported: any
+    try {
+      exported = (await require(filepath)).default
+    } catch (err: any) {
+      if (err.message && err.message.contains('Unable to compile TypeScript')) {
+        throw new Error(`You might try installing "jiti" instead of "ts-node" for improved TypeScript support\n${err.stack}`)
+      }
+      throw err
     }
     tsCompiler.enabled(false) // Re-disable the TS compiler
     return exported
-  } catch (err: any) {
-    throw new Error(`Error loading file ${filepath}\n${err.stack}`)
   }
+
+  throw new Error('Please install "jiti" to use TypeScript files')
+}
+
+// Regular type import gave issue with jest.
+type Jiti = ReturnType<(typeof import('jiti', {
+  with: {
+    'resolution-mode': 'import'
+  }
+}))['createJiti']>
+
+// To avoid a dependency on typescript for users with no TS checks, we need to dynamically import jiti
+let jiti: Jiti
+async function getJiti (): Promise<Jiti | undefined> {
+  if (jiti) return jiti
+  try {
+    jiti = (await import('jiti')).createJiti(__filename)
+  } catch (err: any) {
+    if (err.code === 'ERR_MODULE_NOT_FOUND' || err.code === 'MODULE_NOT_FOUND') {
+      return undefined
+    }
+    throw err
+  }
+  return jiti
 }
 
 // To avoid a dependency on typescript for users with no TS checks, we need to dynamically import ts-node
-let tsCompiler: Service
-async function getTsCompiler (): Promise<Service> {
-  if (tsCompiler) return tsCompiler
+let tsNodeService: Service
+async function getTsNodeService (): Promise<Service | undefined> {
+  if (tsNodeService) return tsNodeService
   try {
     const tsNode = await import('ts-node')
-    tsCompiler = tsNode.register({
+    tsNodeService = tsNode.register({
       moduleTypes: {
         '**/*': 'cjs',
       },
@@ -104,11 +133,11 @@ async function getTsCompiler (): Promise<Service> {
     })
   } catch (err: any) {
     if (err.code === 'ERR_MODULE_NOT_FOUND' || err.code === 'MODULE_NOT_FOUND') {
-      throw new Error('Please install "ts-node" and "typescript" to use TypeScript configuration files')
+      return undefined
     }
     throw err
   }
-  return tsCompiler
+  return tsNodeService
 }
 
 /**

--- a/packages/create-cli/e2e/__tests__/fixtures/initiated-project/package.json
+++ b/packages/create-cli/e2e/__tests__/fixtures/initiated-project/package.json
@@ -10,7 +10,6 @@
   "license": "ISC",
   "devDependencies": {
     "checkly": "latest",
-    "ts-node": "latest",
-    "typescript": "latest"
+    "jiti": "^2"
   }
 }

--- a/packages/create-cli/e2e/__tests__/fixtures/playwright-project/package.json
+++ b/packages/create-cli/e2e/__tests__/fixtures/playwright-project/package.json
@@ -10,7 +10,6 @@
   "license": "ISC",
   "devDependencies": {
     "checkly": "latest",
-    "ts-node": "latest",
-    "typescript": "latest"
+    "jiti": "^2"
   }
 }

--- a/packages/create-cli/package.json
+++ b/packages/create-cli/package.json
@@ -80,10 +80,19 @@
     "@types/uuid": "9.0.1",
     "config": "3.3.9",
     "jest": "29.7.0",
+    "jiti": "2.4.2",
     "rimraf": "5.0.1",
     "ts-jest": "29.2.4",
     "ts-node": "10.9.1",
     "typescript": "5.3.3"
+  },
+  "peerDependencies": {
+    "jiti": ">=2"
+  },
+  "peerDependenciesMeta": {
+    "jiti": {
+      "optional": true
+    }
   },
   "jest": {
     "projects": [

--- a/packages/create-cli/src/actions/dependencies.ts
+++ b/packages/create-cli/src/actions/dependencies.ts
@@ -14,8 +14,7 @@ export function addDevDependecies (projectDirectory: string, packageJson: Packag
 
   Object.assign(packageJson.devDependencies, {
     checkly: 'latest',
-    'ts-node': 'latest',
-    typescript: 'latest',
+    jiti: '^2',
   })
 
   fs.writeFileSync(path.join(projectDirectory, 'package.json'), JSON.stringify(packageJson, null, 2))

--- a/packages/create-cli/src/actions/playwright.ts
+++ b/packages/create-cli/src/actions/playwright.ts
@@ -45,7 +45,14 @@ function handleError (copySpinner: ora.Ora, message: string | unknown) {
 }
 
 function getChecklyConfigFile (): {checklyConfig: string, fileName: string} | undefined {
-  const filenames: string[] = ['checkly.config.ts', 'checkly.config.js', 'checkly.config.mjs']
+  const filenames = [
+    'checkly.config.ts',
+    'checkly.config.mts',
+    'checkly.config.cts',
+    'checkly.config.js',
+    'checkly.config.mjs',
+    'checkly.config.cjs',
+  ]
   let config
   for (const configFile of filenames) {
     const dir = path.resolve(path.dirname(configFile))

--- a/packages/create-cli/src/utils/__tests__/fixtures/checkly-project/package.json
+++ b/packages/create-cli/src/utils/__tests__/fixtures/checkly-project/package.json
@@ -11,7 +11,6 @@
   "license": "ISC",
   "devDependencies": {
     "checkly": "latest",
-    "ts-node": "10.9.1",
-    "typescript": "4.9.5"
+    "jiti": "^2"
   }
 }

--- a/packages/create-cli/src/utils/directory.ts
+++ b/packages/create-cli/src/utils/directory.ts
@@ -24,7 +24,15 @@ export function readPackageJson (dirPath: string): PackageJson {
 }
 
 export function loadPlaywrightConfig (playwrightConfigPath: string) {
-  return loadFile(playwrightConfigPath)
+  if (!fs.existsSync(playwrightConfigPath)) {
+    return Promise.resolve(null)
+  }
+  if (/\.[mc]?(js|ts)$/.test(playwrightConfigPath)) {
+    return loadFile(playwrightConfigPath)
+  } else {
+    throw new Error('Unable to load the config file. ' +
+    `Please use a .js, .mjs, .cjs, .ts, .mts or .cts file instead.\n${playwrightConfigPath}`)
+  }
 }
 
 export function isValidProjectDirectory (dirPath: string) {

--- a/packages/create-cli/src/utils/fileloader.ts
+++ b/packages/create-cli/src/utils/fileloader.ts
@@ -1,11 +1,14 @@
 import { Service } from 'ts-node'
-import { existsSync } from 'fs'
-import * as path from 'path'
 
-export async function loadJsFile (filepath: string): Promise<any> {
+export async function loadFile (filepath: string): Promise<any> {
   try {
-    let { default: exported } = { default: await require(filepath) }
-    if (exported instanceof Function) {
+    let exported: any
+    if (/\.[mc]?ts$/.test(filepath)) {
+      exported = await loadTsFileDefault(filepath)
+    } else {
+      exported = (await import(filepath)).default
+    }
+    if (typeof exported === 'function') {
       exported = await exported()
     }
     return exported
@@ -14,28 +17,63 @@ export async function loadJsFile (filepath: string): Promise<any> {
   }
 }
 
-async function loadTsFile (filepath: string): Promise<any> {
-  try {
-    const tsCompiler = await getTsCompiler()
+async function loadTsFileDefault (filepath: string): Promise<any> {
+  const jiti = await getJiti()
+  if (jiti) {
+    return jiti.import<any>(filepath, {
+      default: true,
+    })
+  }
+
+  // Backward-compatibility for users who installed ts-node.
+  const tsCompiler = await getTsNodeService()
+  if (tsCompiler) {
     tsCompiler.enabled(true)
-    let { default: exported } = await require(filepath)
-    if (exported instanceof Function) {
-      exported = await exported()
+    let exported: any
+    try {
+      exported = (await require(filepath)).default
+    } catch (err: any) {
+      if (err.message && err.message.contains('Unable to compile TypeScript')) {
+        throw new Error(`You might try installing "jiti" instead of "ts-node" for improved TypeScript support\n${err.stack}`)
+      }
+      throw err
     }
     tsCompiler.enabled(false) // Re-disable the TS compiler
     return exported
-  } catch (err: any) {
-    throw new Error(`Error loading file ${filepath}\n${err.stack}`)
   }
+
+  throw new Error('Please install "jiti" to use TypeScript files')
+}
+
+// Regular type import gave issue with jest.
+type Jiti = ReturnType<(typeof import('jiti', {
+  with: {
+    'resolution-mode': 'import'
+  }
+}))['createJiti']>
+
+// To avoid a dependency on typescript for users with no TS checks, we need to dynamically import jiti
+let jiti: Jiti
+async function getJiti (): Promise<Jiti | undefined> {
+  if (jiti) return jiti
+  try {
+    jiti = (await import('jiti')).createJiti(__filename)
+  } catch (err: any) {
+    if (err.code === 'ERR_MODULE_NOT_FOUND' || err.code === 'MODULE_NOT_FOUND') {
+      return undefined
+    }
+    throw err
+  }
+  return jiti
 }
 
 // To avoid a dependency on typescript for users with no TS checks, we need to dynamically import ts-node
-let tsCompiler: Service
-async function getTsCompiler (): Promise<Service> {
-  if (tsCompiler) return tsCompiler
+let tsNodeService: Service
+async function getTsNodeService (): Promise<Service | undefined> {
+  if (tsNodeService) return tsNodeService
   try {
     const tsNode = await import('ts-node')
-    tsCompiler = tsNode.register({
+    tsNodeService = tsNode.register({
       moduleTypes: {
         '**/*': 'cjs',
       },
@@ -45,23 +83,9 @@ async function getTsCompiler (): Promise<Service> {
     })
   } catch (err: any) {
     if (err.code === 'ERR_MODULE_NOT_FOUND' || err.code === 'MODULE_NOT_FOUND') {
-      throw new Error('Please install "ts-node" and "typescript" to use TypeScript configuration files')
+      return undefined
     }
     throw err
   }
-  return tsCompiler
-}
-
-export function loadFile (file: string) {
-  if (!existsSync(file)) {
-    return Promise.resolve(null)
-  }
-  switch (path.extname(file)) {
-    case '.js':
-      return loadJsFile(file)
-    case '.ts':
-      return loadTsFile(file)
-    default:
-      throw new Error(`Unsupported file extension ${file} for the config file`)
-  }
+  return tsNodeService
 }


### PR DESCRIPTION
I hereby confirm that I followed the code guidelines found at [engineering guidelines](https://www.notion.so/checkly/Engineering-Guidelines-a3a165a203a04dc1a112f0e26b2f2d3f) <-- I don't have access to this

## Affected Components
* [x] CLI
* [x] Create CLI
* [x] Test
* [ ] Docs
* [x] Examples
* [ ] Other

## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #1015

The current use of `ts-node` is problematic:

- Only CommonJS is supported, so loading ESM doesn't work as expected
- `ts-node` is currently not maintained and haven't received updates for 1+ year. It lacks newer TypeScript features. For instance it does not support multiple extends in `tsconfig.json` that came with TypeScript 5.

This has been a large pain as most of the code I work with is in ESM. It has required non-trivial tsconfig files to workaround this.

This PR introduces [Jiti](https://github.com/unjs/jiti) as an alternative to `ts-node`. I could have picked tsx as well, but I don't find the API of tsx as intuitive/simple as Jiti. This is very similar as the implementation of eslint that uses Jiti for its TypeScript support.

Additional file extensions are also supported: `.mts`, `.cts`, `.cjs`

To avoid a breaking change it supports both `ts-node` and `jiti`. Existing users with only `ts-node` should not be affected, while new users will be recommended to add `jiti`. Jiti does not depend on a `tsconfig.json` file (and does not do type checking), so `typescript` is not requested as a dependency. Existing users can add `jiti` to get better (and ESM) support, and we also recommend this on compile issues. If you're open for a breaking change we could remove `ts-node` support and avoid dealing with both.