### PR TITLE
fix: allow all files with the include option [sc-0]

### DIFF
--- a/packages/cli/src/services/util.ts
+++ b/packages/cli/src/services/util.ts
@@ -259,7 +259,7 @@ export async function loadPlaywrightProjectFiles (
   archive.glob('**/pnpm*.yaml', { cwd: path.join(dir, '/'), ignore: ignoredFiles })
   archive.glob('**/yarn.lock', { cwd: path.join(dir, '/'), ignore: ignoredFiles })
   for (const includePattern of include) {
-    archive.glob(includePattern, { cwd: path.join(dir, '/'), ignore: ignoredFiles })
+    archive.glob(includePattern, { cwd: path.join(dir, '/') })
   }
 }
 


### PR DESCRIPTION
## Affected Components
* [ ] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
If the user wants to have specific files, we should just allow what they want