### PR TITLE
feat: use existing variables in code generated for import [sc-24139]

### DIFF
--- a/packages/cli/src/constructs/check-codegen.ts
+++ b/packages/cli/src/constructs/check-codegen.ts
@@ -84,13 +84,13 @@ export function buildCheckProps (
       for (const privateLocationId of privateLocationIds) {
         try {
           const privateLocationVariable = context.lookupPrivateLocation(privateLocationId)
-          context.importVariable(privateLocationVariable, genfile)
-          builder.value(privateLocationVariable.id)
+          const id = context.importVariable(privateLocationVariable, genfile)
+          builder.value(id)
         } catch {
           try {
             const privateLocationVariable = context.lookupFriendPrivateLocation(privateLocationId)
-            context.importFriendVariable(privateLocationVariable, genfile)
-            builder.value(privateLocationVariable.id)
+            const id = context.importFriendVariable(privateLocationVariable, genfile)
+            builder.value(id)
           } catch {
             builder.value(valueForPrivateLocationFromId(genfile, privateLocationId))
           }
@@ -128,13 +128,13 @@ export function buildCheckProps (
   if (resource.groupId) {
     try {
       const groupVariable = context.lookupCheckGroup(resource.groupId)
-      context.importVariable(groupVariable, genfile)
-      builder.value('group', groupVariable.id)
+      const id = context.importVariable(groupVariable, genfile)
+      builder.value('group', id)
     } catch {
       try {
         const groupVariable = context.lookupFriendCheckGroup(resource.groupId)
-        context.importFriendVariable(groupVariable, genfile)
-        builder.value('group', groupVariable.id)
+        const id = context.importFriendVariable(groupVariable, genfile)
+        builder.value('group', id)
       } catch {
         builder.value('group', valueForCheckGroupFromId(genfile, resource.groupId))
       }
@@ -154,13 +154,13 @@ export function buildCheckProps (
       for (const alertChannelId of alertChannelIds) {
         try {
           const alertChannelVariable = context.lookupAlertChannel(alertChannelId)
-          context.importVariable(alertChannelVariable, genfile)
-          builder.value(alertChannelVariable.id)
+          const id = context.importVariable(alertChannelVariable, genfile)
+          builder.value(id)
         } catch {
           try {
             const alertChannelVariable = context.lookupFriendAlertChannel(alertChannelId)
-            context.importFriendVariable(alertChannelVariable, genfile)
-            builder.value(alertChannelVariable.id)
+            const id = context.importFriendVariable(alertChannelVariable, genfile)
+            builder.value(id)
           } catch {
             builder.value(valueForAlertChannelFromId(genfile, alertChannelId))
           }

--- a/packages/cli/src/constructs/check-codegen.ts
+++ b/packages/cli/src/constructs/check-codegen.ts
@@ -87,7 +87,13 @@ export function buildCheckProps (
           context.importVariable(privateLocationVariable, genfile)
           builder.value(privateLocationVariable.id)
         } catch {
-          builder.value(valueForPrivateLocationFromId(genfile, privateLocationId))
+          try {
+            const privateLocationVariable = context.lookupFriendPrivateLocation(privateLocationId)
+            context.importFriendVariable(privateLocationVariable, genfile)
+            builder.value(privateLocationVariable.id)
+          } catch {
+            builder.value(valueForPrivateLocationFromId(genfile, privateLocationId))
+          }
         }
       }
     })
@@ -125,7 +131,13 @@ export function buildCheckProps (
       context.importVariable(groupVariable, genfile)
       builder.value('group', groupVariable.id)
     } catch {
-      builder.value('group', valueForCheckGroupFromId(genfile, resource.groupId))
+      try {
+        const groupVariable = context.lookupFriendCheckGroup(resource.groupId)
+        context.importFriendVariable(groupVariable, genfile)
+        builder.value('group', groupVariable.id)
+      } catch {
+        builder.value('group', valueForCheckGroupFromId(genfile, resource.groupId))
+      }
     }
   }
 
@@ -145,7 +157,13 @@ export function buildCheckProps (
           context.importVariable(alertChannelVariable, genfile)
           builder.value(alertChannelVariable.id)
         } catch {
-          builder.value(valueForAlertChannelFromId(genfile, alertChannelId))
+          try {
+            const alertChannelVariable = context.lookupFriendAlertChannel(alertChannelId)
+            context.importFriendVariable(alertChannelVariable, genfile)
+            builder.value(alertChannelVariable.id)
+          } catch {
+            builder.value(valueForAlertChannelFromId(genfile, alertChannelId))
+          }
         }
       }
     })

--- a/packages/cli/src/constructs/check-group-codegen.ts
+++ b/packages/cli/src/constructs/check-group-codegen.ts
@@ -89,13 +89,13 @@ function buildCheckGroupProps (
       for (const privateLocationId of privateLocationIds) {
         try {
           const privateLocationVariable = context.lookupPrivateLocation(privateLocationId)
-          context.importVariable(privateLocationVariable, genfile)
-          builder.value(privateLocationVariable.id)
+          const id = context.importVariable(privateLocationVariable, genfile)
+          builder.value(id)
         } catch {
           try {
             const privateLocationVariable = context.lookupFriendPrivateLocation(privateLocationId)
-            context.importFriendVariable(privateLocationVariable, genfile)
-            builder.value(privateLocationVariable.id)
+            const id = context.importFriendVariable(privateLocationVariable, genfile)
+            builder.value(id)
           } catch {
             builder.value(valueForPrivateLocationFromId(genfile, privateLocationId))
           }
@@ -143,13 +143,13 @@ function buildCheckGroupProps (
       for (const alertChannelId of alertChannelIds) {
         try {
           const alertChannelVariable = context.lookupAlertChannel(alertChannelId)
-          context.importVariable(alertChannelVariable, genfile)
-          builder.value(alertChannelVariable.id)
+          const id = context.importVariable(alertChannelVariable, genfile)
+          builder.value(id)
         } catch {
           try {
             const alertChannelVariable = context.lookupFriendAlertChannel(alertChannelId)
-            context.importFriendVariable(alertChannelVariable, genfile)
-            builder.value(alertChannelVariable.id)
+            const id = context.importFriendVariable(alertChannelVariable, genfile)
+            builder.value(id)
           } catch {
             builder.value(valueForAlertChannelFromId(genfile, alertChannelId))
           }

--- a/packages/cli/src/constructs/check-group-codegen.ts
+++ b/packages/cli/src/constructs/check-group-codegen.ts
@@ -311,6 +311,7 @@ export class CheckGroupCodegen extends Codegen<CheckGroupResource> {
 
     context.registerCheckGroup(
       resource.id,
+      resource.name,
       this.program.generatedConstructFile(filename.fullPath),
     )
   }

--- a/packages/cli/src/constructs/check-group-codegen.ts
+++ b/packages/cli/src/constructs/check-group-codegen.ts
@@ -92,7 +92,13 @@ function buildCheckGroupProps (
           context.importVariable(privateLocationVariable, genfile)
           builder.value(privateLocationVariable.id)
         } catch {
-          builder.value(valueForPrivateLocationFromId(genfile, privateLocationId))
+          try {
+            const privateLocationVariable = context.lookupFriendPrivateLocation(privateLocationId)
+            context.importFriendVariable(privateLocationVariable, genfile)
+            builder.value(privateLocationVariable.id)
+          } catch {
+            builder.value(valueForPrivateLocationFromId(genfile, privateLocationId))
+          }
         }
       }
     })
@@ -140,7 +146,13 @@ function buildCheckGroupProps (
           context.importVariable(alertChannelVariable, genfile)
           builder.value(alertChannelVariable.id)
         } catch {
-          builder.value(valueForAlertChannelFromId(genfile, alertChannelId))
+          try {
+            const alertChannelVariable = context.lookupFriendAlertChannel(alertChannelId)
+            context.importFriendVariable(alertChannelVariable, genfile)
+            builder.value(alertChannelVariable.id)
+          } catch {
+            builder.value(valueForAlertChannelFromId(genfile, alertChannelId))
+          }
         }
       }
     })

--- a/packages/cli/src/constructs/email-alert-channel-codegen.ts
+++ b/packages/cli/src/constructs/email-alert-channel-codegen.ts
@@ -17,9 +17,11 @@ export class EmailAlertChannelCodegen extends Codegen<EmailAlertChannelResource>
   }
 
   prepare (logicalId: string, resource: EmailAlertChannelResource, context: Context): void {
+    const { address } = resource.config
+
     context.registerAlertChannel(
       resource.id,
-      'emailAlert',
+      `${address.split('@')[0]} email`,
       this.program.generatedConstructFile('resources/alert-channels/email'),
     )
   }

--- a/packages/cli/src/constructs/incidentio-alert-channel-codegen.ts
+++ b/packages/cli/src/constructs/incidentio-alert-channel-codegen.ts
@@ -65,9 +65,11 @@ export class IncidentioAlertChannelCodegen extends Codegen<IncidentioAlertChanne
   prepare (logicalId: string, resource: IncidentioAlertChannelResource, context: Context): void {
     this.validateSafety(resource)
 
+    const { name } = resource.config
+
     context.registerAlertChannel(
       resource.id,
-      'incidentioAlert',
+      `${name} incidentio`,
       this.program.generatedConstructFile('resources/alert-channels/incident-io'),
     )
   }

--- a/packages/cli/src/constructs/internal/codegen/context.ts
+++ b/packages/cli/src/constructs/internal/codegen/context.ts
@@ -79,7 +79,13 @@ export class FilePath {
  * @returns Formatted variable name
  */
 function formatVariable (base: string, name: string): string {
-  let prefix = cased(name, 'camelCase').replace(/^[0-9]+/, '')
+  let prefix = cased(name, 'camelCase')
+
+  // Even camelcased, the prefix may start with a number. Get rid of it.
+  if (/^[0-9]+/.test(prefix)) {
+    prefix = prefix.replace(/^[0-9]+/, '')
+    prefix = cased(prefix, 'camelCase')
+  }
 
   // Allow pretty long variables but set a hard limit. Limit does not include
   // the suffix.

--- a/packages/cli/src/constructs/msteams-alert-channel-codegen.ts
+++ b/packages/cli/src/constructs/msteams-alert-channel-codegen.ts
@@ -42,9 +42,11 @@ export class MSTeamsAlertChannelCodegen extends Codegen<MSTeamsAlertChannelResou
   prepare (logicalId: string, resource: MSTeamsAlertChannelResource, context: Context): void {
     this.validateSafety(resource)
 
+    const { name } = resource.config
+
     context.registerAlertChannel(
       resource.id,
-      'teamsAlert',
+      name ? `${name} teams` : 'teams',
       this.program.generatedConstructFile('resources/alert-channels/ms-teams'),
     )
   }

--- a/packages/cli/src/constructs/opsgenie-alert-channel-codegen.ts
+++ b/packages/cli/src/constructs/opsgenie-alert-channel-codegen.ts
@@ -20,9 +20,11 @@ export class OpsgenieAlertChannelCodegen extends Codegen<OpsgenieAlertChannelRes
   }
 
   prepare (logicalId: string, resource: OpsgenieAlertChannelResource, context: Context): void {
+    const { name } = resource.config
+
     context.registerAlertChannel(
       resource.id,
-      'opsgenieAlert',
+      `${name} opsgenie`,
       this.program.generatedConstructFile('resources/alert-channels/opsgenie'),
     )
   }

--- a/packages/cli/src/constructs/pagerduty-alert-channel-codegen.ts
+++ b/packages/cli/src/constructs/pagerduty-alert-channel-codegen.ts
@@ -27,9 +27,11 @@ export class PagerdutyAlertChannelCodegen extends Codegen<PagerdutyAlertChannelR
   }
 
   prepare (logicalId: string, resource: PagerdutyAlertChannelResource, context: Context): void {
+    const { serviceName, account } = resource.config
+
     context.registerAlertChannel(
       resource.id,
-      'pagerdutyAlert',
+      serviceName ? `${serviceName} pagerduty` : (account ? `${account} pagerduty` : `pagerduty`),
       this.program.generatedConstructFile('resources/alert-channels/pagerduty'),
     )
   }

--- a/packages/cli/src/constructs/phone-call-alert-channel-codegen.ts
+++ b/packages/cli/src/constructs/phone-call-alert-channel-codegen.ts
@@ -22,9 +22,11 @@ export class PhoneCallAlertChannelCodegen extends Codegen<PhoneCallAlertChannelR
   }
 
   prepare (logicalId: string, resource: PhoneCallAlertChannelResource, context: Context): void {
+    const { name } = resource.config
+
     context.registerAlertChannel(
       resource.id,
-      'phoneCallAlert',
+      name ? `${name} phone call` : 'phone call',
       this.program.generatedConstructFile('resources/alert-channels/phone-call'),
     )
   }

