### PR TITLE
feat: output a warning if user is using an incompatible version of Node [sc-24193]

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,7 +11,7 @@
     "./util": "./dist/util/index.js"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": "^18.19.0 || >=20.5.0"
   },
   "scripts": {
     "clean": "rimraf ./dist",

--- a/packages/create-cli/package.json
+++ b/packages/create-cli/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "private": false,
   "engines": {
-    "node": ">=18.0.0"
+    "node": "^18.19.0 || >=20.5.0"
   },
   "scripts": {
     "clean": "rimraf ./dist",


### PR DESCRIPTION
Adds a warning if the user is running a Node version that isn't supported. The supported version is retrieved from package.json.

The create-cli is not updated for now as it is in need of other changes as well.

The minimum version is updated to `^18.19.0 || >=20.5.0` which matches the value `execa` uses. Right now it's mainly execa that's causing incompatibility issues.

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
