### PR TITLE
feat: use CLI's own version when adding checkly to package.json on import [sc-24879]

### DIFF
--- a/packages/cli/src/commands/import/plan.ts
+++ b/packages/cli/src/commands/import/plan.ts
@@ -663,8 +663,10 @@ ${chalk.cyan('For safety, resources are not deletable until the plan has been co
             }
           })()
 
+          const ownPackageJson = await this.loadPackageJsonOfSelf()
+
           const updated = packageJson.upsertDevDependencies({
-            checkly: `^5`,
+            checkly: `^${ownPackageJson?.version ?? '6'}`,
             jiti: '^2',
           })
 

--- a/packages/cli/src/services/check-parser/package-files/package-json-file.ts
+++ b/packages/cli/src/services/check-parser/package-files/package-json-file.ts
@@ -51,6 +51,10 @@ export class PackageJsonFile {
     return this.jsonFile.meta
   }
 
+  public get version () {
+    return this.jsonFile.data.version
+  }
+
   public get dependencies () {
     return this.jsonFile.data.dependencies
   }


### PR DESCRIPTION
This PR changes the hardcoded default to dynamically load the CLI's own version instead. Ensures that we don't forget to bump it.

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
