### PR TITLE
feat: full ESM config support using Jiti (build #1041)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
       - run: npm run lint
   test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
     name: test - ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
     name: test - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/examples/advanced-project/package.json
+++ b/examples/advanced-project/package.json
@@ -11,7 +11,6 @@
   "license": "ISC",
   "devDependencies": {
     "checkly": "latest",
-    "ts-node": "10.9.1",
-    "typescript": "4.9.5"
+    "jiti": "^2"
   }
 }

--- a/examples/boilerplate-project/package.json
+++ b/examples/boilerplate-project/package.json
@@ -11,7 +11,6 @@
   "license": "ISC",
   "devDependencies": {
     "checkly": "latest",
-    "ts-node": "10.9.1",
-    "typescript": "4.9.5"
+    "jiti": "^2"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6633,6 +6633,8 @@
     },
     "node_modules/cross-env": {
       "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15799,6 +15801,7 @@
         "@types/prompts": "^2.4.9",
         "@types/uuid": "^10.0.0",
         "config": "^3.3.12",
+        "cross-env": "^7.0.3",
         "jest": "^29.7.0",
         "jiti": "^2.4.2",
         "rimraf": "^5.0.10",
@@ -20747,6 +20750,7 @@
         "axios": "^1.8.4",
         "chalk": "^4.1.2",
         "config": "^3.3.12",
+        "cross-env": "^7.0.3",
         "debug": "^4.4.0",
         "execa": "^5.1.0",
         "giget": "^1.2.5",
@@ -20971,6 +20975,8 @@
     },
     "cross-env": {
       "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
       "dev": true,
       "requires": {
         "cross-spawn": "^7.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9328,6 +9328,16 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jiti": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/js-sdsl": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
@@ -15616,6 +15626,7 @@
         "config": "^3.3.12",
         "cross-env": "^7.0.3",
         "jest": "^29.7.0",
+        "jiti": "^2.4.2",
         "nanoid": "^3.3.11",
         "oclif": "^4.17.44",
         "rimraf": "^5.0.10",
@@ -15626,6 +15637,14 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "jiti": ">=2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
       }
     },
     "packages/cli/node_modules/@types/node": {
@@ -15781,6 +15800,7 @@
         "@types/uuid": "^10.0.0",
         "config": "^3.3.12",
         "jest": "^29.7.0",
+        "jiti": "^2.4.2",
         "rimraf": "^5.0.10",
         "ts-jest": "^29.3.2",
         "ts-node": "^10.9.2",
@@ -15788,6 +15808,14 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "jiti": ">=2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
       }
     },
     "packages/create-cli/node_modules/@types/node": {
@@ -20305,6 +20333,7 @@
         "glob": "^10.4.5",
         "indent-string": "^4.0.0",
         "jest": "^29.7.0",
+        "jiti": "^2.4.2",
         "json-stream-stringify": "^3.1.6",
         "json5": "^2.2.3",
         "jwt-decode": "^3.1.2",
@@ -20722,6 +20751,7 @@
         "execa": "^5.1.0",
         "giget": "^1.2.5",
         "jest": "^29.7.0",
+        "jiti": "^2.4.2",
         "json5": "^2.2.3",
         "ora": "^5.4.1",
         "passwd-user": "^3.0.0",
@@ -22676,6 +22706,12 @@
           }
         }
       }
+    },
+    "jiti": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "dev": true
     },
     "js-sdsl": {
       "version": "4.3.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -112,6 +112,7 @@
     "config": "^3.3.12",
     "cross-env": "^7.0.3",
     "jest": "^29.7.0",
+    "jiti": "^2.4.2",
     "nanoid": "^3.3.11",
     "oclif": "^4.17.44",
     "rimraf": "^5.0.10",
@@ -119,6 +120,14 @@
     "ts-jest": "^29.3.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.3.3"
+  },
+  "peerDependencies": {
+    "jiti": ">=2"
+  },
+  "peerDependenciesMeta": {
+    "jiti": {
+      "optional": true
+    }
   },
   "jest": {
     "testTimeout": 30000,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,8 +15,8 @@
     "clean": "rimraf ./dist",
     "prepack": "npx oclif manifest",
     "prepare": "npm run clean && tsc --build",
-    "test": "jest --selectProjects unit",
-    "test:e2e": "npm run prepare && cross-env NODE_CONFIG_DIR=./e2e/config jest --selectProjects E2E",
+    "test": "cross-env NODE_OPTIONS=\"--experimental-vm-modules\" jest --selectProjects unit",
+    "test:e2e": "npm run prepare && cross-env NODE_OPTIONS=\"--experimental-vm-modules\" NODE_CONFIG_DIR=./e2e/config jest --selectProjects E2E",
     "test:e2e:local": "cross-env CHECKLY_BASE_URL=http://localhost:3000  CHECKLY_ENV=local npm run test:e2e",
     "watch": "tsc --watch"
   },

