### PR TITLE
fix: avoid duplicate resources when retrying an import [sc-24150]

### DIFF
--- a/packages/cli/src/commands/import/plan.ts
+++ b/packages/cli/src/commands/import/plan.ts
@@ -147,14 +147,6 @@ future deployments include the imported resources.`
       `local changes get overwritten by generated code.`,
     )
 
-    const program = new Program({
-      rootDirectory,
-      constructFileSuffix: '.check',
-      constructHeaders: preview ? [previewComment()] : undefined,
-      specFileSuffix: '.spec',
-      language: 'typescript',
-    })
-
     const checklyConfig = await this.#loadConfig(configFilename)
       ?? await this.#interactiveCreateConfig()
 
@@ -174,6 +166,19 @@ future deployments include the imported resources.`
       }
     }
 
+    const createProgram = () => {
+      return new Program({
+        rootDirectory,
+        constructFileSuffix: '.check',
+        constructHeaders: preview ? [previewComment()] : undefined,
+        specFileSuffix: '.spec',
+        language: 'typescript',
+      })
+    }
+
+    // These are needed for the interactive filter creation for now. Ideally
+    // we'd remove these.
+    const program = createProgram()
     const codegen = new ConstructCodegen(program)
 
     // If the user provided no filter, ask interactively.
@@ -191,6 +196,11 @@ future deployments include the imported resources.`
     })
 
     while (true) {
+      // Recreate program on every attempt as otherwise resources from earlier
+      // runs will persist.
+      const program = createProgram()
+      const codegen = new ConstructCodegen(program)
+
       const plan = await this.#createImportPlan(logicalId, {
         preview,
         filters,


### PR DESCRIPTION
Due to an oversight, `Program` was getting reused between retried import runs which resulted in duplicate code.

Some slight refactoring should be done in the future to clean it up a little (mostly to avoid having to create a program for interactive filters which only need the `.describe()` from the codegen) but this change will do for now.

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
