### PR TITLE
fix: improve Frequency codegen [sc-24999]

### DIFF
--- a/packages/cli/src/constructs/__tests__/frequency-codegen.spec.ts
+++ b/packages/cli/src/constructs/__tests__/frequency-codegen.spec.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+
+import { Frequency } from '../frequency'
+import { valueForFrequency } from '../frequency-codegen'
+import { GeneratedFile, Output } from '../../sourcegen'
+
+describe('Frequency Codegen', () => {
+  it('should generate predefined constants', () => {
+    const predefined = [
+      { input: Frequency.EVERY_10S, expected: 'Frequency.EVERY_10S\n' },
+      { input: Frequency.EVERY_20S, expected: 'Frequency.EVERY_20S\n' },
+      { input: Frequency.EVERY_30S, expected: 'Frequency.EVERY_30S\n' },
+      { input: Frequency.EVERY_1M, expected: 'Frequency.EVERY_1M\n' },
+      { input: Frequency.EVERY_2M, expected: 'Frequency.EVERY_2M\n' },
+      { input: Frequency.EVERY_5M, expected: 'Frequency.EVERY_5M\n' },
+      { input: Frequency.EVERY_10M, expected: 'Frequency.EVERY_10M\n' },
+      { input: Frequency.EVERY_15M, expected: 'Frequency.EVERY_15M\n' },
+      { input: Frequency.EVERY_30M, expected: 'Frequency.EVERY_30M\n' },
+      { input: Frequency.EVERY_1H, expected: 'Frequency.EVERY_1H\n' },
+      { input: Frequency.EVERY_2H, expected: 'Frequency.EVERY_2H\n' },
+      { input: Frequency.EVERY_3H, expected: 'Frequency.EVERY_3H\n' },
+      { input: Frequency.EVERY_6H, expected: 'Frequency.EVERY_6H\n' },
+      { input: Frequency.EVERY_12H, expected: 'Frequency.EVERY_12H\n' },
+      { input: Frequency.EVERY_24H, expected: 'Frequency.EVERY_24H\n' },
+    ]
+
+    for (const test of predefined) {
+      const output = new Output()
+      const file = new GeneratedFile('foo.ts')
+      const result = valueForFrequency(file, test.input)
+      result.render(output)
+      expect(output.finalize()).toEqual(test.expected)
+    }
+  })
+
+  it('should generate predefined constants for equivalent values', () => {
+    const predefined = [
+      { input: { frequency: 0, frequencyOffset: 10 }, expected: 'Frequency.EVERY_10S\n' },
+      { input: { frequency: 1 }, expected: 'Frequency.EVERY_1M\n' },
+      { input: { frequency: 720 }, expected: 'Frequency.EVERY_12H\n' },
+    ]
+
+    for (const test of predefined) {
+      const output = new Output()
+      const file = new GeneratedFile('foo.ts')
+      const result = valueForFrequency(file, test.input)
+      result.render(output)
+      expect(output.finalize()).toEqual(test.expected)
+    }
+  })
+
+  it('should ignore frequencyOffset if undefined in predefined value', () => {
+    const predefined = [
+      { input: { frequency: 0, frequencyOffset: 10 }, expected: 'Frequency.EVERY_10S\n' },
+      { input: { frequency: 1, frequencyOffset: 12 }, expected: 'Frequency.EVERY_1M\n' },
+      { input: { frequency: 720, frequencyOffset: 45 }, expected: 'Frequency.EVERY_12H\n' },
+      { input: { frequency: 1440, frequencyOffset: 15 }, expected: 'Frequency.EVERY_24H\n' },
+    ]
+
+    for (const test of predefined) {
+      const output = new Output()
+      const file = new GeneratedFile('foo.ts')
+      const result = valueForFrequency(file, test.input)
+      result.render(output)
+      expect(output.finalize()).toEqual(test.expected)
+    }
+  })
+
+  it('should generate constructor call for non-predefined values', () => {
+    const predefined = [
+      { input: { frequency: 123 }, expected: 'new Frequency(123)\n' },
+      { input: { frequency: 123, frequencyOffset: 456 }, expected: 'new Frequency(123, 456)\n' },
+    ]
+
+    for (const test of predefined) {
+      const output = new Output()
+      const file = new GeneratedFile('foo.ts')
+      const result = valueForFrequency(file, test.input)
+      result.render(output)
+      expect(output.finalize()).toEqual(test.expected)
+    }
+  })
+
+  it('should generate predefined constants for equivalent number value', () => {
+    const predefined = [
+      { input: 1, expected: 'Frequency.EVERY_1M\n' },
+      { input: 5, expected: 'Frequency.EVERY_5M\n' },
+      { input: 1440, expected: 'Frequency.EVERY_24H\n' },
+    ]
+
+    for (const test of predefined) {
+      const output = new Output()
+      const file = new GeneratedFile('foo.ts')
+      const result = valueForFrequency(file, test.input)
+      result.render(output)
+      expect(output.finalize()).toEqual(test.expected)
+    }
+  })
+})

