### PR TITLE
feat: show an accurate description for Constructs in validation errors [sc-24882]

### DIFF
--- a/packages/cli/src/constructs/alert-channel-subscription.ts
+++ b/packages/cli/src/constructs/alert-channel-subscription.ts
@@ -48,6 +48,10 @@ export class AlertChannelSubscription extends Construct {
     Session.registerConstruct(this)
   }
 
+  describe (): string {
+    return `AlertChannelSubscription:${this.logicalId}`
+  }
+
   synthesize () {
     return {
       alertChannelId: this.alertChannelId,

--- a/packages/cli/src/constructs/alert-channel.ts
+++ b/packages/cli/src/constructs/alert-channel.ts
@@ -77,6 +77,10 @@ export class AlertChannelRef extends Construct {
     Session.registerConstruct(this)
   }
 
+  describe (): string {
+    return `AlertChannelRef:${this.logicalId}`
+  }
+
   synthesize () {
     return null
   }

--- a/packages/cli/src/constructs/api-check.ts
+++ b/packages/cli/src/constructs/api-check.ts
@@ -231,6 +231,10 @@ export class ApiCheck extends RuntimeCheck {
     this.addPrivateLocationCheckAssignments()
   }
 
+  describe (): string {
+    return `ApiCheck:${this.logicalId}`
+  }
+
   async validate (diagnostics: Diagnostics): Promise<void> {
     if (this.setupScript) {
       if (!isEntrypoint(this.setupScript) && !isContent(this.setupScript)) {

--- a/packages/cli/src/constructs/browser-check.ts
+++ b/packages/cli/src/constructs/browser-check.ts
@@ -102,6 +102,10 @@ export class BrowserCheck extends RuntimeCheck {
     this.addPrivateLocationCheckAssignments()
   }
 
+  describe (): string {
+    return `BrowserCheck:${this.logicalId}`
+  }
+
   protected configDefaultsGetter (props: CheckProps): ConfigDefaultsGetter {
     return makeConfigDefaultsGetter(
       props.group?.getBrowserCheckDefaults(),

--- a/packages/cli/src/constructs/check-group-ref.ts
+++ b/packages/cli/src/constructs/check-group-ref.ts
@@ -14,6 +14,10 @@ export class CheckGroupRef extends Construct {
     Session.registerConstruct(this)
   }
 
+  describe (): string {
+    return `CheckGroupRef:${this.logicalId}`
+  }
+
   public getCheckDefaults (): CheckConfigDefaults {
     // The only value CheckGroup.getCheckDefaults() returns is frequency,
     // which exists purely for convenience, and only at CLI-level. It never

--- a/packages/cli/src/constructs/check-group-v1.ts
+++ b/packages/cli/src/constructs/check-group-v1.ts
@@ -350,6 +350,10 @@ export class CheckGroupV1 extends Construct {
     this.__addPrivateLocationGroupAssignments()
   }
 
+  describe (): string {
+    return `CheckGroupV1:${this.logicalId}`
+  }
+
   protected async onBeforeValidate (diagnostics: Diagnostics): Promise<void> {
     diagnostics.add(new DeprecatedConstructDiagnostic(
       'CheckGroup',

--- a/packages/cli/src/constructs/check-group-v2.ts
+++ b/packages/cli/src/constructs/check-group-v2.ts
@@ -146,6 +146,10 @@ export class CheckGroupV2 extends CheckGroupV1 {
     this.useGlobalAlertSettings = useGlobalAlertSettings
   }
 
+  describe (): string {
+    return `CheckGroupV2:${this.logicalId}`
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async onBeforeValidate (diagnostics: Diagnostics): Promise<void> {
     // No-op

--- a/packages/cli/src/constructs/construct-diagnostics.ts
+++ b/packages/cli/src/constructs/construct-diagnostics.ts
@@ -89,7 +89,7 @@ export class ConstructDiagnostic extends Diagnostic {
 
   constructor (construct: Construct, underlying: Diagnostic) {
     super({
-      title: `[${construct.type}:${construct.logicalId}] ${underlying.title}`,
+      title: `[${construct.describe()}] ${underlying.title}`,
       message: underlying.message,
     })
 

--- a/packages/cli/src/constructs/construct.ts
+++ b/packages/cli/src/constructs/construct.ts
@@ -73,6 +73,11 @@ export abstract class Construct implements Validate, Bundle {
   }
 
   /**
+   * @returns A unique description of the Construct instance.
+   */
+  abstract describe (): string
+
+  /**
    * Creates a reference to this construct that can be used in other constructs.
    * 
    * @returns A reference object that can be used to link to this construct

--- a/packages/cli/src/constructs/dashboard.ts
+++ b/packages/cli/src/constructs/dashboard.ts
@@ -273,6 +273,10 @@ export class Dashboard extends Construct {
     Session.registerConstruct(this)
   }
 
+  describe (): string {
+    return `Dashboard:${this.logicalId}`
+  }
+
   async validate (diagnostics: Diagnostics): Promise<void> {
     if (!this.customUrl && !this.customDomain) {
       diagnostics.add(new InvalidPropertyValueDiagnostic(

--- a/packages/cli/src/constructs/email-alert-channel.ts
+++ b/packages/cli/src/constructs/email-alert-channel.ts
@@ -30,6 +30,10 @@ export class EmailAlertChannel extends AlertChannel {
     Session.registerConstruct(this)
   }
 
+  describe (): string {
+    return `EmailAlertChannel:${this.logicalId}`
+  }
+
   synthesize () {
     return {
       ...super.synthesize(),

--- a/packages/cli/src/constructs/heartbeat-monitor.ts
+++ b/packages/cli/src/constructs/heartbeat-monitor.ts
@@ -79,6 +79,10 @@ export class HeartbeatMonitor extends Monitor {
     this.addSubscriptions()
   }
 
+  describe (): string {
+    return `HeartbeatMonitor:${this.logicalId}`
+  }
+
   synthesize (): any | null {
     return {
       ...super.synthesize(),

--- a/packages/cli/src/constructs/incidentio-alert-channel.ts
+++ b/packages/cli/src/constructs/incidentio-alert-channel.ts
@@ -70,6 +70,10 @@ export class IncidentioAlertChannel extends WebhookAlertChannel {
     this.template = props.payload ?? IncidentioAlertChannel.DEFAULT_PAYLOAD
   }
 
+  describe (): string {
+    return `IncidentioAlertChannel:${this.logicalId}`
+  }
+
   synthesize () {
     return {
       ...super.synthesize(),

--- a/packages/cli/src/constructs/maintenance-window.ts
+++ b/packages/cli/src/constructs/maintenance-window.ts
@@ -74,6 +74,10 @@ export class MaintenanceWindow extends Construct {
     Session.registerConstruct(this)
   }
 
+  describe (): string {
+    return `MaintenanceWindow:${this.logicalId}`
+  }
+
   synthesize (): any|null {
     return {
       name: this.name,

--- a/packages/cli/src/constructs/msteams-alert-channel.ts
+++ b/packages/cli/src/constructs/msteams-alert-channel.ts
@@ -115,6 +115,10 @@ export class MSTeamsAlertChannel extends WebhookAlertChannel {
     this.template = props.payload ?? MSTeamsAlertChannel.DEFAULT_PAYLOAD
   }
 
+  describe (): string {
+    return `MSTeamsAlertChannel:${this.logicalId}`
+  }
+
   synthesize () {
     return {
       ...super.synthesize(),

--- a/packages/cli/src/constructs/multi-step-check.ts
+++ b/packages/cli/src/constructs/multi-step-check.ts
@@ -50,6 +50,10 @@ export class MultiStepCheck extends RuntimeCheck {
     this.addPrivateLocationCheckAssignments()
   }
 
+  describe (): string {
+    return `MultiStepCheck:${this.logicalId}`
+  }
+
   async validate (diagnostics: Diagnostics): Promise<void> {
     if (!isEntrypoint(this.code) && !isContent(this.code)) {
       diagnostics.add(new InvalidPropertyValueDiagnostic(

--- a/packages/cli/src/constructs/opsgenie-alert-channel.ts
+++ b/packages/cli/src/constructs/opsgenie-alert-channel.ts
@@ -54,6 +54,10 @@ export class OpsgenieAlertChannel extends AlertChannel {
     Session.registerConstruct(this)
   }
 
+  describe (): string {
+    return `OpsgenieAlertChannel:${this.logicalId}`
+  }
+
   synthesize () {
     return {
       ...super.synthesize(),

--- a/packages/cli/src/constructs/pagerduty-alert-channel.ts
+++ b/packages/cli/src/constructs/pagerduty-alert-channel.ts
@@ -45,6 +45,10 @@ export class PagerdutyAlertChannel extends AlertChannel {
     Session.registerConstruct(this)
   }
 
+  describe (): string {
+    return `PagerdutyAlertChannel:${this.logicalId}`
+  }
+
   synthesize () {
     return {
       ...super.synthesize(),

--- a/packages/cli/src/constructs/phone-call-alert-channel.ts
+++ b/packages/cli/src/constructs/phone-call-alert-channel.ts
@@ -39,6 +39,10 @@ export class PhoneCallAlertChannel extends AlertChannel {
     Session.registerConstruct(this)
   }
 
+  describe (): string {
+    return `PhoneCallAlertChannel:${this.logicalId}`
+  }
+
   synthesize () {
     return {
       ...super.synthesize(),

--- a/packages/cli/src/constructs/playwright-check.ts
+++ b/packages/cli/src/constructs/playwright-check.ts
@@ -52,6 +52,10 @@ export class PlaywrightCheck extends RuntimeCheck {
     this.addPrivateLocationCheckAssignments()
   }
 
+  describe (): string {
+    return `PlaywrightCheck:${this.logicalId}`
+  }
+
   async validate (diagnostics: Diagnostics): Promise<void> {
     try {
       await fs.access(this.playwrightConfigPath, fs.constants.R_OK)

--- a/packages/cli/src/constructs/private-location-check-assignment.ts
+++ b/packages/cli/src/constructs/private-location-check-assignment.ts
@@ -33,6 +33,10 @@ export class PrivateLocationCheckAssignment extends Construct {
     Session.registerConstruct(this)
   }
 
+  describe (): string {
+    return `PrivateLocationCheckAssignment:${this.logicalId}`
+  }
+
   synthesize () {
     return {
       privateLocationId: this.privateLocationId,

--- a/packages/cli/src/constructs/private-location-group-assignment.ts
+++ b/packages/cli/src/constructs/private-location-group-assignment.ts
@@ -33,6 +33,10 @@ export class PrivateLocationGroupAssignment extends Construct {
     Session.registerConstruct(this)
   }
 
+  describe (): string {
+    return `PrivateLocationGroupAssignment:${this.logicalId}`
+  }
+
   synthesize () {
     return {
       privateLocationId: this.privateLocationId,

--- a/packages/cli/src/constructs/private-location.ts
+++ b/packages/cli/src/constructs/private-location.ts
@@ -59,6 +59,10 @@ export class PrivateLocationRef extends Construct {
     Session.registerConstruct(this)
   }
 
+  describe (): string {
+    return `PrivateLocationRef:${this.logicalId}`
+  }
+
   synthesize () {
     return null
   }
@@ -97,6 +101,10 @@ export class PrivateLocation extends Construct {
     this.proxyUrl = props.proxyUrl
 
     Session.registerConstruct(this)
+  }
+
+  describe (): string {
+    return `PrivateLocation:${this.logicalId}`
   }
 
   async validate (diagnostics: Diagnostics): Promise<void> {

--- a/packages/cli/src/constructs/project.ts
+++ b/packages/cli/src/constructs/project.ts
@@ -88,6 +88,10 @@ export class Project extends Construct {
     this.logicalId = logicalId
   }
 
+  describe (): string {
+    return `Project:${this.logicalId}`
+  }
+
   async validate (diagnostics: Diagnostics): Promise<void> {
     if (!this.name) {
       diagnostics.add(new InvalidPropertyValueDiagnostic(

--- a/packages/cli/src/constructs/slack-alert-channel.ts
+++ b/packages/cli/src/constructs/slack-alert-channel.ts
@@ -31,6 +31,10 @@ export class SlackAlertChannel extends AlertChannel {
     Session.registerConstruct(this)
   }
 
+  describe (): string {
+    return `SlackAlertChannel:${this.logicalId}`
+  }
+
   synthesize () {
     return {
       ...super.synthesize(),

--- a/packages/cli/src/constructs/sms-alert-channel.ts
+++ b/packages/cli/src/constructs/sms-alert-channel.ts
@@ -37,6 +37,10 @@ export class SmsAlertChannel extends AlertChannel {
     Session.registerConstruct(this)
   }
 
+  describe (): string {
+    return `SmsAlertChannel:${this.logicalId}`
+  }
+
   synthesize () {
     return {
       ...super.synthesize(),

--- a/packages/cli/src/constructs/status-page-service.ts
+++ b/packages/cli/src/constructs/status-page-service.ts
@@ -19,6 +19,10 @@ export class StatusPageServiceRef extends Construct {
     Session.registerConstruct(this)
   }
 
+  describe (): string {
+    return `StatusPageServiceRef:${this.logicalId}`
+  }
+
   synthesize () {
     return null
   }
@@ -45,6 +49,10 @@ export class StatusPageService extends Construct {
     this.name = props.name
 
     Session.registerConstruct(this)
+  }
+
+  describe (): string {
+    return `StatusPageService:${this.logicalId}`
   }
 
   static fromId (id: string) {

--- a/packages/cli/src/constructs/status-page.ts
+++ b/packages/cli/src/constructs/status-page.ts
@@ -88,6 +88,10 @@ export class StatusPage extends Construct {
     Session.registerConstruct(this)
   }
 
+  describe (): string {
+    return `StatusPage:${this.logicalId}`
+  }
+
   synthesize (): any|null {
     return {
       name: this.name,

--- a/packages/cli/src/constructs/tcp-monitor.ts
+++ b/packages/cli/src/constructs/tcp-monitor.ts
@@ -151,6 +151,10 @@ export class TcpMonitor extends Monitor {
     this.addPrivateLocationCheckAssignments()
   }
 
+  describe (): string {
+    return `TcpMonitor:${this.logicalId}`
+  }
+
   async validate (diagnostics: Diagnostics): Promise<void> {
     await super.validate(diagnostics)
 

--- a/packages/cli/src/constructs/telegram-alert-channel.ts
+++ b/packages/cli/src/constructs/telegram-alert-channel.ts
@@ -56,6 +56,10 @@ Tags: {{#each TAGS}} <i><b>{{this}}</b></i> {{#unless @last}},{{/unless}} {{/eac
     this.url = `https://api.telegram.org/bot${props.apiKey}/sendMessage`
   }
 
+  describe (): string {
+    return `TelegramAlertChannel:${this.logicalId}`
+  }
+
   synthesize () {
     return {
       ...super.synthesize(),

--- a/packages/cli/src/constructs/url-monitor.ts
+++ b/packages/cli/src/constructs/url-monitor.ts
@@ -128,6 +128,10 @@ export class UrlMonitor extends Monitor {
     this.addPrivateLocationCheckAssignments()
   }
 
+  describe (): string {
+    return `UrlMonitor:${this.logicalId}`
+  }
+
   async validate (diagnostics: Diagnostics): Promise<void> {
     await super.validate(diagnostics)
 

--- a/packages/cli/src/constructs/webhook-alert-channel.ts
+++ b/packages/cli/src/constructs/webhook-alert-channel.ts
@@ -78,6 +78,10 @@ export class WebhookAlertChannel extends AlertChannel {
     Session.registerConstruct(this)
   }
 
+  describe (): string {
+    return `WebhookAlertChannel:${this.logicalId}`
+  }
+
   synthesize () {
     return {
       ...super.synthesize(),


### PR DESCRIPTION
Until now, validation errors would only show the underlying base type of the construct. Many Constructs share the same base type (e.g. `alert-channel`, `check`), which makes it hard to tell them apart.

Now, each Construct implements a `describe()` method which returns a unique description for the Construct instance. It consists of the Construct class name and the logicalId of the instance.

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
