### PR TITLE
fix: default playwrightConfig was not being set for Browser/MultiStep checks [sc-24851]

### DIFF
--- a/packages/cli/src/constructs/__tests__/browser-check.spec.ts
+++ b/packages/cli/src/constructs/__tests__/browser-check.spec.ts
@@ -201,4 +201,91 @@ describe('BrowserCheck', () => {
     const bundle = await check.bundle()
     expect(bundle.synthesize()).toMatchObject({ groupId: { ref: 'main-group' } })
   })
+
+  describe('playwrightConfig', () => {
+    it('should set from check defaults', () => {
+      Session.project = new Project('project-id', {
+        name: 'Test Project',
+        repoUrl: 'https://github.com/checkly/checkly-cli',
+      })
+      const defaults = {
+        playwrightConfig: {
+          use: {
+            baseURL: 'https://example.org',
+          },
+        },
+      }
+      Session.checkDefaults = {
+        ...defaults,
+      }
+      Session.browserCheckDefaults = {}
+      const browserCheck = new BrowserCheck('test-check', {
+        name: 'Test Check',
+        code: { content: 'console.log("test check")' },
+      })
+      Session.checkDefaults = undefined
+      Session.browserCheckDefaults = undefined
+      expect(browserCheck).toMatchObject(defaults)
+    })
+
+    it('should set from browser check defaults', () => {
+      Session.project = new Project('project-id', {
+        name: 'Test Project',
+        repoUrl: 'https://github.com/checkly/checkly-cli',
+      })
+      const defaults = {
+        playwrightConfig: {
+          use: {
+            baseURL: 'https://example.org',
+          },
+        },
+      }
+      Session.checkDefaults = {}
+      Session.browserCheckDefaults = {
+        ...defaults,
+      }
+      const browserCheck = new BrowserCheck('test-check', {
+        name: 'Test Check',
+        code: { content: 'console.log("test check")' },
+      })
+      Session.checkDefaults = undefined
+      Session.browserCheckDefaults = undefined
+      expect(browserCheck).toMatchObject(defaults)
+    })
+
+    it('should not override with default if set', () => {
+      Session.project = new Project('project-id', {
+        name: 'Test Project',
+        repoUrl: 'https://github.com/checkly/checkly-cli',
+      })
+      const defaults = {
+        playwrightConfig: {
+          use: {
+            baseURL: 'https://example.org/foo',
+          },
+        },
+      }
+      Session.checkDefaults = {
+        ...defaults,
+      }
+      Session.browserCheckDefaults = {
+        ...defaults,
+      }
+      const custom = {
+        playwrightConfig: {
+          use: {
+            baseURL: 'https://example.org/bar',
+          }
+        }
+      }
+      const browserCheck = new BrowserCheck('test-check', {
+        name: 'Test Check',
+        code: { content: 'console.log("test check")' },
+        ...custom,
+      })
+      Session.checkDefaults = undefined
+      Session.browserCheckDefaults = undefined
+      expect(browserCheck).toMatchObject(custom)
+    })
+  })
 })

--- a/packages/cli/src/constructs/__tests__/multi-step-check.spec.ts
+++ b/packages/cli/src/constructs/__tests__/multi-step-check.spec.ts
@@ -140,4 +140,91 @@ describe('MultistepCheck', () => {
       Session.defaultRuntimeId = undefined
     }
   })
+
+  describe('playwrightConfig', () => {
+    it('should set from check defaults', () => {
+      Session.project = new Project('project-id', {
+        name: 'Test Project',
+        repoUrl: 'https://github.com/checkly/checkly-cli',
+      })
+      const defaults = {
+        playwrightConfig: {
+          use: {
+            baseURL: 'https://example.org',
+          },
+        },
+      }
+      Session.checkDefaults = {
+        ...defaults,
+      }
+      Session.browserCheckDefaults = {}
+      const browserCheck = new MultiStepCheck('test-check', {
+        name: 'Test Check',
+        code: { content: 'console.log("test check")' },
+      })
+      Session.checkDefaults = undefined
+      Session.browserCheckDefaults = undefined
+      expect(browserCheck).toMatchObject(defaults)
+    })
+
+    it('should set from multi step check defaults', () => {
+      Session.project = new Project('project-id', {
+        name: 'Test Project',
+        repoUrl: 'https://github.com/checkly/checkly-cli',
+      })
+      const defaults = {
+        playwrightConfig: {
+          use: {
+            baseURL: 'https://example.org',
+          },
+        },
+      }
+      Session.checkDefaults = {}
+      Session.multiStepCheckDefaults = {
+        ...defaults,
+      }
+      const browserCheck = new MultiStepCheck('test-check', {
+        name: 'Test Check',
+        code: { content: 'console.log("test check")' },
+      })
+      Session.checkDefaults = undefined
+      Session.multiStepCheckDefaults = undefined
+      expect(browserCheck).toMatchObject(defaults)
+    })
+
+    it('should not override with default if set', () => {
+      Session.project = new Project('project-id', {
+        name: 'Test Project',
+        repoUrl: 'https://github.com/checkly/checkly-cli',
+      })
+      const defaults = {
+        playwrightConfig: {
+          use: {
+            baseURL: 'https://example.org/foo',
+          },
+        },
+      }
+      Session.checkDefaults = {
+        ...defaults,
+      }
+      Session.browserCheckDefaults = {
+        ...defaults,
+      }
+      const custom = {
+        playwrightConfig: {
+          use: {
+            baseURL: 'https://example.org/bar',
+          }
+        }
+      }
+      const browserCheck = new MultiStepCheck('test-check', {
+        name: 'Test Check',
+        code: { content: 'console.log("test check")' },
+        ...custom,
+      })
+      Session.checkDefaults = undefined
+      Session.browserCheckDefaults = undefined
+      expect(browserCheck).toMatchObject(custom)
+    })
+  })
 })