--- a/packages/cli/src/constructs/check-codegen.ts
+++ b/packages/cli/src/constructs/check-codegen.ts
@@ -26,7 +26,8 @@ export interface CheckResource {
   shouldFail?: boolean
   locations?: string[]
   tags?: string[]
-  frequency?: FrequencyResource
+  frequency?: number | FrequencyResource
+  frequencyOffset?: number
   groupId?: number
   alertSettings?: AlertEscalationResource
   testOnly?: boolean
@@ -106,7 +107,14 @@ export function buildCheckProps (
   }
 
   if (resource.frequency !== undefined) {
-    builder.value('frequency', valueForFrequency(genfile, resource.frequency))
+    if (typeof resource.frequency === 'number') {
+      builder.value('frequency', valueForFrequency(genfile, {
+        frequency: resource.frequency,
+        frequencyOffset: resource.frequencyOffset,
+      }))
+    } else {
+      builder.value('frequency', valueForFrequency(genfile, resource.frequency))
+    }
   }
 
   if (resource.groupId) {

--- a/packages/cli/src/constructs/check-group-codegen.ts
+++ b/packages/cli/src/constructs/check-group-codegen.ts
@@ -30,9 +30,15 @@ export interface CheckGroupResource {
   locations?: string[]
   tags?: string[]
   concurrency?: number
+  // This is a virtual property that doesn't exist in the backend. However,
+  // it may be useful for advanced purposes in the CLI.
   frequency?: FrequencyResource
   environmentVariables?: EnvironmentVariable[]
+  // This is a virtual property that doesn't exist in the backend. However,
+  // it may be useful for advanced purposes in the CLI.
   browserChecks?: BrowserCheckConfigResource
+  // This is a virtual property that doesn't exist in the backend. However,
+  // it may be useful for advanced purposes in the CLI.
   multiStepChecks?: MultiStepCheckConfigResource
   alertSettings?: AlertEscalationResource | null
   useGlobalAlertSettings?: boolean | null

--- a/packages/cli/src/constructs/frequency-codegen.ts
+++ b/packages/cli/src/constructs/frequency-codegen.ts
@@ -1,11 +1,18 @@
-import { expr, GeneratedFile, ident, NumberValue, Value } from '../sourcegen'
+import { expr, GeneratedFile, ident, Value } from '../sourcegen'
 import { Frequency } from './frequency'
 
-export type FrequencyResource = Frequency | number
+interface FrequencyLike {
+  frequency: number
+  frequencyOffset?: number
+}
+
+export type FrequencyResource = FrequencyLike | number
 
 export function valueForFrequency (genfile: GeneratedFile, frequency: FrequencyResource): Value {
   if (typeof frequency === 'number') {
-    return new NumberValue(frequency)
+    return valueForFrequency(genfile, {
+      frequency: frequency,
+    })
   }
 
   genfile.namedImport('Frequency', 'checkly/constructs')
@@ -33,8 +40,12 @@ export function valueForFrequency (genfile: GeneratedFile, frequency: FrequencyR
       continue
     }
 
-    if (frequency.frequencyOffset !== definition.frequencyOffset) {
-      continue
+    // If the definition has no offset, a random value has almost certainly
+    // been generated for it. Just ignore the offset.
+    if (definition.frequencyOffset !== undefined) {
+      if (frequency.frequencyOffset !== definition.frequencyOffset) {
+        continue
+      }
     }
 
     return expr(ident('Frequency'), builder => {


### PR DESCRIPTION
Values returned from the backend are always numbers, which meant that we always generated a number instead of one of the predefined constants. Now we always use the constants instead.

This affects the examples generated for the rules file. I checked that they now use the predefined constants as intended.

## Affected Components
* [x] CLI
* [ ] Create CLI
* [x] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
