### PR TITLE
feat: allow `NO_RETRIES` value for `retryStrategy`

### DIFF
--- a/packages/cli/src/constructs/check-group.ts
+++ b/packages/cli/src/constructs/check-group.ts
@@ -296,10 +296,7 @@ export class CheckGroup extends Construct {
       localTearDownScript: this.localTearDownScript,
       apiCheckDefaults: this.apiCheckDefaults,
       environmentVariables: this.environmentVariables,
-      // The backend doesn't actually support the `NO_RETRIES` type, it uses `null` instead.
-      retryStrategy: this.retryStrategy?.type === 'NO_RETRIES'
-        ? null
-        : this.retryStrategy,
+      retryStrategy: this.retryStrategy,
       // When `retryStrategy: NO_RETRIES` and `doubleCheck: undefined`, we want to let the user disable all retries.
       // The backend has a Joi default of `doubleCheck: true`, though, so we need special handling for this case.
       doubleCheck: this.doubleCheck === undefined && this.retryStrategy?.type === 'NO_RETRIES'


### PR DESCRIPTION
## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->
We want to allow "NO_RETRIES" as value for the "retryStrategy" of a check group.
The "null" value will start to be interpreted as fallback to check configuration by the backend
starting from this version of the CLI

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