--- a/packages/cli/src/constructs/private-location-codegen.ts
+++ b/packages/cli/src/constructs/private-location-codegen.ts
@@ -34,6 +34,7 @@ export class PrivateLocationCodegen extends Codegen<PrivateLocationResource> {
 
     context.registerPrivateLocation(
       resource.id,
+      resource.name,
       this.program.generatedConstructFile(filePath.fullPath),
     )
   }

--- a/packages/cli/src/constructs/slack-alert-channel-codegen.ts
+++ b/packages/cli/src/constructs/slack-alert-channel-codegen.ts
@@ -22,9 +22,11 @@ export class SlackAlertChannelCodegen extends Codegen<SlackAlertChannelResource>
   }
 
   prepare (logicalId: string, resource: SlackAlertChannelResource, context: Context): void {
+    const { channel } = resource.config
+
     context.registerAlertChannel(
       resource.id,
-      'slackAlert',
+      channel ? `${channel} slack` : 'slack',
       this.program.generatedConstructFile('resources/alert-channels/slack'),
     )
   }

--- a/packages/cli/src/constructs/sms-alert-channel-codegen.ts
+++ b/packages/cli/src/constructs/sms-alert-channel-codegen.ts
@@ -22,9 +22,11 @@ export class SmsAlertChannelCodegen extends Codegen<SmsAlertChannelResource> {
   }
 
   prepare (logicalId: string, resource: SmsAlertChannelResource, context: Context): void {
+    const { name } = resource.config
+
     context.registerAlertChannel(
       resource.id,
-      'smsAlert',
+      name ? `${name} sms` : 'sms',
       this.program.generatedConstructFile('resources/alert-channels/sms'),
     )
   }

