### PR TITLE
feat: include jiti directly in create-cli because it's not a library [sc-24412]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8116,7 +8116,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
       "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -14798,6 +14797,7 @@
         "debug": "^4.4.0",
         "execa": "^5.1.0",
         "giget": "^1.2.5",
+        "jiti": "^2.4.2",
         "json5": "^2.2.3",
         "ora": "^5.4.1",
         "passwd-user": "^3.0.0",
@@ -14817,7 +14817,6 @@
         "@types/uuid": "^10.0.0",
         "config": "^3.3.12",
         "cross-env": "^7.0.3",
-        "jiti": "^2.4.2",
         "rimraf": "^5.0.10",
         "ts-node": "^10.9.2",
         "typescript": "^5.3.3",
@@ -14825,14 +14824,6 @@
       },
       "engines": {
         "node": "^18.19.0 || >=20.5.0"
-      },
-      "peerDependencies": {
-        "jiti": ">=2"
-      },
-      "peerDependenciesMeta": {
-        "jiti": {
-          "optional": true
-        }
       }
     },
     "packages/create-cli/node_modules/@types/node": {
@@ -20595,8 +20586,7 @@
     "jiti": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
-      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
-      "dev": true
+      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A=="
     },
     "js-sdsl": {
       "version": "4.3.0",

--- a/packages/create-cli/package.json
+++ b/packages/create-cli/package.json
@@ -62,6 +62,7 @@
     "debug": "^4.4.0",
     "execa": "^5.1.0",
     "giget": "^1.2.5",
+    "jiti": "^2.4.2",
     "json5": "^2.2.3",
     "ora": "^5.4.1",
     "passwd-user": "^3.0.0",
@@ -78,18 +79,9 @@
     "@types/uuid": "^10.0.0",
     "config": "^3.3.12",
     "cross-env": "^7.0.3",
-    "jiti": "^2.4.2",
     "rimraf": "^5.0.10",
     "ts-node": "^10.9.2",
     "typescript": "^5.3.3",
     "vitest": "3.1.2"
-  },
-  "peerDependencies": {
-    "jiti": ">=2"
-  },
-  "peerDependenciesMeta": {
-    "jiti": {
-      "optional": true
-    }
   }
 }


### PR DESCRIPTION
The only supported usage of the create-cli is via the `npm create` command. When used, the package gets installed to a global location and any dependencies it tries to load are resolved from that global location. Therefore even if the user adds jiti by themselves, it's not going to be effective because the create-cli will not see it.

It makes sense to just include jiti outright in create-cli because it's intended to be purely a CLI and not a library.

## Affected Components
* [ ] CLI
* [x] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
