### PR TITLE
fix: avoid breakage if user has jiti 1.x installed [sc-24059]

### DIFF
--- a/packages/cli/src/services/util.ts
+++ b/packages/cli/src/services/util.ts
@@ -107,10 +107,17 @@ type Jiti = ReturnType<(typeof import('jiti', {
 
 // To avoid a dependency on typescript for users with no TS checks, we need to dynamically import jiti
 let jiti: Jiti
+let haveJiti = false
 async function getJiti (): Promise<Jiti | undefined> {
-  if (jiti) return jiti
+  if (haveJiti) return jiti
   try {
-    jiti = (await import('jiti')).createJiti(__filename)
+    const maybeJiti = await import('jiti')
+    // Jiti 1x does not have createJiti().
+    if (typeof maybeJiti.createJiti !== 'function') {
+      return
+    }
+    jiti = maybeJiti.createJiti(__filename)
+    haveJiti = true
   } catch (err: any) {
     if (err.code === 'ERR_MODULE_NOT_FOUND' || err.code === 'MODULE_NOT_FOUND') {
       return undefined

--- a/packages/create-cli/src/utils/fileloader.ts
+++ b/packages/create-cli/src/utils/fileloader.ts
@@ -56,10 +56,17 @@ type Jiti = ReturnType<(typeof import('jiti', {
 
 // To avoid a dependency on typescript for users with no TS checks, we need to dynamically import jiti
 let jiti: Jiti
+let haveJiti = false
 async function getJiti (): Promise<Jiti | undefined> {
-  if (jiti) return jiti
+  if (haveJiti) return jiti
   try {
-    jiti = (await import('jiti')).createJiti(__filename)
+    const maybeJiti = await import('jiti')
+    // Jiti 1x does not have createJiti().
+    if (typeof maybeJiti.createJiti !== 'function') {
+      return
+    }
+    jiti = maybeJiti.createJiti(__filename)
+    haveJiti = true
   } catch (err: any) {
     if (err.code === 'ERR_MODULE_NOT_FOUND' || err.code === 'MODULE_NOT_FOUND') {
       return undefined


### PR DESCRIPTION
If a user already had jiti 1.x installed, or managed to install it in some way without violating `peerDependencies`, we'd be unable to use it because we expected jiti 2.x.

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
