### PR TITLE
feat: add validation for {max,degraded}ResponseTime [sc-24880]

### DIFF
--- a/packages/cli/e2e/__tests__/fixtures/deploy-project/tcp.check.ts
+++ b/packages/cli/e2e/__tests__/fixtures/deploy-project/tcp.check.ts
@@ -9,5 +9,5 @@ new TcpMonitor('tcp-monitor', {
     port: 443,
   },
   degradedResponseTime: 5000,
-  maxResponseTime: 20000,
+  maxResponseTime: 5000,
 })

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -1,0 +1,94 @@
+import * as api from '../rest/api'
+import config from '../services/config'
+import { Flags } from '@oclif/core'
+import { AuthCommand } from './authCommand'
+import { parseProject } from '../services/project-parser'
+import { loadChecklyConfig } from '../services/checkly-config-loader'
+import type { Runtime } from '../rest/runtimes'
+import { Diagnostics } from '../constructs'
+import { splitConfigFilePath } from '../services/util'
+import commonMessages from '../messages/common-messages'
+
+export default class Validate extends AuthCommand {
+  static coreCommand = true
+  static hidden = true // Expose when validation is more thorough.
+  static description = 'Validate your project.'
+
+  static flags = {
+    config: Flags.string({
+      char: 'c',
+      description: commonMessages.configFile,
+    }),
+    'verify-runtime-dependencies': Flags.boolean({
+      description: '[default: true] Return an error if checks import dependencies that are not supported by the selected runtime.',
+      default: true,
+      allowNo: true,
+      env: 'CHECKLY_VERIFY_RUNTIME_DEPENDENCIES',
+    }),
+  }
+
+  async run (): Promise<void> {
+    this.style.actionStart('Parsing your project')
+    const { flags } = await this.parse(Validate)
+    const {
+      config: configFilename,
+      'verify-runtime-dependencies': verifyRuntimeDependencies,
+    } = flags
+    const { configDirectory, configFilenames } = splitConfigFilePath(configFilename)
+    const {
+      config: checklyConfig,
+      constructs: checklyConfigConstructs,
+    } = await loadChecklyConfig(configDirectory, configFilenames)
+    const { data: account } = await api.accounts.get(config.getAccountId())
+    const { data: avilableRuntimes } = await api.runtimes.getAll()
+    const project = await parseProject({
+      directory: configDirectory,
+      projectLogicalId: checklyConfig.logicalId,
+      projectName: checklyConfig.projectName,
+      repoUrl: checklyConfig.repoUrl,
+      checkMatch: checklyConfig.checks?.checkMatch,
+      browserCheckMatch: checklyConfig.checks?.browserChecks?.testMatch,
+      multiStepCheckMatch: checklyConfig.checks?.multiStepChecks?.testMatch,
+      ignoreDirectoriesMatch: checklyConfig.checks?.ignoreDirectoriesMatch,
+      checkDefaults: checklyConfig.checks,
+      browserCheckDefaults: checklyConfig.checks?.browserChecks,
+      availableRuntimes: avilableRuntimes.reduce((acc, runtime) => {
+        acc[runtime.name] = runtime
+        return acc
+      }, <Record<string, Runtime>> {}),
+      defaultRuntimeId: account.runtimeId,
+      verifyRuntimeDependencies,
+      checklyConfigConstructs,
+      playwrightConfigPath: checklyConfig.checks?.playwrightConfigPath,
+      include: checklyConfig.checks?.include,
+      playwrightChecks: checklyConfig.checks?.playwrightChecks,
+    })
+
+    this.style.actionSuccess()
+
+    this.style.actionStart('Validating project resources')
+
+    const diagnostics = new Diagnostics()
+    await project.validate(diagnostics)
+
+    for (const diag of diagnostics.observations) {
+      if (diag.isFatal()) {
+        this.style.longError(diag.title, diag.message)
+      } else if (!diag.isBenign()) {
+        this.style.longWarning(diag.title, diag.message)
+      } else {
+        this.style.longInfo(diag.title, diag.message)
+      }
+    }
+
+    if (diagnostics.isFatal()) {
+      this.style.actionFailure()
+      this.style.shortError(`Your project is not valid.`)
+      this.exit(1)
+    }
+
+    this.style.actionSuccess()
+
+    this.style.shortSuccess(`Your project is valid.`)
+  }
+}

--- a/packages/cli/src/constructs/api-check.ts
+++ b/packages/cli/src/constructs/api-check.ts
@@ -10,6 +10,7 @@ import { Diagnostics } from './diagnostics'
 import { DeprecatedPropertyDiagnostic, InvalidPropertyValueDiagnostic } from './construct-diagnostics'
 import { ApiCheckBundle, ApiCheckBundleProps } from './api-check-bundle'
 import { Assertion } from './api-assertion'
