### PR TITLE
feat: more intelligent file loader [sc-24135]

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": "./dist/index.js",
     "./constructs": "./dist/constructs/index.js",
+    "./loader": "./dist/loader/index.js",
     "./util": "./dist/util/index.js"
   },
   "engines": {

--- a/packages/cli/src/commands/sync-playwright.ts
+++ b/packages/cli/src/commands/sync-playwright.ts
@@ -16,16 +16,16 @@ export default class SyncPlaywright extends BaseCommand {
       ux.action.start('Syncing Playwright config to the Checkly config file', undefined, { stdout: true })
     }
 
-    const config = await loadPlaywrightConfig()
-    if (!config) {
-      return this.handleError('Could not find any playwright.config file.')
-    }
-
-    const configFile = getChecklyConfigFile()
+    const configFile = await getChecklyConfigFile()
     if (!configFile) {
       return this.handleError('Could not find a checkly config file')
     }
     const checklyAst = recast.parse(configFile.checklyConfig)
+
+    const config = await loadPlaywrightConfig()
+    if (!config) {
+      return this.handleError('Could not find any playwright.config file.')
+    }
 
     const checksAst = this.findPropertyByName(checklyAst, 'checks')
     if (!checksAst) {

--- a/packages/cli/src/loader/index.ts
+++ b/packages/cli/src/loader/index.ts
@@ -1,0 +1,17 @@
+export { JitiFileLoader, JitiFileLoaderOptions } from './jiti'
+export {
+  FileLoader,
+  FileLoaderOptions,
+  UnsupportedFileLoaderError,
+} from './loader'
+export { FileMatch, FileMatchFunction } from './match'
+export { MixedFileLoader } from './mixed'
+export {
+  NativeFileLoader,
+  NativeFileLoaderOptions,
+  BunDetector,
+  DenoDetector,
+  detectNativeTypeScriptSupport,
+  hasNativeTypeScriptSupport,
+} from './native'
+export { TSNodeFileLoader, TSNodeFileLoaderOptions } from './ts-node'

--- a/packages/cli/src/loader/jiti.ts
+++ b/packages/cli/src/loader/jiti.ts
@@ -1,0 +1,80 @@
+import { FileLoader, FileLoaderOptions, UnsupportedFileLoaderError } from './loader'
+import { FileMatch } from './match';
+
+interface JitiExports {
+  createJiti (id: string, userOptions?: any): Jiti;
+}
+
+interface Jiti {
+  import<T = unknown> (
+    id: string,
+    opts?: { default?: true },
+  ): Promise<T>
+}
+
+export class UninitializedJitiFileLoaderState extends FileLoader {
+  init?: Promise<void>
+
+  async loadFile<T = unknown> (filePath: string): Promise<T> {
+    this.init ??= (async () => {
+      try {
+        const jitiExports: JitiExports = await import('jiti')
+        const jiti = jitiExports.createJiti(__filename)
+        JitiFileLoader.state = new InitializedJitiFileLoaderState(jiti)
+      } catch (err) {
+        JitiFileLoader.state = new FailedJitiFileLoaderState(err as Error)
+      }
+    })()
+
+    await this.init
+
+    return await JitiFileLoader.state.loadFile(filePath)
+  }
+}
+
+export class FailedJitiFileLoaderState extends FileLoader {
+  error: Error
+
+  constructor (error: Error) {
+    super()
+    this.error = error
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async loadFile<T = unknown> (filePath: string): Promise<T> {
+    throw new UnsupportedFileLoaderError('JitiFileLoader is not supported', {
+      cause: this.error,
+    })
+  }
+}
+
+export class InitializedJitiFileLoaderState extends FileLoader {
+  jiti: Jiti
+
+  constructor (jiti: Jiti) {
+    super()
+    this.jiti = jiti
+  }
+
+  async loadFile<T = unknown> (filePath: string): Promise<T> {
+    const moduleExports = await this.jiti.import<T>(filePath)
+    return moduleExports
+  }
+}
+
+export type JitiFileLoaderOptions = FileLoaderOptions
+
+export class JitiFileLoader extends FileLoader {
+  static state: FileLoader = new UninitializedJitiFileLoaderState()
+
+  constructor (options?: JitiFileLoaderOptions) {
+    super({
+      match: FileMatch.standardFiles().complement(),
+      ...options,
+    })
+  }
+
+  async loadFile<T = unknown> (filePath: string): Promise<T> {
+    return JitiFileLoader.state.loadFile<T>(filePath)
+  }
+}

--- a/packages/cli/src/loader/loader.ts
+++ b/packages/cli/src/loader/loader.ts
@@ -1,0 +1,42 @@
+import { FileMatch } from './match'
+
+export interface FileLoaderOptions {
+  match?: FileMatch
+}
+
+export abstract class FileLoader {
+  protected fileMatcher: FileMatch
+
+  constructor (options?: FileLoaderOptions) {
+    this.fileMatcher = options?.match ?? FileMatch.any()
+  }
+
+  /**
+   * Checks whether the FileLoader can be used for a file path.
+   *
+   * @param filePath The file path to evaluate.
+   * @returns Whether the FileLoader is authoritative for the file path.
+   */
+  isAuthoritativeFor (filePath: string): boolean {
+    return this.fileMatcher.match(filePath)
+  }
+
+  /**
+   * Loads a file.
+   *
+   * @param filePath The path to load the file from.
+   * @returns The unmodified exports of the file.
+   */
+  abstract loadFile<T = unknown> (filePath: string): Promise<T>
+}
+
+/**
+ * Error thrown when a FileLoader is authoritative for a file path but
+ * fails to load it.
+ */
+export class UnsupportedFileLoaderError extends Error {
+  constructor (message = 'File cannot be loaded by this loader', options?: ErrorOptions) {
+    super(message, options)
+    this.name = 'UnsupportedFileLoaderError'
+  }
+}

--- a/packages/cli/src/loader/match.ts
+++ b/packages/cli/src/loader/match.ts
@@ -1,0 +1,56 @@
+import { extname } from 'node:path'
+
+export type FileMatchFunction = (filePath: string) => boolean
+
+export class FileMatch {
+  match: FileMatchFunction
+
+  protected constructor (match: FileMatchFunction) {
+    this.match = match
+  }
+
+  complement (): FileMatch {
+    return new FileMatch(filePath => !this.match(filePath))
+  }
+
+  union (matcher: FileMatch): FileMatch {
+    return new FileMatch(filePath => {
+      return this.match(filePath) || matcher.match(filePath)
+    })
+  }
+
+  intersection (matcher: FileMatch): FileMatch {
+    return new FileMatch(filePath => {
+      return this.match(filePath) && matcher.match(filePath)
+    })
+  }
+
+  difference (matcher: FileMatch): FileMatch {
+    return this.intersection(matcher.complement())
+  }
+
+  static none (): FileMatch {
+    return new FileMatch(() => false)
+  }
+
+  static any (): FileMatch {
+    return new FileMatch(() => true)
+  }
+
+  static pattern (pattern: RegExp): FileMatch {
+    return new FileMatch(filePath => pattern.test(filePath))
+  }
+
+  static extension (...extensions: string[]): FileMatch {
+    const set = new Set(extensions)
+    return new FileMatch(filePath => set.has(extname(filePath)))
+  }
+
+  static custom (match: FileMatchFunction): FileMatch {
+    return new FileMatch(match)
+  }
+
+  static standardFiles (): FileMatch {
+    return FileMatch.extension('.js', '.mjs', '.cjs', '.json')
+  }
+}

--- a/packages/cli/src/loader/mixed.ts
+++ b/packages/cli/src/loader/mixed.ts
@@ -1,0 +1,45 @@
+import {
+  FileLoader,
+  UnsupportedFileLoaderError,
+} from './loader'
+
+export class MixedFileLoader extends FileLoader {
+  loaders: Set<FileLoader>
+
+  constructor (...loaders: FileLoader[]) {
+    super()
+    this.loaders = new Set(loaders)
+  }
+
+  isAuthoritativeFor (filePath: string): boolean {
+    for (const loader of this.loaders) {
+      if (loader.isAuthoritativeFor(filePath)) {
+        return true
+      }
+    }
+
+    return false
+  }
+
+  async loadFile<T = unknown> (filePath: string): Promise<T> {
+    for (const loader of this.loaders) {
+      if (loader.isAuthoritativeFor(filePath)) {
+        try {
+          return loader.loadFile<T>(filePath)
+        } catch (err) {
+          if (err instanceof UnsupportedFileLoaderError) {
+            // We'll always get the same error. Just remove the loader to
+            // avoid calling it again.
+            this.loaders.delete(loader)
+          }
+
+          throw err
+        }
+      }
+    }
+
+    throw new UnsupportedFileLoaderError(
+      `Unable to find authoritative loader for file '${filePath}'`,
+    )
+  }
+}

--- a/packages/cli/src/loader/native.ts
+++ b/packages/cli/src/loader/native.ts
@@ -1,0 +1,38 @@
+import { BunDetector, DenoDetector } from '../services/check-parser/package-files/package-manager'
+import { pathToPosix } from '../services/util'
+import { FileLoader, FileLoaderOptions } from './loader'
+import { FileMatch } from './match'
+
+export { BunDetector, DenoDetector }
+
+export function detectNativeTypeScriptSupport (): boolean {
+  if (new BunDetector().detectRuntime()) {
+    return true
+  }
+
+  if (new DenoDetector().detectRuntime()) {
+    return true
+  }
+
+  return false
+}
+
+export const hasNativeTypeScriptSupport = detectNativeTypeScriptSupport()
+
+export type NativeFileLoaderOptions = FileLoaderOptions
+
+export class NativeFileLoader extends FileLoader {
+  constructor (options?: NativeFileLoaderOptions) {
+    super({
+      match: hasNativeTypeScriptSupport
+        ? FileMatch.any()
+        : FileMatch.standardFiles(),
+      ...options,
+    })
+  }
+
+  async loadFile<T = unknown> (filePath: string): Promise<T> {
+    const moduleExports = await import(pathToPosix(filePath))
+    return moduleExports
+  }
+}

--- a/packages/cli/src/loader/ts-node.ts
+++ b/packages/cli/src/loader/ts-node.ts
@@ -1,0 +1,99 @@
+import { FileLoader, FileLoaderOptions, UnsupportedFileLoaderError } from './loader'
+import { FileMatch } from './match'
+
+interface TSNodeExports {
+  register (opts?: any): TSNodeService
+}
+
+interface TSNodeService {
+  enabled (enabled?: boolean): boolean
+}
+
+export class UninitializedTSNodeFileLoaderState extends FileLoader {
+  init?: Promise<void>
+
+  async loadFile<T = unknown> (filePath: string): Promise<T> {
+    this.init ??= (async () => {
+      try {
+        const tsNodeExports: TSNodeExports = await import('ts-node')
+        const service = tsNodeExports.register({
+          moduleTypes: {
+            '**/*': 'cjs',
+          },
+          compilerOptions: {
+            module: 'CommonJS',
+          },
+        })
+        TSNodeFileLoader.state = new InitializedTSNodeFileLoaderState(service)
+      } catch (err) {
+        TSNodeFileLoader.state = new FailedTSNodeFileLoaderState(err as Error)
+      }
+    })()
+
+    await this.init
+
+    return await TSNodeFileLoader.state.loadFile(filePath)
+  }
+}
+
+export class FailedTSNodeFileLoaderState extends FileLoader {
+  error: Error
+
+  constructor (error: Error) {
+    super()
+    this.error = error
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async loadFile<T = unknown> (filePath: string): Promise<T> {
+    throw new UnsupportedFileLoaderError('TSNodeFileLoader is not supported', {
+      cause: this.error,
+    })
+  }
+}
+
+export class InitializedTSNodeFileLoaderState extends FileLoader {
+  service: TSNodeService
+
+  constructor (service: TSNodeService) {
+    super()
+    this.service = service
+  }
+
+  async loadFile<T = unknown> (filePath: string): Promise<T> {
+    try {
+      this.service.enabled(true)
+
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const moduleExports = require(filePath)
+      return moduleExports
+    } catch (err: any) {
+      if (err.message?.includes('Unable to compile TypeScript')) {
+        throw new Error(`Unable to load file '${filePath}' with 'ts-node' (hint: consider installing 'jiti' for improved TypeScript support)`, {
+          cause: err as Error,
+        })
+      }
+
+      throw err
+    } finally {
+      this.service.enabled(false)
+    }
+  }
+}
+
+export type TSNodeFileLoaderOptions = FileLoaderOptions
+
+export class TSNodeFileLoader extends FileLoader {
+  static state: FileLoader = new UninitializedTSNodeFileLoaderState()
+
+  constructor (options?: TSNodeFileLoaderOptions) {
+    super({
+      match: FileMatch.standardFiles().complement(),
+      ...options,
+    })
+  }
+
+  async loadFile<T = unknown> (filePath: string): Promise<T> {
+    return TSNodeFileLoader.state.loadFile<T>(filePath)
+  }
+}

--- a/packages/cli/src/loader/ts-node.ts
+++ b/packages/cli/src/loader/ts-node.ts
@@ -69,7 +69,7 @@ export class InitializedTSNodeFileLoaderState extends FileLoader {
       return moduleExports
     } catch (err: any) {
       if (err.message?.includes('Unable to compile TypeScript')) {
-        throw new Error(`Unable to load file '${filePath}' with 'ts-node' (hint: consider installing 'jiti' for improved TypeScript support)`, {
+        throw new Error(`Unable to load file '${filePath}' with 'ts-node' (hint: consider installing 'jiti' for improved TypeScript support)\n${err.stack}`, {
           cause: err as Error,
         })
       }

--- a/packages/cli/src/playwright/playwright-config-loader.ts
+++ b/packages/cli/src/playwright/playwright-config-loader.ts
@@ -1,6 +1,6 @@
-import fs from 'fs'
+import fs from 'node:fs/promises'
 import path from 'path'
-import { loadFile } from '../services/util'
+import { Session } from '../constructs/project'
 
 export async function loadPlaywrightConfig () {
   const filenames = [
@@ -13,10 +13,12 @@ export async function loadPlaywrightConfig () {
   ]
   for (const configFile of filenames) {
     const configPath = path.resolve(configFile)
-    if (!fs.existsSync(configPath)) {
+    try {
+      await fs.access(configPath, fs.constants.R_OK)
+    } catch {
       continue
     }
-    const result = await loadFile(configPath)
+    const result = await Session.loadFile(configPath)
     return result
   }
   return undefined

--- a/packages/cli/src/services/checkly-config-loader.ts
+++ b/packages/cli/src/services/checkly-config-loader.ts
@@ -1,13 +1,12 @@
 import * as path from 'path'
-import { existsSync } from 'fs'
-import { loadFile } from './util'
+import fs from 'node:fs/promises'
 import { CheckProps } from '../constructs/check'
 import { Session } from '../constructs'
 import { Construct } from '../constructs/construct'
 import type { Region } from '..'
 import { ReporterType } from '../reporters/reporter'
-import * as fs from 'fs'
 import { PlaywrightConfig } from '../constructs/playwright-config'
+import { FileLoader } from '../loader'
 
 export type CheckConfigDefaults = Pick<CheckProps, 'activated' | 'muted' | 'doubleCheck'
   | 'shouldFail' | 'runtimeId' | 'locations' | 'tags' | 'frequency' | 'environmentVariables'
@@ -70,6 +69,7 @@ export type ChecklyConfig = {
     failOnNoMatching?: boolean,
     reporters?: ReporterType[],
     retries?: number,
+    loader?: FileLoader,
   }
 }
 
@@ -77,7 +77,7 @@ function isString (obj: any) {
   return (Object.prototype.toString.call(obj) === '[object String]')
 }
 
-export function getChecklyConfigFile (): {checklyConfig: string, fileName: string} | undefined {
+export async function getChecklyConfigFile (): Promise<{checklyConfig: string, fileName: string} | undefined> {
   const filenames = [
     'checkly.config.ts',
     'checkly.config.mts',
@@ -89,10 +89,13 @@ export function getChecklyConfigFile (): {checklyConfig: string, fileName: strin
   let config
   for (const configFile of filenames) {
     const dir = path.resolve(path.dirname(configFile))
-    if (!existsSync(path.resolve(dir, configFile))) {
+    const configFilePath = path.resolve(dir, configFile)
+    try {
+      await fs.access(configFilePath, fs.constants.R_OK)
+    } catch {
       continue
     }
-    const file = fs.readFileSync(path.resolve(dir, configFile))
+    const file = await fs.readFile(configFilePath)
     if (file) {
       config = {
         checklyConfig: file.toString(),
@@ -107,22 +110,25 @@ export function getChecklyConfigFile (): {checklyConfig: string, fileName: strin
 export class ConfigNotFoundError extends Error {}
 
 export async function loadChecklyConfig (dir: string, filenames = ['checkly.config.ts', 'checkly.config.mts', 'checkly.config.cts', 'checkly.config.js', 'checkly.config.mjs', 'checkly.config.cjs']): Promise<{ config: ChecklyConfig, constructs: Construct[] }> {
-  let config
+  let config: ChecklyConfig | undefined
   Session.loadingChecklyConfigFile = true
   Session.checklyConfigFileConstructs = []
   for (const filename of filenames) {
     const filePath = path.join(dir, filename)
-    if (existsSync(filePath)) {
-      config = await loadFile(filePath)
-      break
+    try {
+      await fs.access(filePath, fs.constants.R_OK)
+    } catch {
+      continue
     }
+    config = await Session.loadFile<ChecklyConfig>(filePath)
+    break
   }
 
   if (!config) {
     throw new ConfigNotFoundError(`Unable to locate a config at ${dir} with ${filenames.join(', ')}.`)
   }
 
-  for (const field of ['logicalId', 'projectName']) {
+  for (const field of ['logicalId', 'projectName'] as const) {
     const requiredField = config?.[field]
     if (!requiredField || !(isString(requiredField))) {
       throw new Error(`Config object missing a ${field} as type string`)
@@ -132,5 +138,8 @@ export async function loadChecklyConfig (dir: string, filenames = ['checkly.conf
   const constructs = Session.checklyConfigFileConstructs
   Session.loadingChecklyConfigFile = false
   Session.checklyConfigFileConstructs = []
+  if (config.cli?.loader) {
+    Session.loader = config.cli.loader
+  }
   return { config, constructs }
 }

--- a/packages/cli/src/services/project-parser.ts
+++ b/packages/cli/src/services/project-parser.ts
@@ -1,5 +1,5 @@
 import * as path from 'path'
-import { findFilesWithPattern, loadFile, pathToPosix } from './util'
+import { findFilesWithPattern, pathToPosix } from './util'
 import {
   Check, BrowserCheck, CheckGroup, Project, Session,
   PrivateLocation, PrivateLocationCheckAssignment, PrivateLocationGroupAssignment, MultiStepCheck,
@@ -84,12 +84,7 @@ async function loadAllCheckFiles (
     // setting the checkFilePath is used for filtering by file name on the command line
     Session.checkFileAbsolutePath = checkFile
     Session.checkFilePath = pathToPosix(path.relative(directory, checkFile))
-    if (/\.[mc]?(js|ts)$/.test(checkFile)) {
-      await loadFile(checkFile)
-    } else {
-      throw new Error('Unable to load check configuration file with unsupported extension. ' +
-      `Please use a .js, .mjs, .cjs, .ts, .mts or .cts file instead.\n${checkFile}`)
-    }
+    await Session.loadFile(checkFile)
     Session.checkFilePath = undefined
     Session.checkFileAbsolutePath = undefined
   }

--- a/packages/cli/src/services/util.ts
+++ b/packages/cli/src/services/util.ts
@@ -1,9 +1,7 @@
-/* eslint-disable @typescript-eslint/no-require-imports */
 import type { CreateAxiosDefaults } from 'axios'
 import * as path from 'path'
 import * as fs from 'fs/promises'
 import * as fsSync from 'fs'
-import { Service } from 'ts-node'
 import gitRepoInfo from 'git-repo-info'
 import { parse } from 'dotenv'
 // @ts-ignore
@@ -50,105 +48,6 @@ export function findFilesRecursively (directory: string, ignoredPaths: Array<str
     }
   }
   return files
-}
-
-export async function loadFile (filepath: string): Promise<any> {
-  try {
-    let exported: any
-    if (/\.[mc]?ts$/.test(filepath)) {
-      exported = await loadTsFileDefault(filepath)
-    } else {
-      const imported = await import(pathToPosix(filepath))
-      exported = imported.default ?? {}
-    }
-    if (typeof exported === 'function') {
-      exported = await exported()
-    }
-    return exported
-  } catch (err: any) {
-    throw new Error(`Error loading file ${filepath}\n${err.stack}`)
-  }
-}
-
-async function loadTsFileDefault (filepath: string): Promise<any> {
-  const jiti = await getJiti()
-  if (jiti) {
-    return jiti.import<any>(filepath, {
-      default: true,
-    })
-  }
-
-  // Backward-compatibility for users who installed ts-node.
-  const tsCompiler = await getTsNodeService()
-  if (tsCompiler) {
-    tsCompiler.enabled(true)
-    let exported: any
-    try {
-      exported = (await require(filepath)).default
-    } catch (err: any) {
-      if (err.message && err.message.includes('Unable to compile TypeScript')) {
-        throw new Error(`Consider installing "jiti" instead of "ts-node" for improved TypeScript support\n${err.stack}`)
-      }
-      throw err
-    } finally {
-      tsCompiler.enabled(false) // Re-disable the TS compiler
-    }
-    return exported
-  }
-
-  throw new Error('Please install "jiti" to use TypeScript files')
-}
-
-// Regular type import gave issue with jest.
-type Jiti = ReturnType<(typeof import('jiti', {
-  with: {
-    'resolution-mode': 'import'
-  }
-}))['createJiti']>
-
-// To avoid a dependency on typescript for users with no TS checks, we need to dynamically import jiti
-let jiti: Jiti
-let haveJiti = false
-async function getJiti (): Promise<Jiti | undefined> {
-  if (haveJiti) return jiti
-  try {
-    const maybeJiti = await import('jiti')
-    // Jiti 1x does not have createJiti().
-    if (typeof maybeJiti.createJiti !== 'function') {
-      return
-    }
-    jiti = maybeJiti.createJiti(__filename)
-    haveJiti = true
-  } catch (err: any) {
-    if (err.code === 'ERR_MODULE_NOT_FOUND' || err.code === 'MODULE_NOT_FOUND') {
-      return undefined
-    }
-    throw err
-  }
-  return jiti
-}
-
-// To avoid a dependency on typescript for users with no TS checks, we need to dynamically import ts-node
-let tsNodeService: Service
-async function getTsNodeService (): Promise<Service | undefined> {
-  if (tsNodeService) return tsNodeService
-  try {
-    const tsNode = await import('ts-node')
-    tsNodeService = tsNode.register({
-      moduleTypes: {
-        '**/*': 'cjs',
-      },
-      compilerOptions: {
-        module: 'CommonJS',
-      },
-    })
-  } catch (err: any) {
-    if (err.code === 'ERR_MODULE_NOT_FOUND' || err.code === 'MODULE_NOT_FOUND') {
-      return undefined
-    }
-    throw err
-  }
-  return tsNodeService
 }
 
 /**


### PR DESCRIPTION
Files are now loaded with a more intelligent loader that's able to utilize several different options. Additionally it is able to simply utilize the native loader in runtimes that support TypeScript natively.

The main benefits of improving the loader are:

1. The ability to skip `jiti` and `ts-node` if the runtime already supports TypeScript, which avoids a whole bunch of potential conflicts and should be way faster too. Currently, it will detect Deno and Bun.
2. The ability to collect exports of check files, which can be used for more intelligent code generation for the import feature.
3. The ability for the user to define their own loader if they like, and for us to easily define more loaders.

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
