### PR TITLE
feat: use the new FileLoader in create-cli [sc-24412]

### DIFF
--- a/packages/cli/src/loader/jiti.ts
+++ b/packages/cli/src/loader/jiti.ts
@@ -13,10 +13,10 @@ interface Jiti {
 }
 
 export class UninitializedJitiFileLoaderState extends FileLoader {
-  init?: Promise<void>
+  private static init?: Promise<void>
 
   async loadFile<T = unknown> (filePath: string): Promise<T> {
-    this.init ??= (async () => {
+    UninitializedJitiFileLoaderState.init ??= (async () => {
       try {
         const jitiExports: JitiExports = await import('jiti')
         const jiti = jitiExports.createJiti(__filename)
@@ -26,7 +26,7 @@ export class UninitializedJitiFileLoaderState extends FileLoader {
       }
     })()
 
-    await this.init
+    await UninitializedJitiFileLoaderState.init
 
     return await JitiFileLoader.state.loadFile(filePath)
   }

--- a/packages/cli/src/loader/ts-node.ts
+++ b/packages/cli/src/loader/ts-node.ts
@@ -10,10 +10,10 @@ interface TSNodeService {
 }
 
 export class UninitializedTSNodeFileLoaderState extends FileLoader {
-  init?: Promise<void>
+  private static init?: Promise<void>
 
   async loadFile<T = unknown> (filePath: string): Promise<T> {
-    this.init ??= (async () => {
+    UninitializedTSNodeFileLoaderState.init ??= (async () => {
       try {
         const tsNodeExports: TSNodeExports = await import('ts-node')
         const service = tsNodeExports.register({
@@ -30,7 +30,7 @@ export class UninitializedTSNodeFileLoaderState extends FileLoader {
       }
     })()
 
-    await this.init
+    await UninitializedTSNodeFileLoaderState.init
 
     return await TSNodeFileLoader.state.loadFile(filePath)
   }

--- a/packages/create-cli/src/loader/index.ts
+++ b/packages/create-cli/src/loader/index.ts
@@ -1,0 +1,13 @@
+export { JitiFileLoader, JitiFileLoaderOptions } from './jiti'
+export {
+  FileLoader,
+  FileLoaderOptions,
+  UnsupportedFileLoaderError,
+} from './loader'
+export { FileMatch, FileMatchFunction } from './match'
+export { MixedFileLoader } from './mixed'
+export {
+  NativeFileLoader,
+  NativeFileLoaderOptions,
+} from './native'
+export { TSNodeFileLoader, TSNodeFileLoaderOptions } from './ts-node'

--- a/packages/create-cli/src/loader/jiti.ts
+++ b/packages/create-cli/src/loader/jiti.ts
@@ -13,10 +13,10 @@ interface Jiti {
 }
 
 export class UninitializedJitiFileLoaderState extends FileLoader {
-  init?: Promise<void>
+  private static init?: Promise<void>
 
   async loadFile<T = unknown> (filePath: string): Promise<T> {
-    this.init ??= (async () => {
+    UninitializedJitiFileLoaderState.init ??= (async () => {
       try {
         const jitiExports: JitiExports = await import('jiti')
         const jiti = jitiExports.createJiti(__filename)
@@ -26,7 +26,7 @@ export class UninitializedJitiFileLoaderState extends FileLoader {
       }
     })()
 
-    await this.init
+    await UninitializedJitiFileLoaderState.init
 
     return await JitiFileLoader.state.loadFile(filePath)
   }

--- a/packages/create-cli/src/loader/jiti.ts
+++ b/packages/create-cli/src/loader/jiti.ts
@@ -1,0 +1,80 @@
+import { FileLoader, FileLoaderOptions, UnsupportedFileLoaderError } from './loader'
+import { FileMatch } from './match';
+
+interface JitiExports {
+  createJiti (id: string, userOptions?: any): Jiti;
+}
+
+interface Jiti {
+  import<T = unknown> (
+    id: string,
+    opts?: { default?: true },
+  ): Promise<T>
+}
+
+export class UninitializedJitiFileLoaderState extends FileLoader {
+  init?: Promise<void>
+
+  async loadFile<T = unknown> (filePath: string): Promise<T> {
+    this.init ??= (async () => {
+      try {
+        const jitiExports: JitiExports = await import('jiti')
+        const jiti = jitiExports.createJiti(__filename)
+        JitiFileLoader.state = new InitializedJitiFileLoaderState(jiti)
+      } catch (err) {
+        JitiFileLoader.state = new FailedJitiFileLoaderState(err as Error)
+      }
+    })()
+
+    await this.init
+
+    return await JitiFileLoader.state.loadFile(filePath)
+  }
+}
+
+export class FailedJitiFileLoaderState extends FileLoader {
+  error: Error
+
+  constructor (error: Error) {
+    super()
+    this.error = error
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async loadFile<T = unknown> (filePath: string): Promise<T> {
+    throw new UnsupportedFileLoaderError('JitiFileLoader is not supported', {
+      cause: this.error,
+    })
+  }
+}
+
+export class InitializedJitiFileLoaderState extends FileLoader {
+  jiti: Jiti
+
+  constructor (jiti: Jiti) {
+    super()
+    this.jiti = jiti
+  }
+
+  async loadFile<T = unknown> (filePath: string): Promise<T> {
+    const moduleExports = await this.jiti.import<T>(filePath)
+    return moduleExports
+  }
+}
+
+export type JitiFileLoaderOptions = FileLoaderOptions
+
+export class JitiFileLoader extends FileLoader {
+  static state: FileLoader = new UninitializedJitiFileLoaderState()
+
+  constructor (options?: JitiFileLoaderOptions) {
+    super({
+      match: FileMatch.standardFiles().complement(),
+      ...options,
+    })
+  }
+
+  async loadFile<T = unknown> (filePath: string): Promise<T> {
+    return JitiFileLoader.state.loadFile<T>(filePath)
+  }
+}

--- a/packages/create-cli/src/loader/loader.ts
+++ b/packages/create-cli/src/loader/loader.ts
@@ -1,0 +1,42 @@
+import { FileMatch } from './match'
+
+export interface FileLoaderOptions {
+  match?: FileMatch
+}
+
+export abstract class FileLoader {
+  protected fileMatcher: FileMatch
+
+  constructor (options?: FileLoaderOptions) {
+    this.fileMatcher = options?.match ?? FileMatch.any()
+  }
+
+  /**
+   * Checks whether the FileLoader can be used for a file path.
+   *
+   * @param filePath The file path to evaluate.
+   * @returns Whether the FileLoader is authoritative for the file path.
+   */
+  isAuthoritativeFor (filePath: string): boolean {
+    return this.fileMatcher.match(filePath)
+  }
+
+  /**
+   * Loads a file.
+   *
+   * @param filePath The path to load the file from.
+   * @returns The unmodified exports of the file.
+   */
+  abstract loadFile<T = unknown> (filePath: string): Promise<T>
+}
+
+/**
+ * Error thrown when a FileLoader is authoritative for a file path but
+ * fails to load it.
+ */
+export class UnsupportedFileLoaderError extends Error {
+  constructor (message = 'File cannot be loaded by this loader', options?: ErrorOptions) {
+    super(message, options)
+    this.name = 'UnsupportedFileLoaderError'
+  }
+}

--- a/packages/create-cli/src/loader/match.ts
+++ b/packages/create-cli/src/loader/match.ts
@@ -1,0 +1,56 @@
+import { extname } from 'node:path'
+
+export type FileMatchFunction = (filePath: string) => boolean
+
+export class FileMatch {
+  match: FileMatchFunction
+
+  protected constructor (match: FileMatchFunction) {
+    this.match = match
+  }
+
+  complement (): FileMatch {
+    return new FileMatch(filePath => !this.match(filePath))
+  }
+
+  union (matcher: FileMatch): FileMatch {
+    return new FileMatch(filePath => {
+      return this.match(filePath) || matcher.match(filePath)
+    })
+  }
+
+  intersection (matcher: FileMatch): FileMatch {
+    return new FileMatch(filePath => {
+      return this.match(filePath) && matcher.match(filePath)
+    })
+  }
+
+  difference (matcher: FileMatch): FileMatch {
+    return this.intersection(matcher.complement())
+  }
+
+  static none (): FileMatch {
+    return new FileMatch(() => false)
+  }
+
+  static any (): FileMatch {
+    return new FileMatch(() => true)
+  }
+
+  static pattern (pattern: RegExp): FileMatch {
+    return new FileMatch(filePath => pattern.test(filePath))
+  }
+
+  static extension (...extensions: string[]): FileMatch {
+    const set = new Set(extensions)
+    return new FileMatch(filePath => set.has(extname(filePath)))
+  }
+
+  static custom (match: FileMatchFunction): FileMatch {
+    return new FileMatch(match)
+  }
+
+  static standardFiles (): FileMatch {
+    return FileMatch.extension('.js', '.mjs', '.cjs', '.json')
+  }
+}

--- a/packages/create-cli/src/loader/mixed.ts
+++ b/packages/create-cli/src/loader/mixed.ts
@@ -1,0 +1,46 @@
+import {
+  FileLoader,
+  UnsupportedFileLoaderError,
+} from './loader'
+
+export class MixedFileLoader extends FileLoader {
+  loaders: Set<FileLoader>
+
+  constructor (...loaders: FileLoader[]) {
+    super()
+    this.loaders = new Set(loaders)
+  }
+
+  isAuthoritativeFor (filePath: string): boolean {
+    for (const loader of this.loaders) {
+      if (loader.isAuthoritativeFor(filePath)) {
+        return true
+      }
+    }
+
+    return false
+  }
+
+  async loadFile<T = unknown> (filePath: string): Promise<T> {
+    for (const loader of this.loaders) {
+      if (loader.isAuthoritativeFor(filePath)) {
+        try {
+          return await loader.loadFile<T>(filePath)
+        } catch (err) {
+          if (err instanceof UnsupportedFileLoaderError) {
+            // We'll always get the same error. Just remove the loader to
+            // avoid calling it again.
+            this.loaders.delete(loader)
+            continue
+          }
+
+          throw err
+        }
+      }
+    }
+
+    throw new UnsupportedFileLoaderError(
+      `Unable to find authoritative loader for file '${filePath}'`,
+    )
+  }
+}

--- a/packages/create-cli/src/loader/native.ts
+++ b/packages/create-cli/src/loader/native.ts
@@ -1,0 +1,18 @@
+import { FileLoader, FileLoaderOptions } from './loader'
+import { FileMatch } from './match'
+
+export type NativeFileLoaderOptions = FileLoaderOptions
+
+export class NativeFileLoader extends FileLoader {
+  constructor (options?: NativeFileLoaderOptions) {
+    super({
+      match: FileMatch.standardFiles(),
+      ...options,
+    })
+  }
+
+  async loadFile<T = unknown> (filePath: string): Promise<T> {
+    const moduleExports = await import(filePath)
+    return moduleExports
+  }
+}

--- a/packages/create-cli/src/loader/ts-node.ts
+++ b/packages/create-cli/src/loader/ts-node.ts
@@ -10,10 +10,10 @@ interface TSNodeService {
 }
 
 export class UninitializedTSNodeFileLoaderState extends FileLoader {
-  init?: Promise<void>
+  private static init?: Promise<void>
 
   async loadFile<T = unknown> (filePath: string): Promise<T> {
-    this.init ??= (async () => {
+    UninitializedTSNodeFileLoaderState.init ??= (async () => {
       try {
         const tsNodeExports: TSNodeExports = await import('ts-node')
         const service = tsNodeExports.register({
@@ -30,7 +30,7 @@ export class UninitializedTSNodeFileLoaderState extends FileLoader {
       }
     })()
 
-    await this.init
+    await UninitializedTSNodeFileLoaderState.init
 
     return await TSNodeFileLoader.state.loadFile(filePath)
   }

--- a/packages/create-cli/src/loader/ts-node.ts
+++ b/packages/create-cli/src/loader/ts-node.ts
@@ -1,0 +1,99 @@
+import { FileLoader, FileLoaderOptions, UnsupportedFileLoaderError } from './loader'
+import { FileMatch } from './match'
+
+interface TSNodeExports {
+  register (opts?: any): TSNodeService
+}
+
+interface TSNodeService {
+  enabled (enabled?: boolean): boolean
+}
+
+export class UninitializedTSNodeFileLoaderState extends FileLoader {
+  init?: Promise<void>
+
+  async loadFile<T = unknown> (filePath: string): Promise<T> {
+    this.init ??= (async () => {
+      try {
+        const tsNodeExports: TSNodeExports = await import('ts-node')
+        const service = tsNodeExports.register({
+          moduleTypes: {
+            '**/*': 'cjs',
+          },
+          compilerOptions: {
+            module: 'CommonJS',
+          },
+        })
+        TSNodeFileLoader.state = new InitializedTSNodeFileLoaderState(service)
+      } catch (err) {
+        TSNodeFileLoader.state = new FailedTSNodeFileLoaderState(err as Error)
+      }
+    })()
+
+    await this.init
+
+    return await TSNodeFileLoader.state.loadFile(filePath)
+  }
+}
+
+export class FailedTSNodeFileLoaderState extends FileLoader {
+  error: Error
+
+  constructor (error: Error) {
+    super()
+    this.error = error
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async loadFile<T = unknown> (filePath: string): Promise<T> {
+    throw new UnsupportedFileLoaderError('TSNodeFileLoader is not supported', {
+      cause: this.error,
+    })
+  }
+}
+
+export class InitializedTSNodeFileLoaderState extends FileLoader {
+  service: TSNodeService
+
+  constructor (service: TSNodeService) {
+    super()
+    this.service = service
+  }
+
+  async loadFile<T = unknown> (filePath: string): Promise<T> {
+    try {
+      this.service.enabled(true)
+
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const moduleExports = require(filePath)
+      return moduleExports
+    } catch (err: any) {
+      if (err.message?.includes('Unable to compile TypeScript')) {
+        throw new Error(`Unable to load file '${filePath}' with 'ts-node' (hint: consider installing 'jiti' for improved TypeScript support)\n${err.stack}`, {
+          cause: err as Error,
+        })
+      }
+
+      throw err
+    } finally {
+      this.service.enabled(false)
+    }
+  }
+}
+
+export type TSNodeFileLoaderOptions = FileLoaderOptions
+
+export class TSNodeFileLoader extends FileLoader {
+  static state: FileLoader = new UninitializedTSNodeFileLoaderState()
+
+  constructor (options?: TSNodeFileLoaderOptions) {
+    super({
+      match: FileMatch.standardFiles().complement(),
+      ...options,
+    })
+  }
+
+  async loadFile<T = unknown> (filePath: string): Promise<T> {
+    return TSNodeFileLoader.state.loadFile<T>(filePath)
+  }
+}

--- a/packages/create-cli/src/utils/fileloader.ts
+++ b/packages/create-cli/src/utils/fileloader.ts
@@ -1,101 +1,26 @@
-/* eslint-disable @typescript-eslint/no-require-imports */
-import { Service } from 'ts-node'
+import { MixedFileLoader, NativeFileLoader, JitiFileLoader, TSNodeFileLoader } from '../loader'
 
-export async function loadFile (filepath: string): Promise<any> {
+const loader = new MixedFileLoader(
+  new NativeFileLoader(),
+  new JitiFileLoader(),
+  new TSNodeFileLoader(),
+)
+
+export async function loadFile (filePath: string): Promise<any> {
+  if (!loader.isAuthoritativeFor(filePath)) {
+    throw new Error(`Unable to find a compatible loader for file '${filePath}'`)
+  }
+
   try {
-    let exported: any
-    if (/\.[mc]?ts$/.test(filepath)) {
-      exported = await loadTsFileDefault(filepath)
-    } else {
-      const imported = await import(filepath)
-      exported = imported.default ?? {}
+    const moduleExports = await loader.loadFile<Record<string, any>>(filePath)
+
+    const defaultExport = moduleExports?.default ?? moduleExports
+    if (typeof defaultExport === 'function') {
+      return await defaultExport()
     }
-    if (typeof exported === 'function') {
-      exported = await exported()
-    }
-    return exported
+
+    return defaultExport
   } catch (err: any) {
-    throw new Error(`Error loading file ${filepath}\n${err.stack}`)
+    throw new Error(`Error loading file '${filePath}'\n${err.stack}`)
   }
-}
-
-async function loadTsFileDefault (filepath: string): Promise<any> {
-  const jiti = await getJiti()
-  if (jiti) {
-    return jiti.import<any>(filepath, {
-      default: true,
-    })
-  }
-
-  // Backward-compatibility for users who installed ts-node.
-  const tsCompiler = await getTsNodeService()
-  if (tsCompiler) {
-    tsCompiler.enabled(true)
-    let exported: any
-    try {
-      exported = (await require(filepath)).default
-    } catch (err: any) {
-      if (err.message && err.message.includes('Unable to compile TypeScript')) {
-        throw new Error(`Consider installing "jiti" instead of "ts-node" for improved TypeScript support\n${err.stack}`)
-      }
-      throw err
-    } finally {
-      tsCompiler.enabled(false) // Re-disable the TS compiler
-    }
-    return exported
-  }
-
-  throw new Error('Please install "jiti" to use TypeScript files')
-}
-
-// Regular type import gave issue with jest.
-type Jiti = ReturnType<(typeof import('jiti', {
-  with: {
-    'resolution-mode': 'import'
-  }
-}))['createJiti']>
-
-// To avoid a dependency on typescript for users with no TS checks, we need to dynamically import jiti
-let jiti: Jiti
-let haveJiti = false
-async function getJiti (): Promise<Jiti | undefined> {
-  if (haveJiti) return jiti
-  try {
-    const maybeJiti = await import('jiti')
-    // Jiti 1x does not have createJiti().
-    if (typeof maybeJiti.createJiti !== 'function') {
-      return
-    }
-    jiti = maybeJiti.createJiti(__filename)
-    haveJiti = true
-  } catch (err: any) {
-    if (err.code === 'ERR_MODULE_NOT_FOUND' || err.code === 'MODULE_NOT_FOUND') {
-      return undefined
-    }
-    throw err
-  }
-  return jiti
-}
-
-// To avoid a dependency on typescript for users with no TS checks, we need to dynamically import ts-node
-let tsNodeService: Service
-async function getTsNodeService (): Promise<Service | undefined> {
-  if (tsNodeService) return tsNodeService
-  try {
-    const tsNode = await import('ts-node')
-    tsNodeService = tsNode.register({
-      moduleTypes: {
-        '**/*': 'cjs',
-      },
-      compilerOptions: {
-        module: 'CommonJS',
-      },
-    })
-  } catch (err: any) {
-    if (err.code === 'ERR_MODULE_NOT_FOUND' || err.code === 'MODULE_NOT_FOUND') {
-      return undefined
-    }
-    throw err
-  }
-  return tsNodeService
 }

--- a/packages/create-cli/tsconfig.json
+++ b/packages/create-cli/tsconfig.json
@@ -8,7 +8,7 @@
     "outDir": "dist",
     "rootDirs": ["src", "e2e"],
     "strict": true,
-    "target": "ES2021",
+    "target": "es2022",
     "sourceMap": true
   },
   "include": [


### PR DESCRIPTION
The old file loader has issues that the new loader resolves, plus we'd ideally use the same loader everywhere anyway.

We do not currently have a good way to share common code between the workspace packages. For now, just copy the files until we have time for a real solution.

It would have been too much trouble to bring over Bun and Deno detection, so they were left out for now.

## Affected Components
* [x] CLI
* [x] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