--- a/packages/cli/src/constructs/status-page-codegen.ts
+++ b/packages/cli/src/constructs/status-page-codegen.ts
@@ -55,7 +55,13 @@ export class StatusPageCodegen extends Codegen<StatusPageResource> {
                       context.importVariable(serviceVariable, file)
                       builder.value(serviceVariable.id)
                     } catch {
-                      builder.value(valueForStatusPageServiceFromId(file, service.id))
+                      try {
+                        const serviceVariable = context.lookupFriendStatusPageService(service.id)
+                        context.importFriendVariable(serviceVariable, file)
+                        builder.value(serviceVariable.id)
+                      } catch {
+                        builder.value(valueForStatusPageServiceFromId(file, service.id))
+                      }
                     }
                   }
                 })

--- a/packages/cli/src/constructs/status-page-codegen.ts
+++ b/packages/cli/src/constructs/status-page-codegen.ts
@@ -52,13 +52,13 @@ export class StatusPageCodegen extends Codegen<StatusPageResource> {
                   for (const service of card.services) {
                     try {
                       const serviceVariable = context.lookupStatusPageService(service.id)
-                      context.importVariable(serviceVariable, file)
-                      builder.value(serviceVariable.id)
+                      const id = context.importVariable(serviceVariable, file)
+                      builder.value(id)
                     } catch {
                       try {
                         const serviceVariable = context.lookupFriendStatusPageService(service.id)
-                        context.importFriendVariable(serviceVariable, file)
-                        builder.value(serviceVariable.id)
+                        const id = context.importFriendVariable(serviceVariable, file)
+                        builder.value(id)
                       } catch {
                         builder.value(valueForStatusPageServiceFromId(file, service.id))
                       }

--- a/packages/cli/src/constructs/status-page-service-codegen.ts
+++ b/packages/cli/src/constructs/status-page-service-codegen.ts
@@ -31,6 +31,7 @@ export class StatusPageServiceCodegen extends Codegen<StatusPageServiceResource>
 
     context.registerStatusPageService(
       resource.id,
+      resource.name,
       this.program.generatedConstructFile(filePath.fullPath),
     )
   }

--- a/packages/cli/src/constructs/telegram-alert-channel-codegen.ts
+++ b/packages/cli/src/constructs/telegram-alert-channel-codegen.ts
@@ -73,9 +73,11 @@ export class TelegramAlertChannelCodegen extends Codegen<TelegramAlertChannelRes
   prepare (logicalId: string, resource: TelegramAlertChannelResource, context: Context): void {
     this.validateSafety(resource)
 
+    const { name } = resource.config
+
     context.registerAlertChannel(
       resource.id,
-      'telegramAlert',
+      `${name} telegram`,
       this.program.generatedConstructFile('resources/alert-channels/telegram'),
     )
   }

--- a/packages/cli/src/constructs/webhook-alert-channel-codegen.ts
+++ b/packages/cli/src/constructs/webhook-alert-channel-codegen.ts
@@ -143,9 +143,11 @@ export class WebhookAlertChannelCodegen extends Codegen<WebhookAlertChannelResou
       }
     }
 
