### PR TITLE
feat: share dependency files between checks [sc-24296]

### DIFF
--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -310,6 +310,7 @@ export default class Test extends AuthCommand {
       config.getAccountId(),
       projectBundle,
       checkBundles,
+      Session.sharedFiles,
       location,
       timeout,
       verbose,

--- a/packages/cli/src/constructs/__tests__/api-check.spec.ts
+++ b/packages/cli/src/constructs/__tests__/api-check.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
 
 import { ApiCheck, CheckGroup, Request } from '../index'
 import { Project, Session } from '../project'
@@ -16,6 +16,14 @@ const request: Request = {
 }
 
 describe('ApiCheck', () => {
+  beforeEach(() => {
+    Session.resetSharedFiles()
+  })
+
+  afterAll(() => {
+    Session.resetSharedFiles()
+  })
+
   it('should correctly load file script dependencies', async () => {
     Session.basePath = __dirname
     Session.availableRuntimes = runtimes
@@ -27,16 +35,21 @@ describe('ApiCheck', () => {
       script: fs.readFileSync(getFilePath('entrypoint.js')).toString(),
       scriptPath: 'fixtures/api-check/entrypoint.js',
       dependencies: [
-        {
-          path: 'fixtures/api-check/dep1.js',
-          content: fs.readFileSync(getFilePath('dep1.js')).toString(),
-        },
-        {
-          path: 'fixtures/api-check/dep2.js',
-          content: fs.readFileSync(getFilePath('dep2.js')).toString(),
-        },
+        0,
+        1,
       ],
     })
+
+    expect(Session.sharedFiles).toEqual([
+      {
+        path: 'fixtures/api-check/dep1.js',
+        content: fs.readFileSync(getFilePath('dep1.js')).toString(),
+      },
+      {
+        path: 'fixtures/api-check/dep2.js',
+        content: fs.readFileSync(getFilePath('dep2.js')).toString(),
+      },
+    ])
   })
 
   it('should fail to bundle if runtime is not specified and default runtime is not set', async () => {

--- a/packages/cli/src/constructs/__tests__/browser-check.spec.ts
+++ b/packages/cli/src/constructs/__tests__/browser-check.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
 
 import { BrowserCheck, CheckGroup } from '../index'
 import { Project, Session } from '../project'
@@ -11,6 +11,14 @@ const runtimes = {
 }
 
 describe('BrowserCheck', () => {
+  beforeEach(() => {
+    Session.resetSharedFiles()
+  })
+
+  afterAll(() => {
+    Session.resetSharedFiles()
+  })
+
   it('should correctly load file dependencies', async () => {
     Session.basePath = __dirname
     Session.availableRuntimes = runtimes
@@ -22,16 +30,21 @@ describe('BrowserCheck', () => {
       script: fs.readFileSync(getFilePath('entrypoint.js')).toString(),
       scriptPath: 'fixtures/browser-check/entrypoint.js',
       dependencies: [
-        {
-          path: 'fixtures/browser-check/dep1.js',
-          content: fs.readFileSync(getFilePath('dep1.js')).toString(),
-        },
-        {
-          path: 'fixtures/browser-check/dep2.js',
-          content: fs.readFileSync(getFilePath('dep2.js')).toString(),
-        },
+        0,
+        1,
       ],
     })
+
+    expect(Session.sharedFiles).toEqual([
+      {
+        path: 'fixtures/browser-check/dep1.js',
+        content: fs.readFileSync(getFilePath('dep1.js')).toString(),
+      },
+      {
+        path: 'fixtures/browser-check/dep2.js',
+        content: fs.readFileSync(getFilePath('dep2.js')).toString(),
+      },
+    ])
   })
 
   it('should fail to bundle if runtime is not specified and default runtime is not set', async () => {

--- a/packages/cli/src/constructs/__tests__/multi-step-check.spec.ts
+++ b/packages/cli/src/constructs/__tests__/multi-step-check.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
 
 import { Project, Session } from '../project'
 import { MultiStepCheck } from '../multi-step-check'
@@ -9,6 +9,14 @@ const runtimesWithMultiStepSupport = {
 }
 
 describe('MultistepCheck', () => {
+  beforeEach(() => {
+    Session.resetSharedFiles()
+  })
+
+  afterAll(() => {
+    Session.resetSharedFiles()
+  })
+
   it('should report multistep as check type', async () => {
     Session.project = new Project('project-id', {
       name: 'Test Project',

--- a/packages/cli/src/constructs/api-check-bundle.ts
+++ b/packages/cli/src/constructs/api-check-bundle.ts
@@ -1,23 +1,24 @@
-import { ScriptDependency, ApiCheck } from './api-check'
+import { ApiCheck } from './api-check'
 import { Bundle } from './construct'
+import { SharedFileRef } from './project'
 
 export interface ApiCheckBundleProps {
   localSetupScript?: string
   setupScriptPath?: string
-  setupScriptDependencies?: ScriptDependency[]
+  setupScriptDependencies?: SharedFileRef[]
   localTearDownScript?: string
   tearDownScriptPath?: string
-  tearDownScriptDependencies?: ScriptDependency[]
+  tearDownScriptDependencies?: SharedFileRef[]
 }
 
 export class ApiCheckBundle implements Bundle {
   apiCheck: ApiCheck
   localSetupScript?: string
   setupScriptPath?: string
-  setupScriptDependencies?: ScriptDependency[]
+  setupScriptDependencies?: SharedFileRef[]
   localTearDownScript?: string
   tearDownScriptPath?: string
-  tearDownScriptDependencies?: ScriptDependency[]
+  tearDownScriptDependencies?: SharedFileRef[]
 
   constructor (apiCheck: ApiCheck, props: ApiCheckBundleProps) {
     this.apiCheck = apiCheck

--- a/packages/cli/src/constructs/api-check.ts
+++ b/packages/cli/src/constructs/api-check.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises'
 
 import { Check, CheckProps } from './check'
 import { HttpHeader } from './http-header'
-import { Session } from './project'
+import { Session, SharedFileRef } from './project'
 import { QueryParam } from './query-param'
 import { Content, Entrypoint, isContent, isEntrypoint } from './construct'
 import { Assertion as CoreAssertion, NumericAssertionBuilder, GeneralAssertionBuilder } from './internal/assertion'
@@ -87,11 +87,6 @@ export interface Request {
   headers?: Array<HttpHeader>
   queryParameters?: Array<QueryParam>
   basicAuth?: BasicAuth
-}
-
-export interface ScriptDependency {
-  path: string
-  content: string
 }
 
 export interface ApiCheckProps extends CheckProps {
@@ -283,12 +278,12 @@ export class ApiCheck extends Check {
     const parsed = await parser.parse(entrypoint)
     // Maybe we can get the parsed deps with the content immediately
 
-    const deps: ScriptDependency[] = []
+    const deps: SharedFileRef[] = []
     for (const { filePath, content } of parsed.dependencies) {
-      deps.push({
+      deps.push(Session.registerSharedFile({
         path: Session.relativePosixPath(filePath),
         content,
-      })
+      }))
     }
     return {
       script: parsed.entrypoint.content,

--- a/packages/cli/src/constructs/browser-check-bundle.ts
+++ b/packages/cli/src/constructs/browser-check-bundle.ts
@@ -1,11 +1,12 @@
 import { Snapshot } from '../services/snapshot-service'
-import { BrowserCheck, CheckDependency } from './browser-check'
+import { BrowserCheck } from './browser-check'
 import { Bundle } from './construct'
+import { SharedFileRef } from './project'
 
 export interface BrowserCheckBundleProps {
   script: string
   scriptPath?: string
-  dependencies?: CheckDependency[]
+  dependencies?: SharedFileRef[]
   rawSnapshots?: { absolutePath: string, path: string }[]
 }
 
@@ -13,7 +14,7 @@ export class BrowserCheckBundle implements Bundle {
   browserCheck: BrowserCheck
   script: string
   scriptPath?: string
-  dependencies?: CheckDependency[]
+  dependencies?: SharedFileRef[]
   // For snapshots, we first store `rawSnapshots` with the path to the file.
   // The `snapshots` field is set later (with a `key`) after these are uploaded to storage.
   rawSnapshots?: { absolutePath: string, path: string }[]

--- a/packages/cli/src/constructs/browser-check.ts
+++ b/packages/cli/src/constructs/browser-check.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 
 import { Check, CheckProps } from './check'
-import { Session } from './project'
+import { Session, SharedFileRef } from './project'
 import { CheckConfigDefaults } from '../services/checkly-config-loader'
 import { pathToPosix } from '../services/util'
 import { Content, Entrypoint, isContent, isEntrypoint } from './construct'
@@ -11,11 +11,6 @@ import { PlaywrightConfig } from './playwright-config'
 import { Diagnostics } from './diagnostics'
 import { InvalidPropertyValueDiagnostic } from './construct-diagnostics'
 import { BrowserCheckBundle } from './browser-check-bundle'
-
-export interface CheckDependency {
-  path: string
-  content: string
-}
 
 export interface BrowserCheckProps extends CheckProps {
   /**
@@ -129,12 +124,12 @@ export class BrowserCheck extends Check {
     const parsed = await parser.parse(entry)
     // Maybe we can get the parsed deps with the content immediately
 
-    const deps: CheckDependency[] = []
+    const deps: SharedFileRef[] = []
     for (const { filePath, content } of parsed.dependencies) {
-      deps.push({
+      deps.push(Session.registerSharedFile({
         path: pathToPosix(path.relative(Session.basePath!, filePath)),
         content,
-      })
+      }))
     }
     return {
       script: parsed.entrypoint.content,

--- a/packages/cli/src/constructs/multi-step-check-bundle.ts
+++ b/packages/cli/src/constructs/multi-step-check-bundle.ts
@@ -1,18 +1,18 @@
-import { CheckDependency } from './browser-check'
 import { Bundle } from './construct'
 import { MultiStepCheck } from './multi-step-check'
+import { SharedFileRef } from './project'
 
 export interface MultiStepCheckBundleProps {
   script: string
   scriptPath?: string
-  dependencies?: CheckDependency[]
+  dependencies?: SharedFileRef[]
 }
 
 export class MultiStepCheckBundle implements Bundle {
   multiStepCheck: MultiStepCheck
   script: string
   scriptPath?: string
-  dependencies?: CheckDependency[]
+  dependencies?: SharedFileRef[]
 
   constructor (multiStepCheck: MultiStepCheck, props: MultiStepCheckBundleProps) {
     this.multiStepCheck = multiStepCheck

--- a/packages/cli/src/constructs/multi-step-check.ts
+++ b/packages/cli/src/constructs/multi-step-check.ts
@@ -1,11 +1,10 @@
 import fs from 'node:fs/promises'
 
 import { Check, CheckProps } from './check'
-import { Session } from './project'
+import { Session, SharedFileRef } from './project'
 import { CheckConfigDefaults } from '../services/checkly-config-loader'
 import { Content, Entrypoint, isContent, isEntrypoint } from './construct'
 import CheckTypes from '../constants'
-import { CheckDependency } from './browser-check'
 import { PlaywrightConfig } from './playwright-config'
 import { Diagnostics } from './diagnostics'
 import { InvalidPropertyValueDiagnostic, UnsupportedRuntimeFeatureDiagnostic } from './construct-diagnostics'
@@ -122,12 +121,12 @@ export class MultiStepCheck extends Check {
     const parsed = await parser.parse(entry)
     // Maybe we can get the parsed deps with the content immediately
 
-    const deps: CheckDependency[] = []
+    const deps: SharedFileRef[] = []
     for (const { filePath, content } of parsed.dependencies) {
-      deps.push({
+      deps.push(Session.registerSharedFile({
         path: Session.relativePosixPath(filePath),
         content,
-      })
+      }))
     }
     return {
       script: parsed.entrypoint.content,

--- a/packages/cli/src/constructs/project.ts
+++ b/packages/cli/src/constructs/project.ts
@@ -177,6 +177,7 @@ export class Project extends Construct {
     }
     return {
       project,
+      sharedFiles: Session.sharedFiles,
     }
   }
 
@@ -205,6 +206,13 @@ export interface ConstructExport {
 }
 
 export type CheckFilter = (check: Check) => boolean
+
+export interface SharedFile {
+  path: string
+  content: string
+}
+
+export type SharedFileRef = number
 
 export class Session {
   static loader: FileLoader = new MixedFileLoader(
@@ -331,5 +339,23 @@ export class Session {
 
   static relativePosixPath (filePath: string): string {
     return pathToPosix(path.relative(Session.basePath!, filePath))
+  }
+
+  static sharedFileRefs = new Map<string, SharedFileRef>()
+  static sharedFiles: SharedFile[] = []
+
+  static registerSharedFile (file: SharedFile): SharedFileRef {
+    const ref = Session.sharedFileRefs.get(file.path)
+    if (ref !== undefined) {
+      return ref
+    }
+    const newRef = Session.sharedFiles.push(file) - 1
+    Session.sharedFileRefs.set(file.path, newRef)
+    return newRef
+  }
+
+  static resetSharedFiles (): void {
+    Session.sharedFileRefs.clear()
+    Session.sharedFiles.splice(0)
   }
 }

--- a/packages/cli/src/rest/projects.ts
+++ b/packages/cli/src/rest/projects.ts
@@ -1,6 +1,7 @@
 import { isAxiosError, type AxiosInstance } from 'axios'
 import type { GitInformation } from '../services/util'
 import { compressJSONPayload } from './util'
+import { SharedFile } from '../constructs'
 
 export interface Project {
   name: string
@@ -63,6 +64,7 @@ export interface AuxiliaryResourceSync {
 
 export interface ProjectSync {
   project: Project,
+  sharedFiles?: SharedFile[]
   resources: Array<ResourceSync>,
   repoInfo: GitInformation|null,
 }

--- a/packages/cli/src/rest/test-sessions.ts
+++ b/packages/cli/src/rest/test-sessions.ts
@@ -1,12 +1,13 @@
 import type { AxiosInstance } from 'axios'
 import { GitInformation } from '../services/util'
-import { RetryStrategy } from '../constructs'
+import { RetryStrategy, SharedFile } from '../constructs'
 import { compressJSONPayload } from './util'
 
 type RunTestSessionRequest = {
   name: string,
   checkRunJobs: any[],
   project: { logicalId: string },
+  sharedFiles?: SharedFile[]
   runLocation: string|{ type: 'PUBLIC', region: string }|{ type: 'PRIVATE', slugName: string, id: string },
   repoInfo?: GitInformation | null,
   environment?: string | null,

--- a/packages/cli/src/services/test-runner.ts
+++ b/packages/cli/src/services/test-runner.ts
@@ -4,7 +4,7 @@ import { testSessions } from '../rest/api'
 import AbstractCheckRunner, { RunLocation, SequenceId } from './abstract-check-runner'
 import { GitInformation } from './util'
 import { Check } from '../constructs/check'
-import { RetryStrategy } from '../constructs'
+import { RetryStrategy, SharedFile } from '../constructs'
 import { ProjectBundle, ResourceDataBundle } from '../constructs/project-bundle'
 import { pullSnapshots } from '../services/snapshot-service'
 import { PlaywrightCheckBundle } from '../constructs/playwright-check-bundle'
@@ -13,6 +13,7 @@ import { PlaywrightCheckBundle } from '../constructs/playwright-check-bundle'
 export default class TestRunner extends AbstractCheckRunner {
   projectBundle: ProjectBundle
   checkBundles: ResourceDataBundle<Check>[]
+  sharedFiles: SharedFile[]
   location: RunLocation
   shouldRecord: boolean
   repoInfo: GitInformation | null
@@ -25,6 +26,7 @@ export default class TestRunner extends AbstractCheckRunner {
     accountId: string,
     projectBundle: ProjectBundle,
     checkBundles: ResourceDataBundle<Check>[],
+    sharedFiles: SharedFile[],
     location: RunLocation,
     timeout: number,
     verbose: boolean,
@@ -38,6 +40,7 @@ export default class TestRunner extends AbstractCheckRunner {
     super(accountId, timeout, verbose)
     this.projectBundle = projectBundle
     this.checkBundles = checkBundles
+    this.sharedFiles = sharedFiles
     this.location = location
     this.shouldRecord = shouldRecord
     this.repoInfo = repoInfo
@@ -81,6 +84,7 @@ export default class TestRunner extends AbstractCheckRunner {
         name: this.projectBundle.project.name,
         checkRunJobs,
         project: { logicalId: this.projectBundle.project.logicalId },
+        sharedFiles: this.sharedFiles,
         runLocation: this.location,
         repoInfo: this.repoInfo,
         environment: this.environment,


### PR DESCRIPTION
When bundling a project, all check dependencies are now collected into a shared list of files, which is transmitted along with the project. Checks refer to files in the shared list only by their index number. The more shared files you have the larger the benefit.

## Affected Components
* [x] CLI
* [ ] Create CLI
* [x] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
