### PR TITLE
fix: the Dashboard customCSS property did not work [sc-25191]

### DIFF
--- a/packages/cli/src/constructs/__tests__/dashboard.spec.ts
+++ b/packages/cli/src/constructs/__tests__/dashboard.spec.ts
@@ -1,0 +1,43 @@
+import path from 'node:path'
+
+import { describe, it, expect } from 'vitest'
+
+import { Dashboard } from '../index'
+import { Project, Session } from '../project'
+
+describe('Dashboard', () => {
+  describe('customCSS', () => {
+    it(`should synthesize 'entrypoint'`, async () => {
+      const getFilePath = (filename: string) => path.join(__dirname, 'fixtures', 'dashboard', filename)
+      Session.project = new Project('project-id', {
+        name: 'Test Project',
+        repoUrl: 'https://github.com/checkly/checkly-cli',
+      })
+      const dashboard = new Dashboard('test-dashboard', {
+        customCSS: {
+          entrypoint: getFilePath('custom.css'),
+        },
+      })
+      const bundle = await dashboard.bundle()
+      expect(bundle.synthesize()).toMatchObject({
+        customCSS: '/* legit CSS */',
+      })
+    })
+
+    it(`should synthesize 'content'`, async () => {
+      Session.project = new Project('project-id', {
+        name: 'Test Project',
+        repoUrl: 'https://github.com/checkly/checkly-cli',
+      })
+      const dashboard = new Dashboard('test-dashboard', {
+        customCSS: {
+          content: 'foo',
+        },
+      })
+      const bundle = await dashboard.bundle()
+      expect(bundle.synthesize()).toMatchObject({
+        customCSS: 'foo',
+      })
+    })
+  })
+})

--- a/packages/cli/src/constructs/__tests__/fixtures/dashboard/custom.css
+++ b/packages/cli/src/constructs/__tests__/fixtures/dashboard/custom.css
@@ -1,0 +1,1 @@
+/* legit CSS */

--- a/packages/cli/src/constructs/dashboard.ts
+++ b/packages/cli/src/constructs/dashboard.ts
@@ -269,6 +269,7 @@ export class Dashboard extends Construct {
     this.isPrivate = props.isPrivate
     this.showP95 = props.showP95
     this.showP99 = props.showP99
+    this.customCSS = props.customCSS
 
     Session.registerConstruct(this)
   }


### PR DESCRIPTION
The `customCSS` property of `Dashboard` was accidentally lost in #1079. This PR adds it back along with tests to make sure we don't lose it again.

## Affected Components
* [x] CLI
* [ ] Create CLI
* [x] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