+    const { name } = resource.config
+
     context.registerAlertChannel(
       resource.id,
-      'webhookAlert',
+      `${name} webhook`,
       this.program.generatedConstructFile('resources/alert-channels/webhook'),
     )
   }

--- a/packages/cli/src/rest/projects.ts
+++ b/packages/cli/src/rest/projects.ts
@@ -25,6 +25,36 @@ export interface ResourceSync {
   payload: any,
 }
 
+export interface AlertChannelFriendResource {
+  type: 'alert-channel'
+  logicalId: string
+  physicalId: number
+}
+
+export interface CheckGroupFriendResource {
+  type: 'check-group'
+  logicalId: string
+  physicalId: number
+}
+
+export interface PrivateLocationFriendResource {
+  type: 'private-location'
+  logicalId: string
+  physicalId: string
+}
+
+export interface StatusPageServiceFriendResource {
+  type: 'status-page-service'
+  logicalId: string
+  physicalId: string
+}
+
+export type FriendResourceSync =
+  AlertChannelFriendResource |
+  CheckGroupFriendResource |
+  PrivateLocationFriendResource |
+  StatusPageServiceFriendResource
+
 export interface AuxiliaryResourceSync {
   physicalId?: string|number
   type: string
@@ -50,13 +80,20 @@ export interface ImportPlanFilter {
   }
 }
 
