### PR TITLE
fix: update Checkly AI rules for UrlAssertionbuilder

### DIFF
--- a/packages/cli/src/rules/checkly.rules.template.md
+++ b/packages/cli/src/rules/checkly.rules.template.md
@@ -93,7 +93,7 @@ The `checkly.config.ts` at the root of your project defines a range of defaults 
 
 - Import the `UrlMonitor` construct from `checkly/constructs`.
 - Reference [the docs for URL monitors](https://www.checklyhq.com/docs/cli/constructs-reference/#urlmonitor) before generating any code.
-- When adding `assertions`, always use `AssertionBuilder` class which is [documented here](https://www.checklyhq.com/docs/cli/constructs-reference/#assertionbuilder)
+- When adding `assertions`, always use `UrlAssertionBuilder` class which is [documented here](https://www.checklyhq.com/docs/cli/constructs-reference/#urlassertionbuilder)
 
 ```typescript
 // INSERT URL MONITOR EXAMPLE HERE //


### PR DESCRIPTION
## Affected Components
* [ ] CLI
* [ ] Create CLI
* [ ] Test
* [x] Docs
* [ ] Examples
* [ ] Other

## Notes for the Reviewer

This PR relies on [this one](https://github.com/checkly/docs.checklyhq.com/pull/1341). While preparing for a webinar, I noticed that AI gets confused about `UrlMonitor` setups. I hope this fixes it.