### PR TITLE
feat: add checkly config example to AI rules template

### DIFF
--- a/packages/cli/scripts/compile-rules.ts
+++ b/packages/cli/scripts/compile-rules.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { readFile, writeFile, mkdir } from 'fs/promises';
+import { mkdir, readFile, writeFile } from 'fs/promises';
 import { join } from 'path';
 
 const EXAMPLES_DIR = join(__dirname, '../gen/');
@@ -12,6 +12,11 @@ const EXAMPLE_CONFIGS: Record<
   string,
   { templateString: string; exampleConfigPath: string }
 > = {
+  CHECKLY_CONFIG: {
+    templateString: '// INSERT CHECKLY CONFIG EXAMPLE HERE //',
+    exampleConfigPath:
+      '../../../examples/boilerplate-project/checkly.config.ts',
+  },
   BROWSER_CHECK: {
     templateString: '// INSERT BROWSER CHECK EXAMPLE HERE //',
     exampleConfigPath:

--- a/packages/cli/src/rules/checkly.rules.template.md
+++ b/packages/cli/src/rules/checkly.rules.template.md
@@ -33,6 +33,10 @@ Here is an example directory tree of what that would look like:
 
 The `checkly.config.ts` at the root of your project defines a range of defaults for all your checks.
 
+```typescript
+// INSERT CHECKLY CONFIG EXAMPLE HERE //
+```
+
 ## Check and Monitor Constructs
 
 ### API Check


### PR DESCRIPTION
Added CHECKLY_CONFIG to compile-rules.ts and corresponding template placeholder in checkly.rules.template.md to include configuration examples in the AI rules.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Affected Components
* [ ] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [x] Other

## Notes for the Reviewer

To improve the AI rules when setting up a new project, I wanted to add a `checkly.config.ts` example to the generated `checkly.rules` file. Now, this solution isn't very pretty because:

- The generation script reaches out of the `cli` package scope into `examples` to read a `checkly.config`.
- It's not very clear that a template `checkly.config` example file will make it into our AI rules.

So, I don't think this solution is ideal, but I couldn't think of anything better. Looking forward to opinions and feedback, and happy to try something else.
