### PR TITLE
feat: retry strategies can now be limited to network errors [sc-24520]

### DIFF
--- a/packages/cli/e2e/__tests__/deploy.spec.ts
+++ b/packages/cli/e2e/__tests__/deploy.spec.ts
@@ -242,6 +242,7 @@ Update and Unchanged:
     ApiCheck: api-check
     ApiCheck: api-check-high-freq
     ApiCheck: api-check-incident-trigger
+    ApiCheck: api-check-retry-only-on-network-error
     HeartbeatMonitor: heartbeat-monitor-1
     BrowserCheck: homepage-browser-check
     TcpMonitor: tcp-monitor
@@ -259,6 +260,7 @@ Update and Unchanged:
     ApiCheck: api-check
     ApiCheck: api-check-high-freq
     ApiCheck: api-check-incident-trigger
+    ApiCheck: api-check-retry-only-on-network-error
     HeartbeatMonitor: heartbeat-monitor-1
     BrowserCheck: homepage-browser-check
     BrowserCheck: snapshot-test.test.ts

--- a/packages/cli/e2e/__tests__/fixtures/deploy-project/api.check.ts
+++ b/packages/cli/e2e/__tests__/fixtures/deploy-project/api.check.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import { ApiCheck, Frequency } from 'checkly/constructs'
+import { ApiCheck, Frequency, RetryStrategyBuilder } from 'checkly/constructs'
 import { privateLocation } from './private-location.check'
 import { fooService } from './status-page.check'
 
@@ -57,4 +57,24 @@ new ApiCheck('api-check-incident-trigger', {
     description: 'We have detected a disruption in connectivity.',
     notifySubscribers: true,
   }
+})
+
+new ApiCheck('api-check-retry-only-on-network-error', {
+  name: 'Api Check Retry Only On Network Error',
+  activated: false,
+  frequency: Frequency.EVERY_30S,
+  request: {
+    url: 'https://www.google.com',
+    method: 'GET',
+    followRedirects: false,
+    skipSSL: false,
+    assertions: []
+  },
+  setupScript: { content: "console.log('hi from setup')" },
+  tearDownScript: { content: "console.log('hi from teardown')" },
+  degradedResponseTime: 20000,
+  maxResponseTime: 30000,
+  retryStrategy: RetryStrategyBuilder.fixedStrategy({
+    onlyOn: 'NETWORK_ERROR',
+  }),
 })

--- a/packages/cli/src/constructs/__tests__/api-check.spec.ts
+++ b/packages/cli/src/constructs/__tests__/api-check.spec.ts
@@ -190,4 +190,25 @@ describe('ApiCheck', () => {
     const bundle = await check.bundle()
     expect(bundle.synthesize()).toMatchObject({ groupId: { ref: 'main-group' } })
   })
+
+  describe('retryStrategy', () => {
+    it('should synthesize `onlyOn`', async () => {
+      Session.project = new Project('project-id', {
+        name: 'Test Project',
+        repoUrl: 'https://github.com/checkly/checkly-cli',
+      })
+      const apiCheck = new ApiCheck('test-check', {
+        name: 'Test Check',
+        runtimeId: '2022.02',
+        request,
+        retryStrategy: {
+          type: 'LINEAR',
+          onlyOn: 'NETWORK_ERROR',
+        },
+      })
+      const bundle = await apiCheck.bundle()
+      const payload = bundle.synthesize()
+      expect(payload.retryStrategy?.onlyOn).toEqual('NETWORK_ERROR')
+    })
+  })
 })

--- a/packages/cli/src/constructs/retry-strategy-codegen.ts
+++ b/packages/cli/src/constructs/retry-strategy-codegen.ts
@@ -25,6 +25,19 @@ export function valueForRetryStrategy (genfile: GeneratedFile, strategy?: RetryS
     if (options.sameRegion !== undefined) {
       builder.boolean('sameRegion', options.sameRegion)
     }
+
+    if (options.onlyOn !== undefined) {
+      const onlyOn = Array.isArray(options.onlyOn) ? options.onlyOn : [options.onlyOn]
+      if (onlyOn.length === 1) {
+        builder.string('onlyOn', onlyOn[0])
+      } else {
+        builder.array('onlyOn', builder => {
+          for (const condition of onlyOn) {
+            builder.string(condition)
+          }
+        })
+      }
+    }
   }
 
   if (strategy === null || strategy === undefined) {

--- a/packages/cli/src/constructs/retry-strategy.ts
+++ b/packages/cli/src/constructs/retry-strategy.ts
@@ -2,6 +2,11 @@
 export type RetryStrategyType = 'LINEAR' | 'EXPONENTIAL' | 'FIXED' | 'NO_RETRIES'
 
 /**
+ * Conditions can be used to limit when a retry strategy applies.
+ */
+export type RetryStrategyCondition = 'NETWORK_ERROR'
+
+/**
  * Configuration for check retry behavior.
  * Defines how and when to retry failed checks before marking them as permanently failed.
  */
@@ -55,13 +60,19 @@ export interface RetryStrategy {
    * @defaultValue true
    */
   sameRegion?: boolean,
+
+  /**
+   * Apply the retry strategy only if the cause of the failure matches the
+   * given condition. Otherwise, do not retry.
+   */
+  onlyOn?: RetryStrategyCondition,
 }
 
 /**
  * Options for configuring retry strategy behavior.
  * These options can be used with any retry strategy type.
  */
-export type RetryStrategyOptions = Pick<RetryStrategy, 'baseBackoffSeconds' | 'maxRetries' | 'maxDurationSeconds' | 'sameRegion'>
+export type RetryStrategyOptions = Omit<RetryStrategy, 'type'>
 
 /**
  * Builder class for creating retry strategies.
@@ -92,6 +103,14 @@ export type RetryStrategyOptions = Pick<RetryStrategy, 'baseBackoffSeconds' | 'm
  * 
  * // No retries - fail immediately
  * const noRetries = RetryStrategyBuilder.noRetries()
+ *
+ * // Retry on network errors only
+ * const retryOnNetworkError = RetryStrategyBuilder.fixedStrategy({
+ *   maxRetries: 1,
+ *   baseBackoffSeconds: 30,
+ *   sameRegion: false,
+ *   onlyOn: 'NETWORK_ERROR'
+ * })
  * ```
  * 
  * @see {@link https://www.checklyhq.com/docs/alerting-and-retries/retries/ | Retry Strategies Documentation}


### PR DESCRIPTION
This PR introduces support for limiting retry strategies to network errors.

To opt a retry strategy into this behavior, specify the `onlyOn` property as part of your RetryStrategy:

```typescriot
RetryStrategyBuilder.fixedStrategy({
  onlyOn: 'NETWORK_ERROR',
})
```

We do have the option to extend the `RetryStrategyCondition` type (the type of the value of `onlyOn`) later if more types or combinations become available.

## Affected Components
* [x] CLI
* [ ] Create CLI
* [x] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
