### PR TITLE
fix: create a separate file for each imported alert channel [sc-24153]

### DIFF
--- a/packages/cli/src/constructs/email-alert-channel-codegen.ts
+++ b/packages/cli/src/constructs/email-alert-channel-codegen.ts
@@ -19,10 +19,16 @@ export class EmailAlertChannelCodegen extends Codegen<EmailAlertChannelResource>
   prepare (logicalId: string, resource: EmailAlertChannelResource, context: Context): void {
     const { address } = resource.config
 
+    const prefix = address.split('@')[0]
+
+    const filename = context.filePath('resources/alert-channels/email', prefix, {
+      unique: true,
+    })
+
     context.registerAlertChannel(
       resource.id,
-      `${address.split('@')[0]} email`,
-      this.program.generatedConstructFile('resources/alert-channels/email'),
+      `${prefix} email`,
+      this.program.generatedConstructFile(filename.fullPath),
     )
   }
 

--- a/packages/cli/src/constructs/incidentio-alert-channel-codegen.ts
+++ b/packages/cli/src/constructs/incidentio-alert-channel-codegen.ts
@@ -67,10 +67,14 @@ export class IncidentioAlertChannelCodegen extends Codegen<IncidentioAlertChanne
 
     const { name } = resource.config
 
+    const filename = context.filePath('resources/alert-channels/incident-io', name, {
+      unique: true,
+    })
+
     context.registerAlertChannel(
       resource.id,
       `${name} incidentio`,
-      this.program.generatedConstructFile('resources/alert-channels/incident-io'),
+      this.program.generatedConstructFile(filename.fullPath),
     )
   }
 

--- a/packages/cli/src/constructs/msteams-alert-channel-codegen.ts
+++ b/packages/cli/src/constructs/msteams-alert-channel-codegen.ts
@@ -44,10 +44,14 @@ export class MSTeamsAlertChannelCodegen extends Codegen<MSTeamsAlertChannelResou
 
     const { name } = resource.config
 
+    const filename = context.filePath('resources/alert-channels/ms-teams', name, {
+      unique: true,
+    })
+
     context.registerAlertChannel(
       resource.id,
-      name ? `${name} teams` : 'teams',
-      this.program.generatedConstructFile('resources/alert-channels/ms-teams'),
+      `${name} teams`,
+      this.program.generatedConstructFile(filename.fullPath),
     )
   }
 

--- a/packages/cli/src/constructs/opsgenie-alert-channel-codegen.ts
+++ b/packages/cli/src/constructs/opsgenie-alert-channel-codegen.ts
@@ -22,10 +22,14 @@ export class OpsgenieAlertChannelCodegen extends Codegen<OpsgenieAlertChannelRes
   prepare (logicalId: string, resource: OpsgenieAlertChannelResource, context: Context): void {
     const { name } = resource.config
 
+    const filename = context.filePath('resources/alert-channels/opsgenie', name, {
+      unique: true,
+    })
+
     context.registerAlertChannel(
       resource.id,
       `${name} opsgenie`,
-      this.program.generatedConstructFile('resources/alert-channels/opsgenie'),
+      this.program.generatedConstructFile(filename.fullPath),
     )
   }
 

--- a/packages/cli/src/constructs/pagerduty-alert-channel-codegen.ts
+++ b/packages/cli/src/constructs/pagerduty-alert-channel-codegen.ts
@@ -27,12 +27,20 @@ export class PagerdutyAlertChannelCodegen extends Codegen<PagerdutyAlertChannelR
   }
 
   prepare (logicalId: string, resource: PagerdutyAlertChannelResource, context: Context): void {
-    const { serviceName, account } = resource.config
+    const { serviceName, account, serviceKey } = resource.config
+
+    const prefix = serviceName ?? account
+    const last4Chars = serviceKey.slice(-4)
+    const fallbackName = `pagerduty-${last4Chars}`
+
+    const filename = context.filePath('resources/alert-channels/pagerduty', prefix || fallbackName, {
+      unique: true,
+    })
 
     context.registerAlertChannel(
       resource.id,
-      serviceName ? `${serviceName} pagerduty` : (account ? `${account} pagerduty` : `pagerduty`),
-      this.program.generatedConstructFile('resources/alert-channels/pagerduty'),
+      prefix ? `${prefix} pagerduty` : fallbackName,
+      this.program.generatedConstructFile(filename.fullPath),
     )
   }
 

