### PR TITLE
feat: make --fail-on-no-matching true by default for the trigger command [sc-24516]

### DIFF
--- a/packages/cli/e2e/__tests__/trigger.spec.ts
+++ b/packages/cli/e2e/__tests__/trigger.spec.ts
@@ -53,7 +53,7 @@ describe('trigger', () => {
     expect(result.status).toBe(0)
   })
 
-  test('Should return code 0 when no checks match', async () => {
+  test('Should return code 1 when no checks match', async () => {
     const result = await runChecklyCli({
       args: [
         'trigger',
@@ -65,7 +65,7 @@ describe('trigger', () => {
     })
 
     expect(result.stdout).toContain('No matching checks were found.')
-    expect(result.status).toBe(0)
+    expect(result.status).toBe(1)
   })
 
   test('Should return code 1 when no checks match and the fail-on-no-match flag is set', async () => {
@@ -82,5 +82,21 @@ describe('trigger', () => {
 
     expect(result.stdout).toContain('No matching checks were found.')
     expect(result.status).toBe(1)
+  })
+
+  test('Should return code - when no checks match and the no-fail-on-no-match flag is set', async () => {
+    const result = await runChecklyCli({
+      args: [
+        'trigger',
+        '--tags',
+        'no-checks-match-this-tag',
+        '--no-fail-on-no-matching',
+      ],
+      apiKey: config.get('apiKey'),
+      accountId: config.get('accountId'),
+    })
+
+    expect(result.stdout).toContain('No matching checks were found.')
+    expect(result.status).toBe(0)
   })
 })

--- a/packages/cli/e2e/__tests__/trigger.spec.ts
+++ b/packages/cli/e2e/__tests__/trigger.spec.ts
@@ -68,7 +68,7 @@ describe('trigger', () => {
     expect(result.status).toBe(1)
   })
 
-  test('Should return code 1 when no checks match and the fail-on-no-match flag is set', async () => {
+  test('Should return code 1 when no checks match and the fail-on-no-matching flag is set', async () => {
     const result = await runChecklyCli({
       args: [
         'trigger',
@@ -84,7 +84,7 @@ describe('trigger', () => {
     expect(result.status).toBe(1)
   })
 
-  test('Should return code - when no checks match and the no-fail-on-no-match flag is set', async () => {
+  test('Should return code 0 when no checks match and the no-fail-on-no-matching flag is set', async () => {
     const result = await runChecklyCli({
       args: [
         'trigger',

--- a/packages/cli/src/commands/trigger.ts
+++ b/packages/cli/src/commands/trigger.ts
@@ -59,7 +59,7 @@ export default class Trigger extends AuthCommand {
       allowNo: true,
     }),
     'fail-on-no-matching': Flags.boolean({
-      description: 'Exit with a failing status code when there are no matching tests.',
+      description: 'Exit with a failing status code when there are no matching tests. Enabled by default.',
       default: true,
       allowNo: true,
     }),
@@ -101,7 +101,7 @@ export default class Trigger extends AuthCommand {
       tags: targetTags,
       timeout,
       verbose: verboseFlag,
-      'fail-on-no-matching': failOnNoMatchingFlag,
+      'fail-on-no-matching': failOnNoMatching,
       record: shouldRecord,
       reporter: reporterFlag,
       env,
@@ -122,7 +122,6 @@ export default class Trigger extends AuthCommand {
       privateRunLocation,
     })
     const verbose = this.prepareVerboseFlag(verboseFlag, checklyConfig?.cli?.verbose)
-    const failOnNoMatching = this.prepareFailOnNoMatching(failOnNoMatchingFlag, checklyConfig?.cli?.failOnNoMatching)
     const reporterTypes = this.prepareReportersTypes(reporterFlag as ReporterType, checklyConfig?.cli?.reporters)
     const reporters = createReporters(reporterTypes, location, verbose)
     const testRetryStrategy = this.prepareTestRetryStrategy(retries, checklyConfig?.cli?.retries)
@@ -229,10 +228,6 @@ export default class Trigger extends AuthCommand {
 
   prepareVerboseFlag (verboseFlag?: boolean, cliVerboseFlag?: boolean) {
     return verboseFlag ?? cliVerboseFlag ?? false
-  }
-
-  prepareFailOnNoMatching (failOnNoMatchingFlag?: boolean, cliFailOnNoMatchingFlag?: boolean) {
-    return failOnNoMatchingFlag ?? cliFailOnNoMatchingFlag ?? false
   }
 
   prepareReportersTypes (reporterFlag: ReporterType, cliReporters: ReporterType[] = []): ReporterType[] {

--- a/packages/cli/src/commands/trigger.ts
+++ b/packages/cli/src/commands/trigger.ts
@@ -60,6 +60,8 @@ export default class Trigger extends AuthCommand {
     }),
     'fail-on-no-matching': Flags.boolean({
       description: 'Exit with a failing status code when there are no matching tests.',
+      default: true,
+      allowNo: true,
     }),
     reporter: Flags.string({
       char: 'r',

--- a/packages/cli/src/services/checkly-config-codegen.ts
+++ b/packages/cli/src/services/checkly-config-codegen.ts
@@ -209,10 +209,6 @@ more information.`))
                 builder.boolean('verbose', cli.verbose)
               }
 
-              if (cli.failOnNoMatching !== undefined) {
-                builder.boolean('failOnNoMatching', cli.failOnNoMatching)
-              }
-
               if (cli.reporters !== undefined) {
                 const reporters = cli.reporters
                 builder.array('reporters', builder => {

--- a/packages/cli/src/services/checkly-config-loader.ts
+++ b/packages/cli/src/services/checkly-config-loader.ts
@@ -87,7 +87,6 @@ export type ChecklyConfig = {
     runLocation?: keyof Region,
     privateRunLocation?: string,
     verbose?: boolean,
-    failOnNoMatching?: boolean,
     reporters?: ReporterType[],
     retries?: number,
     loader?: FileLoader,


### PR DESCRIPTION
Until `--fail-on-no-matching` was added some time ago, the `trigger` command would return a 0 exit code if no checks matched, which was likely a mistake in the original implementation. The `--fail-on-no-matching`  flag made it possible to enable more sensible behavior without breaking backwards compatibility. With the v6 major release we are now making it the default.

The `failOnNoMatching` option in Checkly config has been removed because realistically the only reason why you'd want to set the flag is to enable it. Since it's now enabled by default, and the option only applied to the trigger command anyway, there is no reason to keep the option anymore.

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
