### PR TITLE
feat: add optional default config support for monitors [sc-24878]

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -106,6 +106,7 @@ export default class Deploy extends AuthCommand {
       ignoreDirectoriesMatch: checklyConfig.checks?.ignoreDirectoriesMatch,
       checkDefaults: checklyConfig.checks,
       browserCheckDefaults: checklyConfig.checks?.browserChecks,
+      monitorDefaults: checklyConfig.checks?.monitors,
       availableRuntimes: avilableRuntimes.reduce((acc, runtime) => {
         acc[runtime.name] = runtime
         return acc

--- a/packages/cli/src/commands/import/plan.ts
+++ b/packages/cli/src/commands/import/plan.ts
@@ -967,6 +967,7 @@ ${chalk.cyan('For safety, resources are not deletable until the plan has been co
         ignoreDirectoriesMatch: checklyConfig.checks?.ignoreDirectoriesMatch,
         checkDefaults: checklyConfig.checks,
         browserCheckDefaults: checklyConfig.checks?.browserChecks,
+        monitorDefaults: checklyConfig.checks?.monitors,
         availableRuntimes: availableRuntimes.reduce((acc, runtime) => {
           acc[runtime.name] = runtime
           return acc

--- a/packages/cli/src/commands/pw-test.ts
+++ b/packages/cli/src/commands/pw-test.ts
@@ -139,6 +139,7 @@ export default class PwTestCommand extends AuthCommand {
       checkMatch: checklyConfig.checks?.checkMatch,
       ignoreDirectoriesMatch: checklyConfig.checks?.ignoreDirectoriesMatch,
       checkDefaults: checklyConfig.checks,
+      monitorDefaults: checklyConfig.checks?.monitors,
       availableRuntimes: availableRuntimes.reduce((acc, runtime) => {
         acc[runtime.name] = runtime
         return acc

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -176,6 +176,7 @@ export default class Test extends AuthCommand {
       ignoreDirectoriesMatch: checklyConfig.checks?.ignoreDirectoriesMatch,
       checkDefaults: checklyConfig.checks,
       browserCheckDefaults: checklyConfig.checks?.browserChecks,
+      monitorDefaults: checklyConfig.checks?.monitors,
       availableRuntimes: availableRuntimes.reduce((acc, runtime) => {
         acc[runtime.name] = runtime
         return acc

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -52,6 +52,7 @@ export default class Validate extends AuthCommand {
       ignoreDirectoriesMatch: checklyConfig.checks?.ignoreDirectoriesMatch,
       checkDefaults: checklyConfig.checks,
       browserCheckDefaults: checklyConfig.checks?.browserChecks,
+      monitorDefaults: checklyConfig.checks?.monitors,
       availableRuntimes: avilableRuntimes.reduce((acc, runtime) => {
         acc[runtime.name] = runtime
         return acc

--- a/packages/cli/src/constructs/check-group-ref.ts
+++ b/packages/cli/src/constructs/check-group-ref.ts
@@ -1,4 +1,4 @@
-import { CheckConfigDefaults } from '../services/checkly-config-loader'
+import { CheckConfigDefaults, MonitorConfigDefaults } from '../services/checkly-config-loader'
 import { CheckGroupV1 } from './check-group-v1'
 import { Construct } from './construct'
 import { Session } from './project'
@@ -28,6 +28,11 @@ export class CheckGroupRef extends Construct {
   }
 
   public getMultiStepCheckDefaults (): CheckConfigDefaults {
+    // See the comment for getCheckDefaults(), the same applies here.
+    return {}
+  }
+
+  public getMonitorDefaults (): MonitorConfigDefaults {
     // See the comment for getCheckDefaults(), the same applies here.
     return {}
   }

--- a/packages/cli/src/constructs/check-group-v1.ts
+++ b/packages/cli/src/constructs/check-group-v1.ts
@@ -16,7 +16,7 @@ import { AlertEscalation } from './alert-escalation-policy'
 import { Diagnostics } from './diagnostics'
 import { DeprecatedConstructDiagnostic, DeprecatedPropertyDiagnostic, InvalidPropertyValueDiagnostic } from './construct-diagnostics'
 import CheckTypes from '../constants'
-import { CheckConfigDefaults } from '../services/checkly-config-loader'
+import { CheckConfigDefaults, MonitorConfigDefaults } from '../services/checkly-config-loader'
 import { pathToPosix } from '../services/util'
 import { AlertChannelSubscription } from './alert-channel-subscription'
 import { BrowserCheck } from './browser-check'
@@ -490,6 +490,12 @@ export class CheckGroupV1 extends Construct {
   public getMultiStepCheckDefaults (): CheckConfigDefaults {
     return {
       frequency: this.multiStepChecks?.frequency,
+    }
+  }
+
+  public getMonitorDefaults (): MonitorConfigDefaults {
+    return {
+      frequency: this.frequency,
     }
   }
 

--- a/packages/cli/src/constructs/monitor.ts
+++ b/packages/cli/src/constructs/monitor.ts
@@ -12,6 +12,8 @@ import { Check, CheckProps } from './check'
 import { Diagnostics } from './diagnostics'
 import { validateRemovedDoubleCheck } from './internal/common-diagnostics'
 import { InvalidPropertyValueDiagnostic } from './construct-diagnostics'
+import { ConfigDefaultsGetter, makeConfigDefaultsGetter } from './check-config'
+import { Session } from './project'
 
 /**
  * Retry strategies supported by monitors.
@@ -135,6 +137,15 @@ export abstract class Monitor extends Check {
         ))
       }
     }
+  }
+
+  protected configDefaultsGetter (props: MonitorProps): ConfigDefaultsGetter {
+    return makeConfigDefaultsGetter(
+      props.group?.getMonitorDefaults(),
+      Session.monitorDefaults,
+      props.group?.getCheckDefaults(),
+      Session.checkDefaults,
+    )
   }
 
   synthesize() {

--- a/packages/cli/src/constructs/project.ts
+++ b/packages/cli/src/constructs/project.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 
 import * as api from '../rest/api'
-import { CheckConfigDefaults } from '../services/checkly-config-loader'
+import { CheckConfigDefaults, MonitorConfigDefaults } from '../services/checkly-config-loader'
 import { Parser } from '../services/check-parser/parser'
 import { Construct } from './construct'
 import { ValidationError } from './validator-error'
@@ -226,6 +226,7 @@ export class Session {
   static checkFilter?: CheckFilter
   static browserCheckDefaults?: CheckConfigDefaults
   static multiStepCheckDefaults?: CheckConfigDefaults
+  static monitorDefaults?: MonitorConfigDefaults
   static checkFilePath?: string
   static checkFileAbsolutePath?: string
   static availableRuntimes: Record<string, Runtime>

--- a/packages/cli/src/services/checkly-config-codegen.ts
+++ b/packages/cli/src/services/checkly-config-codegen.ts
@@ -7,7 +7,7 @@ import { valueForPlaywrightConfig } from '../constructs/playwright-config-codege
 import { valueForPrivateLocationFromId } from '../constructs/private-location-codegen'
 import { valueForRetryStrategy } from '../constructs/retry-strategy-codegen'
 import { array, decl, docComment, expr, GeneratedFile, ident, ObjectValueBuilder, Program, StringValue } from '../sourcegen'
-import { ChecklyConfig, CheckConfigDefaults } from './checkly-config-loader'
+import { ChecklyConfig, CheckConfigDefaults, MonitorConfigDefaults } from './checkly-config-loader'
 
 function buildCheckConfigDefaults (
   program: Program,
@@ -113,6 +113,16 @@ function buildCheckConfigDefaults (
   }
 }
 
+function buildMonitorConfigDefaults (
+  program: Program,
+  file: GeneratedFile,
+  context: Context,
+  builder: ObjectValueBuilder,
+  resource: MonitorConfigDefaults,
+) {
+  return buildCheckConfigDefaults(program, file, context, builder, resource)
+}
+
 function valueForStringOrStringArray (value: string | string[]) {
   if (Array.isArray(value)) {
     return array(builder => {
@@ -189,6 +199,13 @@ more information.`))
                   }
 
                   buildCheckConfigDefaults(program, file, context, builder, multiStepChecks)
+                })
+              }
+
+              if (checks.monitors !== undefined) {
+                const monitors = checks.monitors
+                builder.object('monitors', builder => {
+                  buildMonitorConfigDefaults(program, file, context, builder, monitors)
                 })
               }
             })

--- a/packages/cli/src/services/checkly-config-loader.ts
+++ b/packages/cli/src/services/checkly-config-loader.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs/promises'
 import { existsSync } from 'fs'
 import { getDefaultChecklyConfig, writeChecklyConfigFile } from './util'
 import { CheckProps, RuntimeCheckProps } from '../constructs/check'
+import { MonitorProps } from '../constructs/monitor'
 import { PlaywrightCheckProps } from '../constructs/playwright-check'
 import { Session } from '../constructs'
 import { Construct } from '../constructs/construct'
@@ -31,6 +32,20 @@ export type CheckConfigDefaults =
   > &
   // This is used by BrowserChecks and MultiStepChecks.
   { playwrightConfig?: PlaywrightConfig }
+
+export type MonitorConfigDefaults =
+  Pick<MonitorProps,
+  | 'activated'
+  | 'alertChannels'
+  | 'alertEscalationPolicy'
+  | 'frequency'
+  | 'locations'
+  | 'muted'
+  | 'privateLocations'
+  | 'retryStrategy'
+  | 'shouldFail'
+  | 'tags'
+  >
 
 export type PlaywrightSlimmedProp = Pick<PlaywrightCheckProps, 'name' | 'activated'
   | 'muted' | 'shouldFail' | 'locations' | 'tags' | 'frequency' | 'environmentVariables'
@@ -83,6 +98,12 @@ export type ChecklyConfig = {
        */
       testMatch?: string | string[],
     },
+    /**
+     * Optional default configuration for monitors.
+     * Properties defined here take precedence over check defaults, a subset
+     * of which are also used for monitors.
+     */
+    monitors?: MonitorConfigDefaults
     /**
      * Playwright config path to be used during bundling and playwright config parsing
      */

--- a/packages/cli/src/services/project-parser.ts
+++ b/packages/cli/src/services/project-parser.ts
@@ -10,7 +10,7 @@ import {
   CheckFilter,
 } from '../constructs'
 import { Ref } from '../constructs/ref'
-import { CheckConfigDefaults, PlaywrightSlimmedProp } from './checkly-config-loader'
+import { CheckConfigDefaults, MonitorConfigDefaults, PlaywrightSlimmedProp } from './checkly-config-loader'
 import type { Runtime } from '../rest/runtimes'
 import { isEntrypoint, type Construct } from '../constructs/construct'
 import { PlaywrightCheck } from '../constructs/playwright-check'
@@ -35,6 +35,7 @@ type ProjectParseOpts = {
   playwrightConfigPath?: string
   include?: string | string[],
   playwrightChecks?: PlaywrightSlimmedProp[]
+  monitorDefaults?: MonitorConfigDefaults
 }
 
 const BASE_CHECK_DEFAULTS = {
@@ -54,6 +55,7 @@ export async function parseProject (opts: ProjectParseOpts): Promise<Project> {
     ignoreDirectoriesMatch = [],
     checkDefaults = {},
     browserCheckDefaults = {},
+    monitorDefaults = {},
     availableRuntimes,
     defaultRuntimeId,
     verifyRuntimeDependencies,
@@ -79,6 +81,7 @@ export async function parseProject (opts: ProjectParseOpts): Promise<Project> {
   Session.checkDefaults = Object.assign({}, BASE_CHECK_DEFAULTS, checkDefaults)
   Session.checkFilter = checkFilter
   Session.browserCheckDefaults = browserCheckDefaults
+  Session.monitorDefaults = monitorDefaults
   Session.availableRuntimes = availableRuntimes
   Session.defaultRuntimeId = defaultRuntimeId
   Session.verifyRuntimeDependencies = verifyRuntimeDependencies ?? true


### PR DESCRIPTION
This PR adds an optional default config section for monitors. The reason why a separate default config may be necessary is that some of the check defaults may be incompatible with monitors. For example, #1106 makes it so that monitors only support a subset of retry strategies available to checks.

There is no separate file pattern for monitors. Only default configuration can be changed.

Monitor config defaults fall back to check config defaults.

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