+import { validateResponseTimes } from './internal/common-diagnostics'
 
 /**
  * Default configuration that can be applied to API checks.
@@ -292,6 +293,11 @@ export class ApiCheck extends RuntimeCheck {
         new Error(`Use "tearDownScript" instead.`),
       ))
     }
+
+    await validateResponseTimes(diagnostics, this, {
+      degradedResponseTime: 30_000,
+      maxResponseTime: 30_000,
+    })
   }
 
   async bundle (): Promise<ApiCheckBundle> {

--- a/packages/cli/src/constructs/internal/common-diagnostics.ts
+++ b/packages/cli/src/constructs/internal/common-diagnostics.ts
@@ -58,3 +58,45 @@ export async function validateDeprecatedDoubleCheck (diagnostics: Diagnostics, p
 export async function validateRemovedDoubleCheck (diagnostics: Diagnostics, props: RetryStrategyProps) {
   await validateDoubleCheck(diagnostics, RemovedPropertyDiagnostic, props)
 }
+
+type ResponseTimeProps = {
+  degradedResponseTime?: number
+  maxResponseTime?: number
+}
+
+type ResponseTimeLimits = {
+  degradedResponseTime: number
+  maxResponseTime: number
+}
+
+export async function validateResponseTimes (diagnostics: Diagnostics, props: ResponseTimeProps, limits: ResponseTimeLimits) {
+  if (props.degradedResponseTime !== undefined) {
+    const value = props.degradedResponseTime
+    const limit = limits.degradedResponseTime
+    if (value > limit) {
+      diagnostics.add(new InvalidPropertyValueDiagnostic(
+        'degradedResponseTime',
+        new Error(
+          `The value of "degradedResponseTime" must be ${limit} or lower.` +
+          `\n\n` +
+          `The current value is ${value}.`
+        ),
+      ))
+    }
+  }
+
+  if (props.maxResponseTime !== undefined) {
+    const value = props.maxResponseTime
+    const limit = limits.maxResponseTime
+    if (value > limit) {
+      diagnostics.add(new InvalidPropertyValueDiagnostic(
+        'maxResponseTime',
+        new Error(
+          `The value of "maxResponseTime" must be ${limit} or lower.` +
+          `\n\n` +
+          `The current value is ${value}.`
+        ),
+      ))
+    }
+  }
+}

--- a/packages/cli/src/constructs/tcp-monitor.ts
+++ b/packages/cli/src/constructs/tcp-monitor.ts
@@ -2,6 +2,8 @@ import { Monitor, MonitorProps } from './monitor'
 import { IPFamily } from './ip'
 import { Session } from './project'
 import { Assertion as CoreAssertion, NumericAssertionBuilder, GeneralAssertionBuilder } from './internal/assertion'
+import { Diagnostics } from './diagnostics'
+import { validateResponseTimes } from './internal/common-diagnostics'
 
 type TcpAssertionSource = 'RESPONSE_DATA' | 'RESPONSE_TIME'
 
@@ -147,6 +149,15 @@ export class TcpMonitor extends Monitor {
     Session.registerConstruct(this)
     this.addSubscriptions()
     this.addPrivateLocationCheckAssignments()
+  }
+
+  async validate (diagnostics: Diagnostics): Promise<void> {
+    await super.validate(diagnostics)
+
+    await validateResponseTimes(diagnostics, this, {
+      degradedResponseTime: 5_000,
+      maxResponseTime: 5_000,
+    })
   }
 
   synthesize () {

--- a/packages/cli/src/constructs/url-monitor.ts
+++ b/packages/cli/src/constructs/url-monitor.ts
@@ -1,3 +1,5 @@
+import { Diagnostics } from './diagnostics'
+import { validateResponseTimes } from './internal/common-diagnostics'
 import { Monitor, MonitorProps } from './monitor'
 import { Session } from './project'
 import { UrlRequest } from './url-request'
@@ -124,6 +126,15 @@ export class UrlMonitor extends Monitor {
     Session.registerConstruct(this)
     this.addSubscriptions()
     this.addPrivateLocationCheckAssignments()
+  }
+
+  async validate (diagnostics: Diagnostics): Promise<void> {
+    await super.validate(diagnostics)
+
+    await validateResponseTimes(diagnostics, this, {
+      degradedResponseTime: 30_000,
+      maxResponseTime: 30_000,
+    })
   }
 
   synthesize () {


### PR DESCRIPTION
The limits are consistent with the API schema.

A new command, `npx checkly validate` is introduced (think e.g. `terraform validate`), but it is kept hidden for now as the CLI-side validation is not very thorough yet.

Also fixes e2e tests that had an invalid value.

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
