### PR TITLE
feat: validate that onlyOn: NETWORK_ERROR is only used with ApiCheck/UrlMonitor [sc-24520]

### DIFF
--- a/packages/cli/src/constructs/api-check.ts
+++ b/packages/cli/src/constructs/api-check.ts
@@ -235,6 +235,10 @@ export class ApiCheck extends RuntimeCheck {
     return `ApiCheck:${this.logicalId}`
   }
 
+  protected supportsOnlyOnNetworkErrorRetryStrategy (): boolean {
+    return true
+  }
+
   async validate (diagnostics: Diagnostics): Promise<void> {
     await super.validate(diagnostics)
 

--- a/packages/cli/src/constructs/check.ts
+++ b/packages/cli/src/constructs/check.ts
@@ -287,6 +287,13 @@ export abstract class Check extends Construct {
             ),
           ))
         }
+      } else {
+        diagnostics.add(new InvalidPropertyValueDiagnostic(
+          'retryStrategy',
+          new Error(
+            `Unsupported value "${this.retryStrategy.onlyOn}" for "onlyOn".`,
+          ),
+        ))
       }
     }
   }

--- a/packages/cli/src/constructs/retry-strategy.ts
+++ b/packages/cli/src/constructs/retry-strategy.ts
@@ -64,6 +64,10 @@ export interface RetryStrategy {
   /**
    * Apply the retry strategy only if the cause of the failure matches the
    * given condition. Otherwise, do not retry.
+   *
+   * The following conditions are supported:
+   * - NETWORK_ERROR: Retry only if the failure was caused by a network error.
+   *   Available with the {@link ApiCheck} and {@link UrlMonitor} constructs.
    */
   onlyOn?: RetryStrategyCondition,
 }

--- a/packages/cli/src/constructs/url-monitor.ts
+++ b/packages/cli/src/constructs/url-monitor.ts
@@ -132,6 +132,10 @@ export class UrlMonitor extends Monitor {
     return `UrlMonitor:${this.logicalId}`
   }
 
+  protected supportsOnlyOnNetworkErrorRetryStrategy (): boolean {
+    return true
+  }
+
   async validate (diagnostics: Diagnostics): Promise<void> {
     await super.validate(diagnostics)
 


### PR DESCRIPTION
Using `RetryStrategy.onlyOn` with checks/monitors other than `ApiCheck`/`UrlMonitor` will now produce the following validation error:

```
✖ [TcpMonitor:tcpsample-1] Invalid property value

  The value provided for property "retryStrategy" is not valid.

  Reason: Using "NETWORK_ERROR" with "onlyOn" is only supported in the
  ApiCheck and UrlMonitor constructs.

✖ [BrowserCheck:browsersample-1] Invalid property value

  The value provided for property "retryStrategy" is not valid.

  Reason: Using "NETWORK_ERROR" with "onlyOn" is only supported in the
  ApiCheck and UrlMonitor constructs.
```

Also, using any other value for `onlyOn` will produce the following error (in addition to TypeScript showing an error):

```
✖ [BrowserCheck:browsersample-1] Invalid property value

  The value provided for property "retryStrategy" is not valid.

  Reason: Unsupported value "FOO" for "onlyOn".
```

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