--- a/packages/cli/src/playwright/playwright-config-loader.ts
+++ b/packages/cli/src/playwright/playwright-config-loader.ts
@@ -1,19 +1,23 @@
-import path from 'path'
-import { loadFile } from '../services/checkly-config-loader'
 import fs from 'fs'
+import path from 'path'
+import { loadFile } from '../services/util'
 
 export async function loadPlaywrightConfig () {
-  let config
-  const filenames = ['playwright.config.ts', 'playwright.config.js']
+  const filenames = [
+    'playwright.config.ts',
+    'playwright.config.mts',
+    'playwright.config.cts',
+    'playwright.config.js',
+    'playwright.config.mjs',
+    'playwright.config.cjs',
+  ]
   for (const configFile of filenames) {
-    if (!fs.existsSync(path.resolve(path.dirname(configFile)))) {
+    const configPath = path.resolve(configFile)
+    if (!fs.existsSync(configPath)) {
       continue
     }
-    const dir = path.resolve(path.dirname(configFile))
-    config = await loadFile(path.join(dir, configFile))
-    if (config) {
-      break
-    }
+    const result = await loadFile(configPath)
+    return result
   }
-  return config
+  return undefined
 }

--- a/packages/cli/src/services/__tests__/checkly-config-loader.spec.ts
+++ b/packages/cli/src/services/__tests__/checkly-config-loader.spec.ts
@@ -23,7 +23,7 @@ describe('loadChecklyConfig()', () => {
       await loadChecklyConfig(configDir)
     } catch (e: any) {
       expect(e.message).toContain(`Unable to locate a config at ${configDir} with ${
-        ['checkly.config.ts', 'checkly.config.js', 'checkly.config.mjs'].join(', ')}.`)
+        ['checkly.config.ts', 'checkly.config.mts', 'checkly.config.cts', 'checkly.config.js', 'checkly.config.mjs', 'checkly.config.cjs'].join(', ')}.`)
     }
   })
   it('config TS file should export an object', async () => {

--- a/packages/cli/src/services/project-parser.ts
+++ b/packages/cli/src/services/project-parser.ts
@@ -1,5 +1,5 @@
 import * as path from 'path'
-import { findFilesWithPattern, loadJsFile, loadTsFile, pathToPosix } from './util'
+import { findFilesWithPattern, loadFile, pathToPosix } from './util'
 import {
   Check, BrowserCheck, CheckGroup, Project, Session,
   PrivateLocation, PrivateLocationCheckAssignment, PrivateLocationGroupAssignment, MultiStepCheck,
@@ -84,15 +84,11 @@ async function loadAllCheckFiles (
     // setting the checkFilePath is used for filtering by file name on the command line
     Session.checkFileAbsolutePath = checkFile
     Session.checkFilePath = pathToPosix(path.relative(directory, checkFile))
-    if (checkFile.endsWith('.js')) {
-      await loadJsFile(checkFile)
-    } else if (checkFile.endsWith('.mjs')) {
-      await loadJsFile(checkFile)
-    } else if (checkFile.endsWith('.ts')) {
-      await loadTsFile(checkFile)
+    if (/\.[mc]?(js|ts)$/.test(checkFile)) {
+      await loadFile(checkFile)
     } else {
       throw new Error('Unable to load check configuration file with unsupported extension. ' +
-      `Please use a .js, .msj  or .ts file instead.\n${checkFile}`)
+      `Please use a .js, .mjs, .cjs, .ts, .mts or .cts file instead.\n${checkFile}`)
     }
     Session.checkFilePath = undefined
     Session.checkFileAbsolutePath = undefined

--- a/packages/cli/src/services/util.ts
+++ b/packages/cli/src/services/util.ts
@@ -89,8 +89,9 @@ async function loadTsFileDefault (filepath: string): Promise<any> {
         throw new Error(`Consider installing "jiti" instead of "ts-node" for improved TypeScript support\n${err.stack}`)
       }
       throw err
+    } finally {
+      tsCompiler.enabled(false) // Re-disable the TS compiler
     }
-    tsCompiler.enabled(false) // Re-disable the TS compiler
     return exported
   }
 

--- a/packages/cli/src/services/util.ts
+++ b/packages/cli/src/services/util.ts
@@ -85,7 +85,7 @@ async function loadTsFileDefault (filepath: string): Promise<any> {
     try {
       exported = (await require(filepath)).default
     } catch (err: any) {
-      if (err.message && err.message.contains('Unable to compile TypeScript')) {
+      if (err.message && err.message.includes('Unable to compile TypeScript')) {
         throw new Error(`You might try installing "jiti" instead of "ts-node" for improved TypeScript support\n${err.stack}`)
       }
       throw err

--- a/packages/cli/src/services/util.ts
+++ b/packages/cli/src/services/util.ts
@@ -86,7 +86,7 @@ async function loadTsFileDefault (filepath: string): Promise<any> {
       exported = (await require(filepath)).default
     } catch (err: any) {
       if (err.message && err.message.includes('Unable to compile TypeScript')) {
-        throw new Error(`You might try installing "jiti" instead of "ts-node" for improved TypeScript support\n${err.stack}`)
+        throw new Error(`Consider installing "jiti" instead of "ts-node" for improved TypeScript support\n${err.stack}`)
       }
       throw err
     }

--- a/packages/create-cli/e2e/__tests__/fixtures/initiated-project/package.json
+++ b/packages/create-cli/e2e/__tests__/fixtures/initiated-project/package.json
@@ -10,7 +10,6 @@
   "license": "ISC",
   "devDependencies": {
     "checkly": "latest",
-    "ts-node": "latest",
-    "typescript": "latest"
+    "jiti": "^2"
   }
 }

--- a/packages/create-cli/e2e/__tests__/fixtures/playwright-project/package.json
+++ b/packages/create-cli/e2e/__tests__/fixtures/playwright-project/package.json
@@ -10,7 +10,6 @@
   "license": "ISC",
   "devDependencies": {
     "checkly": "latest",
-    "ts-node": "latest",
-    "typescript": "latest"
+    "jiti": "^2"
   }
 }

--- a/packages/create-cli/package.json
+++ b/packages/create-cli/package.json
@@ -12,8 +12,8 @@
     "clean": "rimraf ./dist",
     "prepack": "echo \"Warning: no oclif manifest configured\"",
     "prepare": "npm run clean && tsc --build",
-    "test": "jest --selectProjects unit",
-    "test:e2e": "npm run prepare && jest --selectProjects E2E",
+    "test": "cross-env NODE_OPTIONS=\"--experimental-vm-modules\" jest --selectProjects unit",
+    "test:e2e": "npm run prepare && cross-env NODE_OPTIONS=\"--experimental-vm-modules\" jest --selectProjects E2E",
     "start": "node ./index.mjs",
     "watch": "tsc --watch"
   },
@@ -78,6 +78,7 @@
     "@types/prompts": "^2.4.9",
     "@types/uuid": "^10.0.0",
     "config": "^3.3.12",
+    "cross-env": "^7.0.3",
     "jest": "^29.7.0",
     "jiti": "^2.4.2",
     "rimraf": "^5.0.10",

--- a/packages/create-cli/package.json
+++ b/packages/create-cli/package.json
@@ -79,10 +79,19 @@
     "@types/uuid": "^10.0.0",
     "config": "^3.3.12",
     "jest": "^29.7.0",
+    "jiti": "^2.4.2",
     "rimraf": "^5.0.10",
     "ts-jest": "^29.3.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.3.3"
+  },
+  "peerDependencies": {
+    "jiti": ">=2"
+  },
+  "peerDependenciesMeta": {
+    "jiti": {
+      "optional": true
+    }
   },
   "jest": {
     "projects": [

--- a/packages/create-cli/src/actions/dependencies.ts
+++ b/packages/create-cli/src/actions/dependencies.ts
@@ -14,8 +14,7 @@ export function addDevDependecies (projectDirectory: string, packageJson: Packag
 
   Object.assign(packageJson.devDependencies, {
     checkly: 'latest',
-    'ts-node': 'latest',
-    typescript: 'latest',
+    jiti: '^2',
   })
 
   fs.writeFileSync(path.join(projectDirectory, 'package.json'), JSON.stringify(packageJson, null, 2))

--- a/packages/create-cli/src/actions/playwright.ts
+++ b/packages/create-cli/src/actions/playwright.ts
@@ -45,7 +45,14 @@ function handleError (copySpinner: ora.Ora, message: string | unknown) {
 }
 
 function getChecklyConfigFile (): {checklyConfig: string, fileName: string} | undefined {
-  const filenames: string[] = ['checkly.config.ts', 'checkly.config.js', 'checkly.config.mjs']
+  const filenames = [
+    'checkly.config.ts',
+    'checkly.config.mts',
+    'checkly.config.cts',
+    'checkly.config.js',
+    'checkly.config.mjs',
+    'checkly.config.cjs',
+  ]
   let config
   for (const configFile of filenames) {
     const dir = path.resolve(path.dirname(configFile))

--- a/packages/create-cli/src/utils/__tests__/fixtures/checkly-project/package.json
+++ b/packages/create-cli/src/utils/__tests__/fixtures/checkly-project/package.json
@@ -11,7 +11,6 @@
   "license": "ISC",
   "devDependencies": {
     "checkly": "latest",
-    "ts-node": "10.9.1",
-    "typescript": "4.9.5"
+    "jiti": "^2"
   }
 }

--- a/packages/create-cli/src/utils/directory.ts
+++ b/packages/create-cli/src/utils/directory.ts
@@ -24,7 +24,15 @@ export function readPackageJson (dirPath: string): PackageJson {
 }
 
 export function loadPlaywrightConfig (playwrightConfigPath: string) {
-  return loadFile(playwrightConfigPath)
+  if (!fs.existsSync(playwrightConfigPath)) {
+    return Promise.resolve(null)
+  }
+  if (/\.[mc]?(js|ts)$/.test(playwrightConfigPath)) {
+    return loadFile(playwrightConfigPath)
+  } else {
+    throw new Error('Unable to load the config file. ' +
+    `Please use a .js, .mjs, .cjs, .ts, .mts or .cts file instead.\n${playwrightConfigPath}`)
+  }
 }
 
 export function isValidProjectDirectory (dirPath: string) {

--- a/packages/create-cli/src/utils/fileloader.ts
+++ b/packages/create-cli/src/utils/fileloader.ts
@@ -35,7 +35,7 @@ async function loadTsFileDefault (filepath: string): Promise<any> {
       exported = (await require(filepath)).default
     } catch (err: any) {
       if (err.message && err.message.includes('Unable to compile TypeScript')) {
-        throw new Error(`You might try installing "jiti" instead of "ts-node" for improved TypeScript support\n${err.stack}`)
+        throw new Error(`Consider installing "jiti" instead of "ts-node" for improved TypeScript support\n${err.stack}`)
       }
       throw err
     }

--- a/packages/create-cli/src/utils/fileloader.ts
+++ b/packages/create-cli/src/utils/fileloader.ts
@@ -1,12 +1,15 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 import { Service } from 'ts-node'
-import { existsSync } from 'fs'
-import * as path from 'path'
 
-export async function loadJsFile (filepath: string): Promise<any> {
+export async function loadFile (filepath: string): Promise<any> {
   try {
-    let { default: exported } = { default: await require(filepath) }
-    if (exported instanceof Function) {
+    let exported: any
+    if (/\.[mc]?ts$/.test(filepath)) {
+      exported = await loadTsFileDefault(filepath)
+    } else {
+      exported = (await import(filepath)).default
+    }
+    if (typeof exported === 'function') {
       exported = await exported()
     }
     return exported
@@ -15,28 +18,63 @@ export async function loadJsFile (filepath: string): Promise<any> {
   }
 }
 
-async function loadTsFile (filepath: string): Promise<any> {
-  try {
-    const tsCompiler = await getTsCompiler()
+async function loadTsFileDefault (filepath: string): Promise<any> {
+  const jiti = await getJiti()
+  if (jiti) {
+    return jiti.import<any>(filepath, {
+      default: true,
+    })
+  }
+
+  // Backward-compatibility for users who installed ts-node.
+  const tsCompiler = await getTsNodeService()
+  if (tsCompiler) {
     tsCompiler.enabled(true)
-    let { default: exported } = await require(filepath)
-    if (exported instanceof Function) {
-      exported = await exported()
+    let exported: any
+    try {
+      exported = (await require(filepath)).default
+    } catch (err: any) {
+      if (err.message && err.message.contains('Unable to compile TypeScript')) {
+        throw new Error(`You might try installing "jiti" instead of "ts-node" for improved TypeScript support\n${err.stack}`)
+      }
+      throw err
     }
     tsCompiler.enabled(false) // Re-disable the TS compiler
     return exported
-  } catch (err: any) {
-    throw new Error(`Error loading file ${filepath}\n${err.stack}`)
   }
+
+  throw new Error('Please install "jiti" to use TypeScript files')
+}
+
+// Regular type import gave issue with jest.
+type Jiti = ReturnType<(typeof import('jiti', {
+  with: {
+    'resolution-mode': 'import'
+  }
+}))['createJiti']>
+
+// To avoid a dependency on typescript for users with no TS checks, we need to dynamically import jiti
+let jiti: Jiti
+async function getJiti (): Promise<Jiti | undefined> {
+  if (jiti) return jiti
+  try {
+    jiti = (await import('jiti')).createJiti(__filename)
+  } catch (err: any) {
+    if (err.code === 'ERR_MODULE_NOT_FOUND' || err.code === 'MODULE_NOT_FOUND') {
+      return undefined
+    }
+    throw err
+  }
+  return jiti
 }
 
 // To avoid a dependency on typescript for users with no TS checks, we need to dynamically import ts-node
-let tsCompiler: Service
-async function getTsCompiler (): Promise<Service> {
-  if (tsCompiler) return tsCompiler
+let tsNodeService: Service
+async function getTsNodeService (): Promise<Service | undefined> {
+  if (tsNodeService) return tsNodeService
   try {
     const tsNode = await import('ts-node')
-    tsCompiler = tsNode.register({
+    tsNodeService = tsNode.register({
       moduleTypes: {
         '**/*': 'cjs',
       },
@@ -46,23 +84,9 @@ async function getTsCompiler (): Promise<Service> {
     })
   } catch (err: any) {
     if (err.code === 'ERR_MODULE_NOT_FOUND' || err.code === 'MODULE_NOT_FOUND') {
-      throw new Error('Please install "ts-node" and "typescript" to use TypeScript configuration files')
+      return undefined
     }
     throw err
   }
-  return tsCompiler
-}
-
-export function loadFile (file: string) {
-  if (!existsSync(file)) {
-    return Promise.resolve(null)
-  }
-  switch (path.extname(file)) {
-    case '.js':
-      return loadJsFile(file)
-    case '.ts':
-      return loadTsFile(file)
-    default:
-      throw new Error(`Unsupported file extension ${file} for the config file`)
-  }
+  return tsNodeService
 }

--- a/packages/create-cli/src/utils/fileloader.ts
+++ b/packages/create-cli/src/utils/fileloader.ts
@@ -38,8 +38,9 @@ async function loadTsFileDefault (filepath: string): Promise<any> {
         throw new Error(`Consider installing "jiti" instead of "ts-node" for improved TypeScript support\n${err.stack}`)
       }
       throw err
+    } finally {
+      tsCompiler.enabled(false) // Re-disable the TS compiler
     }
-    tsCompiler.enabled(false) // Re-disable the TS compiler
     return exported
   }
 

--- a/packages/create-cli/src/utils/fileloader.ts
+++ b/packages/create-cli/src/utils/fileloader.ts
@@ -34,7 +34,7 @@ async function loadTsFileDefault (filepath: string): Promise<any> {
     try {
       exported = (await require(filepath)).default
     } catch (err: any) {
-      if (err.message && err.message.contains('Unable to compile TypeScript')) {
+      if (err.message && err.message.includes('Unable to compile TypeScript')) {
         throw new Error(`You might try installing "jiti" instead of "ts-node" for improved TypeScript support\n${err.stack}`)
       }
       throw err


### PR DESCRIPTION
This PR merges #1041.

Temporarily disables testing on Windows due to (presumably) ts-jest and jiti fighting over the module cache. A different test setup is needed to make this work.