--- a/packages/cli/src/constructs/browser-check.ts
+++ b/packages/cli/src/constructs/browser-check.ts
@@ -91,9 +91,11 @@ export class BrowserCheck extends RuntimeCheck {
   constructor (logicalId: string, props: BrowserCheckProps) {
     super(logicalId, props)
 
-    this.code = props.code
-    this.sslCheckDomain = props.sslCheckDomain
-    this.playwrightConfig = props.playwrightConfig
+    const config = this.applyConfigDefaults(props)
+
+    this.code = config.code
+    this.sslCheckDomain = config.sslCheckDomain
+    this.playwrightConfig = config.playwrightConfig
 
     Session.registerConstruct(this)
     this.addSubscriptions()
@@ -107,6 +109,15 @@ export class BrowserCheck extends RuntimeCheck {
       props.group?.getCheckDefaults(),
       Session.checkDefaults,
     )
+  }
+
+  protected applyConfigDefaults<T extends RuntimeCheckProps & Pick<BrowserCheckProps, 'playwrightConfig'>> (props: T): T {
+    const config = super.applyConfigDefaults(props)
+    const defaults = this.configDefaultsGetter(props)
+
+    config.playwrightConfig ??= defaults("playwrightConfig")
+
+    return config
   }
 
   async validate (diagnostics: Diagnostics): Promise<void> {

--- a/packages/cli/src/constructs/multi-step-check.ts
+++ b/packages/cli/src/constructs/multi-step-check.ts
@@ -40,8 +40,10 @@ export class MultiStepCheck extends RuntimeCheck {
   constructor (logicalId: string, props: MultiStepCheckProps) {
     super(logicalId, props)
 
-    this.code = props.code
-    this.playwrightConfig = props.playwrightConfig
+    const config = this.applyConfigDefaults(props)
+
+    this.code = config.code
+    this.playwrightConfig = config.playwrightConfig
 
     Session.registerConstruct(this)
     this.addSubscriptions()
@@ -95,6 +97,15 @@ export class MultiStepCheck extends RuntimeCheck {
       props.group?.getCheckDefaults(),
       Session.checkDefaults,
     )
+  }
+
+  protected applyConfigDefaults<T extends RuntimeCheckProps & Pick<MultiStepCheckProps, 'playwrightConfig'>> (props: T): T {
+    const config = super.applyConfigDefaults(props)
+    const defaults = this.configDefaultsGetter(props)
+
+    config.playwrightConfig ??= defaults("playwrightConfig")
+
+    return config
   }
 
   static async bundle (entry: string, runtimeId?: string) {

--- a/packages/cli/src/services/checkly-config-codegen.ts
+++ b/packages/cli/src/services/checkly-config-codegen.ts
@@ -107,6 +107,10 @@ function buildCheckConfigDefaults (
   if (resource.alertEscalationPolicy !== undefined) {
     builder.value('alertEscalationPolicy', valueForAlertEscalation(file, resource.alertEscalationPolicy))
   }
+
+  if (resource.playwrightConfig !== undefined) {
+    builder.value('playwrightConfig', valueForPlaywrightConfig(resource.playwrightConfig))
+  }
 }
 
 function valueForStringOrStringArray (value: string | string[]) {
@@ -162,10 +166,6 @@ more information.`))
                     builder.string(match)
                   }
                 })
-              }
-
-              if (checks.playwrightConfig !== undefined) {
-                builder.value('playwrightConfig', valueForPlaywrightConfig(checks.playwrightConfig))
               }
 
               buildCheckConfigDefaults(program, file, context, builder, checks)

--- a/packages/cli/src/services/checkly-config-loader.ts
+++ b/packages/cli/src/services/checkly-config-loader.ts
@@ -28,7 +28,9 @@ export type CheckConfigDefaults =
   Pick<RuntimeCheckProps,
   | 'environmentVariables'
   | 'runtimeId'
-  >
+  > &
+  // This is used by BrowserChecks and MultiStepChecks.
+  { playwrightConfig?: PlaywrightConfig }
 
 export type PlaywrightSlimmedProp = Pick<PlaywrightCheckProps, 'name' | 'activated'
   | 'muted' | 'shouldFail' | 'locations' | 'tags' | 'frequency' | 'environmentVariables'


### PR DESCRIPTION
The issue was caused by the introduction of typed defaults in version 6.1.0. However, it turns out that the original type (which was used more of as a hint) had never included `playwrightConfig`, but it had still been working because all properties were overwritten blindly regardless of whether they were present in the type or not.

This change makes BrowserChecks and MultiStepChecks use the appropriate default playwrightConfig again. Tests were added to make sure it won't break again.

## Affected Components
* [x] CLI
* [ ] Create CLI
* [x] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