--- a/packages/cli/src/constructs/phone-call-alert-channel-codegen.ts
+++ b/packages/cli/src/constructs/phone-call-alert-channel-codegen.ts
@@ -22,12 +22,19 @@ export class PhoneCallAlertChannelCodegen extends Codegen<PhoneCallAlertChannelR
   }
 
   prepare (logicalId: string, resource: PhoneCallAlertChannelResource, context: Context): void {
-    const { name } = resource.config
+    const { name, number } = resource.config
+
+    const last4Digits = number.slice(-4)
+    const fallbackName = `phone-call-${last4Digits}`
+
+    const filename = context.filePath('resources/alert-channels/phone-call', name || fallbackName, {
+      unique: true,
+    })
 
     context.registerAlertChannel(
       resource.id,
-      name ? `${name} phone call` : 'phone call',
-      this.program.generatedConstructFile('resources/alert-channels/phone-call'),
+      name ? `${name} phone call` : fallbackName,
+      this.program.generatedConstructFile(filename.fullPath),
     )
   }
 

--- a/packages/cli/src/constructs/slack-alert-channel-codegen.ts
+++ b/packages/cli/src/constructs/slack-alert-channel-codegen.ts
@@ -22,12 +22,19 @@ export class SlackAlertChannelCodegen extends Codegen<SlackAlertChannelResource>
   }
 
   prepare (logicalId: string, resource: SlackAlertChannelResource, context: Context): void {
-    const { channel } = resource.config
+    const { channel, url } = resource.config
+
+    const last4Chars = url.slice(-4)
+    const fallbackName = `slack-${last4Chars}`
+
+    const filename = context.filePath('resources/alert-channels/slack', channel || fallbackName, {
+      unique: true,
+    })
 
     context.registerAlertChannel(
       resource.id,
-      channel ? `${channel} slack` : 'slack',
-      this.program.generatedConstructFile('resources/alert-channels/slack'),
+      channel ? `${channel} slack` : fallbackName,
+      this.program.generatedConstructFile(filename.fullPath),
     )
   }
 

--- a/packages/cli/src/constructs/sms-alert-channel-codegen.ts
+++ b/packages/cli/src/constructs/sms-alert-channel-codegen.ts
@@ -22,12 +22,19 @@ export class SmsAlertChannelCodegen extends Codegen<SmsAlertChannelResource> {
   }
 
   prepare (logicalId: string, resource: SmsAlertChannelResource, context: Context): void {
-    const { name } = resource.config
+    const { name, number } = resource.config
+
+    const last4Digits = number.slice(-4)
+    const fallbackName = `sms-${last4Digits}`
+
+    const filename = context.filePath('resources/alert-channels/sms', name || fallbackName, {
+      unique: true,
+    })
 
     context.registerAlertChannel(
       resource.id,
-      name ? `${name} sms` : 'sms',
-      this.program.generatedConstructFile('resources/alert-channels/sms'),
+      name ? `${name} sms` : fallbackName,
+      this.program.generatedConstructFile(filename.fullPath),
     )
   }
 

--- a/packages/cli/src/constructs/telegram-alert-channel-codegen.ts
+++ b/packages/cli/src/constructs/telegram-alert-channel-codegen.ts
@@ -75,10 +75,14 @@ export class TelegramAlertChannelCodegen extends Codegen<TelegramAlertChannelRes
 
     const { name } = resource.config
 
+    const filename = context.filePath('resources/alert-channels/telegram', name, {
+      unique: true,
+    })
+
     context.registerAlertChannel(
       resource.id,
       `${name} telegram`,
-      this.program.generatedConstructFile('resources/alert-channels/telegram'),
+      this.program.generatedConstructFile(filename.fullPath),
     )
   }
 

--- a/packages/cli/src/constructs/webhook-alert-channel-codegen.ts
+++ b/packages/cli/src/constructs/webhook-alert-channel-codegen.ts
@@ -145,10 +145,14 @@ export class WebhookAlertChannelCodegen extends Codegen<WebhookAlertChannelResou
 
     const { name } = resource.config
 
+    const filename = context.filePath('resources/alert-channels/webhook', name, {
+      unique: true,
+    })
+
     context.registerAlertChannel(
       resource.id,
       `${name} webhook`,
-      this.program.generatedConstructFile('resources/alert-channels/webhook'),
+      this.program.generatedConstructFile(filename.fullPath),
     )
   }
 


### PR DESCRIPTION
Earlier, all alert channels of the same type were bundled into the same file. Unfortunately when you did a per-resource import of the same type later, it would clear everything else in the file and only include the newly generated construct.

Now, each alert channels is in a separate file.

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
