### PR TITLE
fix: include .npmrc by default

### DIFF
--- a/packages/cli/src/services/util.ts
+++ b/packages/cli/src/services/util.ts
@@ -258,6 +258,7 @@ export async function loadPlaywrightProjectFiles (
   archive.glob('**/package*.json', { cwd: path.join(dir, '/'), ignore: ignoredFiles })
   archive.glob('**/pnpm*.yaml', { cwd: path.join(dir, '/'), ignore: ignoredFiles })
   archive.glob('**/yarn.lock', { cwd: path.join(dir, '/'), ignore: ignoredFiles })
+  archive.glob('**/.npmrc', { cwd: path.join(dir, '/'), ignore: ignoredFiles })
   for (const includePattern of include) {
     archive.glob(includePattern, { cwd: path.join(dir, '/'), ignore: ignoredFiles })
   }


### PR DESCRIPTION
## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->
Include `.npmrc` when bundling the playwright project