### PR TITLE
fix: keep validation chain intact when inheriting from constructs [sc-25009]

### DIFF
--- a/packages/cli/src/constructs/api-check.ts
+++ b/packages/cli/src/constructs/api-check.ts
@@ -236,6 +236,8 @@ export class ApiCheck extends RuntimeCheck {
   }
 
   async validate (diagnostics: Diagnostics): Promise<void> {
+    await super.validate(diagnostics)
+
     if (this.setupScript) {
       if (!isEntrypoint(this.setupScript) && !isContent(this.setupScript)) {
         diagnostics.add(new InvalidPropertyValueDiagnostic(

--- a/packages/cli/src/constructs/browser-check.ts
+++ b/packages/cli/src/constructs/browser-check.ts
@@ -125,6 +125,8 @@ export class BrowserCheck extends RuntimeCheck {
   }
 
   async validate (diagnostics: Diagnostics): Promise<void> {
+    await super.validate(diagnostics)
+
     if (!isEntrypoint(this.code) && !isContent(this.code)) {
       diagnostics.add(new InvalidPropertyValueDiagnostic(
         'code',

--- a/packages/cli/src/constructs/check-group-v1.ts
+++ b/packages/cli/src/constructs/check-group-v1.ts
@@ -371,6 +371,8 @@ export class CheckGroupV1 extends Construct {
   }
 
   async validate (diagnostics: Diagnostics): Promise<void> {
+    await super.validate(diagnostics)
+
     await this.onBeforeValidate(diagnostics)
 
     await this.validateDoubleCheck(diagnostics)

--- a/packages/cli/src/constructs/dashboard.ts
+++ b/packages/cli/src/constructs/dashboard.ts
@@ -278,6 +278,8 @@ export class Dashboard extends Construct {
   }
 
   async validate (diagnostics: Diagnostics): Promise<void> {
+    await super.validate(diagnostics)
+
     if (!this.customUrl && !this.customDomain) {
       diagnostics.add(new InvalidPropertyValueDiagnostic(
         'customUrl',

--- a/packages/cli/src/constructs/multi-step-check.ts
+++ b/packages/cli/src/constructs/multi-step-check.ts
@@ -55,6 +55,8 @@ export class MultiStepCheck extends RuntimeCheck {
   }
 
   async validate (diagnostics: Diagnostics): Promise<void> {
+    await super.validate(diagnostics)
+
     if (!isEntrypoint(this.code) && !isContent(this.code)) {
       diagnostics.add(new InvalidPropertyValueDiagnostic(
         'code',

--- a/packages/cli/src/constructs/playwright-check.ts
+++ b/packages/cli/src/constructs/playwright-check.ts
@@ -57,6 +57,8 @@ export class PlaywrightCheck extends RuntimeCheck {
   }
 
   async validate (diagnostics: Diagnostics): Promise<void> {
+    await super.validate(diagnostics)
+
     try {
       await fs.access(this.playwrightConfigPath, fs.constants.R_OK)
     } catch (err: any) {

--- a/packages/cli/src/constructs/private-location.ts
+++ b/packages/cli/src/constructs/private-location.ts
@@ -108,6 +108,8 @@ export class PrivateLocation extends Construct {
   }
 
   async validate (diagnostics: Diagnostics): Promise<void> {
+    await super.validate(diagnostics)
+
     if (!RE_SLUG.test(this.slugName)) {
       diagnostics.add(new InvalidPropertyValueDiagnostic(
         'slugName',

--- a/packages/cli/src/constructs/project.ts
+++ b/packages/cli/src/constructs/project.ts
@@ -93,6 +93,8 @@ export class Project extends Construct {
   }
 
   async validate (diagnostics: Diagnostics): Promise<void> {
+    await super.validate(diagnostics)
+
     if (!this.name) {
       diagnostics.add(new InvalidPropertyValueDiagnostic(
         'name',


### PR DESCRIPTION
Some constructs did not call `super.validate()` in their own `validate()` method like they should have.

The impact of this mishap is that `ApiCheck`, `BrowserCheck`, `MultiStepCheck` and `PlaywrightCheck` did not show a deprecation notice for the `doubleCheck` property like they should have. Other constructs directly inherit from Construct which has a no-op `validate()` method, so there was no impact, but it's good to have it fully operational either way.

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
