### PR TITLE
fix: the `test` command's `--tags` option now also matches `CheckGroup`s [sc-23699]

### DIFF
--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -203,7 +203,7 @@ export default class Test extends AuthCommand {
         const checkGroup = this.getCheckGroup(project, check)
         if (checkGroup) {
           const checkGroupTags = checkGroup.tags ?? []
-          tags.concat(checkGroupTags)
+          tags.push(...checkGroupTags)
         }
         return filterByTags(targetTags?.map((tags: string) => tags.split(',')) ?? [], tags)
       })

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -199,7 +199,7 @@ export default class Test extends AuthCommand {
         return filterByCheckNamePattern(grep, check.name)
       })
       .filter(([, check]) => {
-        const tags = check.tags ?? []
+        const tags = [...check.tags ?? []]
         const checkGroup = this.getCheckGroup(project, check)
         if (checkGroup) {
           const checkGroupTags = checkGroup.tags ?? []


### PR DESCRIPTION
This is the intended behavior, but an oversight in the code effectively disabled it.

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #1044 

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
