### PR TITLE
fix: test report for UrlMonitor now shows details on failure like ApiCheck does [sc-25192]

### DIFF
--- a/packages/cli/src/reporters/util.ts
+++ b/packages/cli/src/reporters/util.ts
@@ -69,7 +69,7 @@ export function formatCheckTitle (
 
 export function formatCheckResult (checkResult: any) {
   const result = []
-  if (checkResult.checkType === 'API') {
+  if (checkResult.checkType === 'API' || checkResult.checkType === 'URL') {
     // Order should follow the check lifecycle (response, then assertions)
     if (checkResult.checkRunData?.requestError) {
       result.push([


### PR DESCRIPTION
This was forgotten in #1093. UrlMonitor will now show the HTTP request, HTTP response and assertions on failure.

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
