### PR TITLE
fix: the RetryStrategyBuilder now applies the onlyOn condition properly [sc-24520]

### DIFF
--- a/packages/cli/src/constructs/retry-strategy.ts
+++ b/packages/cli/src/constructs/retry-strategy.ts
@@ -162,6 +162,7 @@ export class RetryStrategyBuilder {
       maxRetries: options?.maxRetries ?? RetryStrategyBuilder.DEFAULT_MAX_RETRIES,
       maxDurationSeconds: options?.maxDurationSeconds ?? RetryStrategyBuilder.DEFAULT_MAX_DURATION_SECONDS,
       sameRegion: options?.sameRegion ?? RetryStrategyBuilder.DEFAULT_SAME_REGION,
+      onlyOn: options?.onlyOn,
     }
   }
 }


### PR DESCRIPTION
Unfortunately the `onlyOn` property was not applied correctly when used with the `RetryStrategyBuilder`. It only worked if used manually without the builder.

We should add tests for the builder.

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
