### PR TITLE
fix(tests): fix CI flakiness/slowness on Windows [sc-24403]

### DIFF
--- a/packages/create-cli/e2e/__tests__/bootstrap.spec.ts
+++ b/packages/create-cli/e2e/__tests__/bootstrap.spec.ts
@@ -78,6 +78,7 @@ describe('bootstrap', () => {
     const commandOutput = runChecklyCreateCli({
       directory,
       promptsInjection: [projectName, 'advanced-project', true, true],
+      timeout: 180_000,
     })
 
     const { status, stdout, stderr } = commandOutput
@@ -96,7 +97,7 @@ describe('bootstrap', () => {
     expect(fs.existsSync(path.join(projectFolder, 'checkly.config.ts'))).toBe(true)
     expect(fs.existsSync(path.join(projectFolder, 'node_modules'))).toBe(true)
     expect(fs.existsSync(path.join(projectFolder, '.git'))).toBe(true)
-  }, 30000)
+  }, 180_000)
 
   it('Should create an boilerplate-project without installing dependencies', () => {
     const directory = path.join(__dirname, 'fixtures', 'empty-project')

--- a/packages/create-cli/e2e/run-create-cli.ts
+++ b/packages/create-cli/e2e/run-create-cli.ts
@@ -31,6 +31,7 @@ export async function runChecklyCreateCli (options: {
     cwd: directory ?? process.cwd(),
     encoding: 'utf-8',
     timeout,
+    reject: false,
     shell: process.platform === 'win32',
   })
 

--- a/packages/create-cli/e2e/run-create-cli.ts
+++ b/packages/create-cli/e2e/run-create-cli.ts
@@ -1,9 +1,10 @@
-import * as path from 'path'
-import * as childProcess from 'node:child_process'
+import path from 'node:path'
+
+import execa from 'execa'
 
 const CHECKLY_PATH = path.resolve(path.dirname(__filename), '..', 'bin', 'run')
 
-export function runChecklyCreateCli (options: {
+export async function runChecklyCreateCli (options: {
   directory?: string,
   args?: string[],
   env?: object,
@@ -19,7 +20,8 @@ export function runChecklyCreateCli (options: {
     promptsInjection = [],
     timeout = 30000,
   } = options
-  return childProcess.spawnSync(CHECKLY_PATH, args, {
+
+  const result = await execa(CHECKLY_PATH, args, {
     env: {
       PATH: process.env.PATH,
       CHECKLY_CLI_VERSION: version,
@@ -31,4 +33,6 @@ export function runChecklyCreateCli (options: {
     timeout,
     shell: process.platform === 'win32',
   })
+
+  return result
 }

--- a/packages/create-cli/src/commands/bootstrap.ts
+++ b/packages/create-cli/src/commands/bootstrap.ts
@@ -2,7 +2,7 @@ import axios from 'axios'
 import chalk from 'chalk'
 import prompts from 'prompts'
 import { Command, Flags } from '@oclif/core'
-import { getUserGreeting, header, footer, hint } from '../utils/messages.js'
+import { getUserGreeting, header, footer, hint } from '../utils/messages'
 import { getPlaywrightConfig, hasPackageJsonFile } from '../utils/directory'
 import {
   copyPlaywrightConfig,


### PR DESCRIPTION
The bootstrap tests are taking ages on Windows and eventually fail, sometimes due to what seems like an internal vitest timeout (probably, our `spawnSync` calls prevented internal state updates). Since this worked before, perhaps it's just due to GH Windows runners being slow right now, but it's resulting in a lot of friction in PRs. Make bootstrap tests async and increase timeout of long tests to hopefully avoid this issue entirely.

## Affected Components
* [ ] CLI
* [x] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