+export interface ImportPlanFriend {
+  type: string
+  logicalId: string
+}
+
 export interface ImportPlanOptions {
   preview?: boolean
   filters?: ImportPlanFilter[]
+  friends?: ImportPlanFriend[]
 }
 
 export interface ImportPlanChanges {
   resources: ResourceSync[]
+  friends?: FriendResourceSync[]
   auxiliary?: AuxiliaryResourceSync[]
 }
 
@@ -123,6 +160,7 @@ class Projects {
   async createImportPlan (logicalId: string, options?: ImportPlanOptions) {
     const payload = {
       filters: options?.filters,
+      friends: options?.friends,
     }
     return this.api.post<ImportPlan>(`/next/projects/${logicalId}/imports`, payload, {
       params: {

--- a/packages/cli/src/sourcegen/program.ts
+++ b/packages/cli/src/sourcegen/program.ts
@@ -197,6 +197,14 @@ export interface NamedImport {
   alias?: string
 }
 
+function sortNamedImports (imports: NamedImport[]): NamedImport[] {
+  return Array.from(imports).sort((a, b) => {
+    const valueA = [a.identifier, a.alias].join(', ')
+    const valueB = [b.identifier, b.alias].join(', ')
+    return valueA.localeCompare(valueB)
+  })
+}
+
 export class GeneratedFile extends ProgramFile {
   #namedImports = new Map<string, NamedImport[]>()
   #plainImports = new Set<string>()
@@ -272,7 +280,7 @@ export class GeneratedFile extends ProgramFile {
         output.cosmeticWhitespace()
         output.append('{')
         let first = true
-        for (const { identifier, alias } of Array.from(imports).sort()) {
+        for (const { identifier, alias } of sortNamedImports(imports)) {
           if (!first) {
             output.append(',')
           }

--- a/packages/cli/src/sourcegen/program.ts
+++ b/packages/cli/src/sourcegen/program.ts
@@ -189,22 +189,38 @@ function posixPath (path: string): string {
 export interface ImportOptions {
   relativeTo?: string
   relativeToSelf?: boolean
+  alias?: string
+}
+
+export interface NamedImport {
+  identifier: string
+  alias?: string
 }
 
 export class GeneratedFile extends ProgramFile {
-  #namedImports = new Map<string, Set<string>>()
+  #namedImports = new Map<string, NamedImport[]>()
   #plainImports = new Set<string>()
   #sections: Content[] = []
   #headers: Header[] = []
 
-  namedImport (type: string, from: string, options?: ImportOptions) {
+  namedImport (identifier: string, from: string, options?: ImportOptions) {
     from = this.#processImportFrom(from, options)
 
-    if (this.#namedImports.has(from)) {
-      this.#namedImports.get(from)?.add(type)
-    } else {
-      this.#namedImports.set(from, new Set([type]))
+    const namedImports = this.#namedImports.get(from) ?? []
+
+    for (const namedImport of namedImports) {
+      if (namedImport.identifier === identifier && namedImport.alias === options?.alias) {
+        // Already imported.
+        return
+      }
     }
+
+    namedImports.push({
+      identifier,
+      alias: options?.alias,
+    })
+
+    this.#namedImports.set(from, namedImports)
   }
 
   plainImport (from: string, options?: ImportOptions) {
@@ -251,18 +267,24 @@ export class GeneratedFile extends ProgramFile {
     }
 
     if (this.#namedImports.size > 0) {
-      for (const [pkg, types] of this.#namedImports.entries()) {
+      for (const [pkg, imports] of this.#namedImports.entries()) {
         output.append('import')
         output.cosmeticWhitespace()
         output.append('{')
         let first = true
-        for (const type of Array.from(types).sort()) {
+        for (const { identifier, alias } of Array.from(imports).sort()) {
           if (!first) {
             output.append(',')
           }
           output.cosmeticWhitespace()
           first = false
-          output.append(type)
+          output.append(identifier)
+          if (alias !== undefined) {
+            output.significantWhitespace()
+            output.append('as')
+            output.significantWhitespace()
+            output.append(alias)
+          }
         }
         output.cosmeticWhitespace()
         output.append('}')


### PR DESCRIPTION
If you import resources that refer to other resources that were already part of your project, previously we'd create `<Resource>.fromId()` references for them. With this change, we'll instead try to find a matching exported construct in the codebase which we can then import in the generated file.

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
