### PR TITLE
chore: validate that logicalId is always a string [sc-24161]

### DIFF
--- a/packages/cli/src/constructs/project.ts
+++ b/packages/cli/src/constructs/project.ts
@@ -235,6 +235,10 @@ export class Session {
   }
 
   static validateCreateConstruct (construct: Construct) {
+    if (typeof construct.logicalId !== 'string') {
+      throw new ValidationError(`The "logicalId" of a construct must be a string (logicalId=${construct.logicalId} [${typeof construct.logicalId}])`)
+    }
+
     if (!/^[A-Za-z0-9_\-/#.]+$/.test(construct.logicalId)) {
       throw new ValidationError(`The "logicalId" can only include the following characters: [A-Za-z0-9_-/#.]. (logicalId='${construct.logicalId}')`)
     }


### PR DESCRIPTION
Currently it's possible to mistakenly use a value that is not a string if you are not using TypeScript, or your editor is not capable of showing compile errors. Since `jiti` is quite forgiving, it will let the user use an invalid value.

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
