### PR TITLE
fix: the new FileLoader did not implement fallback correctly [sc-24179]

### DIFF
--- a/packages/cli/src/loader/mixed.ts
+++ b/packages/cli/src/loader/mixed.ts
@@ -25,12 +25,13 @@ export class MixedFileLoader extends FileLoader {
     for (const loader of this.loaders) {
       if (loader.isAuthoritativeFor(filePath)) {
         try {
-          return loader.loadFile<T>(filePath)
+          return await loader.loadFile<T>(filePath)
         } catch (err) {
           if (err instanceof UnsupportedFileLoaderError) {
             // We'll always get the same error. Just remove the loader to
             // avoid calling it again.
             this.loaders.delete(loader)
+            continue
           }
 
           throw err


### PR DESCRIPTION
This would cause the loader to fail if Jiti could not be found, or an earlier version of Jiti was used.

The reason why I did not spot this earlier is that during manual testing, I used a symlink to the checkly package, which led to Node finding the appropriate version of `jiti` in the checkly-cli repo (or in other words, from the node_modules folder relative to the actual file behind the symlink). So it seemed to work, but in fact did not. I have now correctly verified both the issue and the fix with `npm pack` and using the generated archive instead.

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
