### PR TITLE
feat: add better handling for API errors [sc-25199]

### DIFF
--- a/packages/cli/e2e/__tests__/env/env.add.spec.ts
+++ b/packages/cli/e2e/__tests__/env/env.add.spec.ts
@@ -38,7 +38,7 @@ describe('checkly env add', () => {
       accountId: config.get('accountId'),
       directory: path.join(__dirname, '../fixtures/check-parse-error'),
     })
-    expect(result.stdout).toContain(`Environment variable testenvvars-${executionId} added.`)
+    expect(result.stdout).toContain(`Environment variable "testenvvars-${executionId}" added.`)
   })
 
   it('should add a new locked env variable called testenvvars', async () => {
@@ -48,7 +48,7 @@ describe('checkly env add', () => {
       accountId: config.get('accountId'),
       directory: path.join(__dirname, '../fixtures/check-parse-error'),
     })
-    expect(result.stdout).toContain(`Environment variable testenvvarslocked-${executionId} added.`)
+    expect(result.stdout).toContain(`Environment variable "testenvvarslocked-${executionId}" added.`)
   })
 
   it('should add fail because env variable called testenvvars exists', async () => {
@@ -66,6 +66,6 @@ describe('checkly env add', () => {
       directory: path.join(__dirname, '../fixtures/check-parse-error'),
       timeout: 10000,
     })
-    expect(result.stderr).toContain(`Environment variable testenvvarslocked-${executionId} already exists.`)
+    expect(result.stdout).toContain(`Environment variable "testenvvarslocked-${executionId}" already exists.`)
   })
 })

--- a/packages/cli/e2e/__tests__/env/env.rm.spec.ts
+++ b/packages/cli/e2e/__tests__/env/env.rm.spec.ts
@@ -39,7 +39,7 @@ describe('checkly env rm', () => {
       directory: path.join(__dirname, '../fixtures/check-parse-error'),
     })
     // expect that 'testenvvars' is in the output
-    expect(result.stdout).toContain(`Environment variable testenvvarsrm-${executionId} deleted.`)
+    expect(result.stdout).toContain(`Environment variable "testenvvarsrm-${executionId}" deleted.`)
   })
 
   it('should ask for permision to remove the testenvvarsrm env variable', async () => {
@@ -63,6 +63,6 @@ describe('checkly env rm', () => {
       directory: path.join(__dirname, '../fixtures/check-parse-error'),
     })
     // expect that 'testenvvars' does not exist
-    expect(result.stderr).toContain(`Environment variable testenvvarsrm-${executionId} does not exist.`)
+    expect(result.stdout).toContain(`Environment variable "testenvvarsrm-${executionId}" does not exist.`)
   })
 })

--- a/packages/cli/e2e/__tests__/env/env.upate.spec.ts
+++ b/packages/cli/e2e/__tests__/env/env.upate.spec.ts
@@ -36,6 +36,6 @@ describe('checkly env update', () => {
       directory: path.join(__dirname, '../fixtures/check-parse-error'),
     })
     // expect that 'testenvvarsUpdate' is in the output
-    expect(result.stdout).toContain(`Environment variable testenvvarsUpdate-${executionId} updated.`)
+    expect(result.stdout).toContain(`Environment variable "testenvvarsUpdate-${executionId}" updated.`)
   })
 })

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -212,11 +212,8 @@ export default class Deploy extends AuthCommand {
         })
       }
     } catch (err: any) {
-      if (err?.response?.status === 400) {
-        throw new Error(`Failed to deploy your project due to wrong configuration. ${err.response.data?.message}`)
-      } else {
-        throw new Error(`Failed to deploy your project. ${err.message}`)
-      }
+      this.style.longError(`Your project could not be deployed.`, err)
+      this.exit(1)
     }
   }
 

--- a/packages/cli/src/commands/destroy.ts
+++ b/packages/cli/src/commands/destroy.ts
@@ -43,11 +43,8 @@ export default class Destroy extends AuthCommand {
       await api.projects.deleteProject(checklyConfig.logicalId)
       this.log(`All resources associated with project "${checklyConfig.projectName}" have been successfully deleted.`)
     } catch (err: any) {
-      if (err?.response?.status === 400) {
-        throw new Error(`Failed to destroy your project: ${err.response.data?.message}`)
-      } else {
-        throw new Error(`Failed to destroy your project. ${err.message}`)
-      }
+      this.style.longError(`Your project could not be destroyed.`, err)
+      this.exit(1)
     }
   }
 }

--- a/packages/cli/src/commands/env/add.ts
+++ b/packages/cli/src/commands/env/add.ts
@@ -54,15 +54,13 @@ export default class EnvAdd extends AuthCommand {
     }
     try {
       await api.environmentVariables.add(envVariableName, envValue, locked, secret)
-      this.log(secret
-        ? `Secret environment variable ${envVariableName} added.`
-        : `Environment variable ${envVariableName} added.`,
+      this.style.shortSuccess(secret
+        ? `Secret environment variable "${envVariableName}" added.`
+        : `Environment variable "${envVariableName}" added.`,
       )
     } catch (err: any) {
-      if (err?.response?.status === 409) {
-        throw new Error(`Environment variable ${envVariableName} already exists.`)
-      }
-      throw err
+      this.style.longError(`Your environment variable could not be added.`, err)
+      this.exit(1)
     }
   }
 }

--- a/packages/cli/src/commands/env/rm.ts
+++ b/packages/cli/src/commands/env/rm.ts
@@ -40,16 +40,12 @@ export default class EnvRm extends AuthCommand {
       }
     }
 
-    // try to delete env variable catch 404 if env variable does not exist
     try {
       await api.environmentVariables.delete(envVariableKey)
-      this.log(`Environment variable ${envVariableKey} deleted.`)
+      this.style.shortSuccess(`Environment variable "${envVariableKey}" deleted.`)
     } catch (err: any) {
-      if (err?.response?.status === 404) {
-        throw new Error(`Environment variable ${envVariableKey} does not exist.`)
-      } else {
-        throw new Error(`Failed to delete environment variable. ${err.message}`)
-      }
+      this.style.longError(`Your environment variable could not be removed.`, err)
+      this.exit(1)
     }
   }
 }

--- a/packages/cli/src/commands/env/update.ts
+++ b/packages/cli/src/commands/env/update.ts
@@ -54,20 +54,13 @@ export default class EnvUpdate extends AuthCommand {
     }
     try {
       await api.environmentVariables.update(envVariableName, envValue, locked, secret)
-      this.log(secret
-        ? `Secret environment variable ${envVariableName} updated.`
-        : `Environment variable ${envVariableName} updated.`,
+      this.style.shortSuccess(secret
+        ? `Secret environment variable "${envVariableName}" updated.`
+        : `Environment variable "${envVariableName}" updated.`,
       )
     } catch (err: any) {
-      if (err?.response?.status === 400 && err?.response?.data?.message) {
-        throw new Error(err.response.data.message)
-      }
-
-      if (err?.response?.status === 404) {
-        throw new Error(`Environment variable ${envVariableName} not found.`)
-      }
-
-      throw err
+      this.style.longError(`Your environment variable could not be updated.`, err)
+      this.exit(1)
     }
   }
 }

--- a/packages/cli/src/commands/trigger.ts
+++ b/packages/cli/src/commands/trigger.ts
@@ -6,7 +6,7 @@ import { AuthCommand } from './authCommand'
 import { loadChecklyConfig } from '../services/checkly-config-loader'
 import { splitConfigFilePath, getEnvs, getGitInformation, getCiInformation } from '../services/util'
 import type { Region } from '..'
-import TriggerRunner, { NoMatchingChecksError } from '../services/trigger-runner'
+import TriggerRunner from '../services/trigger-runner'
 import {
   RunLocation,
   Events,
@@ -17,7 +17,7 @@ import {
 import config from '../services/config'
 import { createReporters, ReporterType } from '../reporters/reporter'
 import { printLn } from '../reporters/util'
-import { TestResultsShortLinks } from '../rest/test-sessions'
+import { NoMatchingChecksError, TestResultsShortLinks } from '../rest/test-sessions'
 import { Session, RetryStrategyBuilder } from '../constructs'
 import { DEFAULT_REGION } from '../helpers/constants'
 

--- a/packages/cli/src/helpers/command-style.ts
+++ b/packages/cli/src/helpers/command-style.ts
@@ -5,9 +5,14 @@ import { BaseCommand } from '../commands/baseCommand'
 import { wrap } from './wrap'
 import logSymbols from 'log-symbols'
 
-const wrapOptions = {
+const textWrapOptions = {
   prefix: '  ',
   length: 78,
+}
+
+const errorWrapOptions = {
+  ...textWrapOptions,
+  length: Infinity,
 }
 
 export class CommandStyle {
@@ -38,14 +43,14 @@ export class CommandStyle {
   }
 
   comment (message: string) {
-    this.c.log(chalk.cyan(wrap(message, { ...wrapOptions, prefix: '// ' })))
+    this.c.log(chalk.cyan(wrap(message, { ...textWrapOptions, prefix: '// ' })))
     this.c.log()
   }
 
   longSuccess (title: string, message: string) {
     this.c.log(`${logSymbols.success} ${title}`)
     this.c.log()
-    this.c.log(wrap(message, wrapOptions))
+    this.c.log(wrap(message, textWrapOptions))
     this.c.log()
   }
 
@@ -57,7 +62,7 @@ export class CommandStyle {
   longInfo (title: string, message: string) {
     this.c.log(`${logSymbols.info} ${title}`)
     this.c.log()
-    this.c.log(wrap(message, wrapOptions))
+    this.c.log(wrap(message, textWrapOptions))
     this.c.log()
   }
 
@@ -66,10 +71,10 @@ export class CommandStyle {
     this.c.log()
   }
 
-  longWarning (title: string, message: string) {
+  longWarning (title: string, message: string | Error) {
     this.c.log(`${logSymbols.warning} ${title}`)
     this.c.log()
-    this.c.log(chalk.yellow(wrap(message, wrapOptions)))
+    this.c.log(chalk.yellow(this.#formatDescription(message)))
     this.c.log()
   }
 
@@ -78,10 +83,10 @@ export class CommandStyle {
     this.c.log()
   }
 
-  longError (title: string, message: string) {
+  longError (title: string, message: string | Error) {
     this.c.log(`${logSymbols.error} ${title}`)
     this.c.log()
-    this.c.log(chalk.red(wrap(message, wrapOptions)))
+    this.c.log(chalk.red(this.#formatDescription(message)))
     this.c.log()
   }
 
@@ -93,5 +98,15 @@ export class CommandStyle {
   fatal (message: string) {
     this.c.log(chalk.red(message))
     this.c.log()
+  }
+
+  #formatDescription (description: string | Error) {
+    if (typeof description === 'string') {
+      return wrap(description, textWrapOptions)
+    }
+
+    const { message } = description
+
+    return wrap(message, errorWrapOptions)
   }
 }

--- a/packages/cli/src/rest/environment-variables.ts
+++ b/packages/cli/src/rest/environment-variables.ts
@@ -1,10 +1,37 @@
-import type { AxiosInstance } from 'axios'
+import { type AxiosInstance } from 'axios'
+import { ConflictError, NotFoundError } from './errors'
 
 export interface EnvironmentVariable {
   key: string
   value: string
   locked: boolean
   secret?: boolean
+}
+
+/**
+ * Error thrown when the requested environment variable does not exist.
+ */
+export class EnvironmentVariableNotFoundError extends Error {
+  environmentVariable: string
+
+  constructor (environmentVariable: string, options?: ErrorOptions) {
+    super(`Environment variable "${environmentVariable}" does not exist.`, options)
+    this.name = 'EnvironmentVariableNotFoundError'
+    this.environmentVariable = environmentVariable
+  }
+}
+
+/**
+ * Error thrown when the requested environment variable already exists.
+ */
+export class EnvironmentVariableAlreadyExistsError extends Error {
+  environmentVariable: string
+
+  constructor (environmentVariable: string, options?: ErrorOptions) {
+    super(`Environment variable "${environmentVariable}" already exists.`, options)
+    this.name = 'EnvironmentVariableAlreadyExistsError'
+    this.environmentVariable = environmentVariable
+  }
 }
 
 class EnvironmentVariables {
@@ -17,21 +44,65 @@ class EnvironmentVariables {
     return this.api.get<Array<EnvironmentVariable>>('/v1/variables')
   }
 
-  delete (environmentVariableKey: string) {
-    return this.api.delete(`/v1/variables/${environmentVariableKey}`)
+  /**
+   * @throws {EnvironmentVariableNotFoundError} If the environment variable does not exist.
+   */
+  async delete (environmentVariableKey: string) {
+    try {
+      return await this.api.delete(`/v1/variables/${environmentVariableKey}`)
+    } catch (err: any) {
+      if (err instanceof NotFoundError) {
+        throw new EnvironmentVariableNotFoundError(environmentVariableKey)
+      }
+
+      throw err
+    }
   }
 
-  add (environmentVariableKey: string, environmentVariableValue: string, locked = false, secret = false) {
-    return this.api.post('/v1/variables', { key: environmentVariableKey, value: environmentVariableValue, locked, secret })
+  /**
+   * @throws {EnvironmentVariableAlreadyExistsError} If the environment variable already exists.
+   */
+  async add (environmentVariableKey: string, environmentVariableValue: string, locked = false, secret = false) {
+    try {
+      return await this.api.post('/v1/variables', { key: environmentVariableKey, value: environmentVariableValue, locked, secret })
+    } catch (err: any) {
+      if (err instanceof ConflictError) {
+        throw new EnvironmentVariableAlreadyExistsError(environmentVariableKey)
+      }
+
+      throw err
+    }
   }
 
-  get (environmentVariableKey: string) {
-    return this.api.get<EnvironmentVariable>(`/v1/variables/${environmentVariableKey}`)
+  /**
+   * @throws {EnvironmentVariableNotFoundError} If the environment variable does not exist.
+   */
+  async get (environmentVariableKey: string) {
+    try {
+      return await this.api.get<EnvironmentVariable>(`/v1/variables/${environmentVariableKey}`)
+    } catch (err: any) {
+      if (err instanceof NotFoundError) {
+        throw new EnvironmentVariableNotFoundError(environmentVariableKey)
+      }
+
+      throw err
+    }
   }
 
+  /**
+   * @throws {EnvironmentVariableNotFoundError} If the environment variable does not exist.
+  */
   // update environment variable with default locked value false
-  update (environmentVariableKey: string, environmentVariableValue: string, locked = false, secret = false) {
-    return this.api.put(`/v1/variables/${environmentVariableKey}`, { value: environmentVariableValue, locked, secret })
+  async update (environmentVariableKey: string, environmentVariableValue: string, locked = false, secret = false) {
+    try {
+      return await this.api.put(`/v1/variables/${environmentVariableKey}`, { value: environmentVariableValue, locked, secret })
+    } catch (err: any) {
+      if (err instanceof NotFoundError) {
+        throw new EnvironmentVariableNotFoundError(environmentVariableKey)
+      }
+
+      throw err
+    }
   }
 }
 

--- a/packages/cli/src/rest/errors.ts
+++ b/packages/cli/src/rest/errors.ts
@@ -1,0 +1,287 @@
+import { isAxiosError } from 'axios'
+
+export abstract class ApiError extends Error {
+  data: ErrorData
+
+  constructor (data: ErrorData, options?: ErrorOptions) {
+    super(data.message, options)
+    this.name = 'ApiError'
+    this.data = data
+  }
+}
+
+/**
+ * Error thrown when an API response indicates that the request was not valid.
+ */
+export class ValidationError extends ApiError {
+  constructor (data: ErrorData, options?: ErrorOptions) {
+    super(data, options)
+    this.name = 'ValidationError'
+  }
+}
+
+/**
+ * Error thrown when an API response indicates that the request was not
+ * authorized.
+ */
+export class UnauthorizedError extends ApiError {
+  constructor (data: ErrorData, options?: ErrorOptions) {
+    super(data, options)
+    this.name = 'UnauthorizedError'
+  }
+}
+
+/**
+ * Error thrown when an API response indicates that the operation exceeded
+ * the capabilities of the user's payment plan. Examples include:
+ *
+ *   - Using features not included in the user's plan
+ *   - Exceeding the resource limits of the plan
+ */
+export class InadequateEntitlementsError extends ApiError {
+  constructor (data: ErrorData, options?: ErrorOptions) {
+    super(data, options)
+    this.name = 'InadequateEntitlementsError'
+  }
+}
+
+/**
+ * Error thrown when an API response indicates that the requested resource
+ * could not be found.
+ */
+export class NotFoundError extends ApiError {
+  constructor (data: ErrorData, options?: ErrorOptions) {
+    super(data, options)
+    this.name = 'NotFoundError'
+  }
+}
+
+/**
+ * Error thrown when an API response indicates that the request was not
+ * allowed.
+ */
+export class ForbiddenError extends ApiError {
+  constructor (data: ErrorData, options?: ErrorOptions) {
+    super(data, options)
+    this.name = 'ForbiddenError'
+  }
+}
+
+/**
+ * Error thrown when an API response indicates that the request conflicts
+ * with server state.
+ */
+export class ConflictError extends ApiError {
+  constructor (data: ErrorData, options?: ErrorOptions) {
+    super(data, options)
+    this.name = 'ConflictError'
+  }
+}
+
+/**
+ * Error thrown when an API response indicates a server error.
+ */
+export class ServerError extends ApiError {
+  constructor (data: ErrorData, options?: ErrorOptions) {
+    super(data, options)
+    this.name = 'ServerError'
+  }
+}
+
+/**
+ * Error thrown when an API response indicates an error that is not handled
+ * globally.
+ */
+export class MiscellaneousError extends ApiError {
+  constructor (data: ErrorData, options?: ErrorOptions) {
+    super(data, options)
+    this.name = 'MiscellaneousError'
+  }
+}
+
+/**
+ * Error thrown when an API request times out.
+ */
+export class RequestTimeoutError extends ApiError {
+  constructor (data: ErrorData, options?: ErrorOptions) {
+    super(data, options)
+    this.name = 'RequestTimeoutError'
+  }
+}
+
+export interface ErrorData {
+  statusCode: number
+  error: string
+  errorCode?: string
+  message: string
+}
+
+function isErrorData (value: any): value is ErrorData {
+  const o = Object(value)
+  return 'statusCode' in o
+    && 'error' in o
+    && 'message' in o
+}
+
+export interface ErrorDataOptions {
+  statusCode: number
+}
+
+export function parseErrorData (data: any, options: ErrorDataOptions): ErrorData | undefined {
+  if (isErrorData(data)) {
+    return {
+      ...data,
+
+      // Prefer the actual HTTP status code from the options just in case the
+      // payload doesn't match.
+      statusCode: options.statusCode,
+    }
+  }
+
+  if (isErrorOnlyErrorData(data)) {
+    return normalizeErrorOnlyErrorData(data, options)
+  }
+
+  if (isMessageAndErrorCodeErrorData(data)) {
+    return normalizeMessageAndErrorCodeErrorData(data, options)
+  }
+
+  if (isStringErrorData(data)) {
+    return normalizeStringErrorData(data, options)
+  }
+}
+
+interface ErrorOnlyErrorData {
+  error: string
+}
+
+function isErrorOnlyErrorData (value: any): value is ErrorOnlyErrorData {
+  return 'error' in Object(value)
+}
+
+function normalizeErrorOnlyErrorData (
+  data: ErrorOnlyErrorData,
+  { statusCode }: ErrorDataOptions,
+): ErrorData {
+  return {
+    ...data,
+    statusCode,
+    message: data.error,
+  }
+}
+
+interface MessageAndErrorCodeErrorData {
+  message: string
+  errorCode: string
+}
+
+function isMessageAndErrorCodeErrorData (value: any): value is MessageAndErrorCodeErrorData {
+  const o = Object(value)
+  return 'message' in o
+    && 'errorCode' in o
+}
+
+function normalizeMessageAndErrorCodeErrorData (
+  data: MessageAndErrorCodeErrorData,
+  { statusCode }: ErrorDataOptions,
+): ErrorData {
+  return {
+    ...data,
+    statusCode,
+    error: data.message,
+  }
+}
+
+type StringErrorData = string
+
+function isStringErrorData (value: any): value is StringErrorData {
+  return typeof value === 'string'
+}
+
+function normalizeStringErrorData (
+  data: StringErrorData,
+  { statusCode }: ErrorDataOptions,
+): ErrorData {
+  return {
+    statusCode,
+    error: data,
+    message: data,
+  }
+}
+
+/**
+ * Error thrown when an API request unexpectedly produces no response.
+ */
+export class MissingResponseError extends Error {
+  constructor (options: ErrorOptions) {
+    super(
+      `Encountered an error connecting to Checkly. Please check that `
+      + `the internet connection is working.`
+      + `\n\n`
+      + `Details: ${options.cause}`,
+      options,
+    )
+    this.name = 'MissingResponseError'
+  }
+}
+
+export function handleErrorResponse (err: Error): never {
+  if (isAxiosError(err)) {
+    if (!err.response) {
+      throw new MissingResponseError({ cause: err })
+    }
+
+    const { status: statusCode, data } = err.response
+
+    const errorData = parseErrorData(data, {
+      statusCode,
+    })
+
+    if (errorData !== undefined) {
+      if (statusCode === 400) {
+        throw new ValidationError(errorData, { cause: err })
+      }
+
+      if (statusCode === 401) {
+        throw new UnauthorizedError(errorData, { cause: err })
+      }
+
+      if (statusCode === 402) {
+        throw new InadequateEntitlementsError(errorData, { cause: err })
+      }
+
+      if (statusCode === 403) {
+        throw new ForbiddenError(errorData, { cause: err })
+      }
+
+      if (statusCode === 404) {
+        throw new NotFoundError(errorData, { cause: err })
+      }
+
+      if (statusCode === 408) {
+        throw new RequestTimeoutError(errorData, { cause: err })
+      }
+
+      if (statusCode === 409) {
+        throw new ConflictError(errorData, { cause: err })
+      }
+
+      if (statusCode >= 500) {
+        throw new ServerError(errorData, { cause: err })
+      }
+
+      throw new MiscellaneousError(errorData, { cause: err })
+    }
+
+    if (statusCode === 408) {
+      throw new RequestTimeoutError({
+        statusCode,
+        error: 'Request Timeout',
+        message: 'Encountered an error connecting to Checkly. '
+          + 'This can be triggered by a slow internet connection or a network with high packet loss.',
+      })
+    }
+  }
+
+  throw err
+}

--- a/packages/cli/src/rest/projects.ts
+++ b/packages/cli/src/rest/projects.ts
@@ -1,7 +1,8 @@
-import { isAxiosError, type AxiosInstance } from 'axios'
+import { type AxiosInstance } from 'axios'
 import type { GitInformation } from '../services/util'
 import { compressJSONPayload } from './util'
 import { SharedFile } from '../constructs'
+import { ConflictError, ForbiddenError, NotFoundError } from './errors'
 
 export interface Project {
   name: string
@@ -107,7 +108,46 @@ export interface ImportPlan {
   changes?: ImportPlanChanges
 }
 
-export class ProjectNotFoundError extends Error {}
+export class ProjectNotFoundError extends Error {
+  logicalId: string
+
+  constructor (logicalId: string, options?: ErrorOptions) {
+    super(`Project "${logicalId}" does not exist.`, options)
+    this.name = 'ProjectNotFoundError'
+    this.logicalId = logicalId
+  }
+}
+
+export class ProjectAlreadyExistsError extends Error {
+  logicalId: string
+
+  constructor (logicalId: string, options?: ErrorOptions) {
+    super(`You are already using the logicalId "${logicalId}" for a different project.`, options)
+    this.name = 'ProjectAlreadyExistsError'
+    this.logicalId = logicalId
+  }
+}
+
+export class NoImportableResourcesFoundError extends Error {
+  constructor (options?: ErrorOptions) {
+    super(`No importable resources were found.`, options)
+    this.name = 'NoImportableResourcesFoundError'
+  }
+}
+
+export class ImportPlanNotFoundError extends Error {
+  constructor (options?: ErrorOptions) {
+    super(`Import plan does not exist.`, options)
+    this.name = 'ImportPlanNotFoundError'
+  }
+}
+
+export class InvalidImportPlanStateError extends Error {
+  constructor (options?: ErrorOptions) {
+    super(`Invalid state for import plan.`, options)
+    this.name = 'InvalidImportPlanStateError'
+  }
+}
 
 class Projects {
   api: AxiosInstance
@@ -119,34 +159,47 @@ class Projects {
     return this.api.get<Array<ProjectResponse>>('/next/projects')
   }
 
+  /**
+   * @throws {ProjectNotFoundError} If the project does not exist.
+   */
   async get (logicalId: string) {
     try {
       const logicalIdParam = encodeURIComponent(logicalId)
       return await this.api.get<ProjectResponse>(`/next/projects/${logicalIdParam}`)
     } catch (err) {
-      if (isAxiosError(err)) {
-        if (err.response?.status === 404) {
-          throw new ProjectNotFoundError()
-        }
+      if (err instanceof NotFoundError) {
+        throw new ProjectNotFoundError(logicalId)
       }
 
       throw err
     }
   }
 
-  create (project: Project) {
-    return this.api.post('/next/projects', project)
+  /**
+   * @throws {ProjectAlreadyExistsError} If the project already exists.
+   */
+  async create (project: Project) {
+    try {
+      return await this.api.post('/next/projects', project)
+    } catch (err) {
+      if (err instanceof ConflictError) {
+        throw new ProjectAlreadyExistsError(project.logicalId)
+      }
+
+      throw err
+    }
   }
 
+  /**
+   * @throws {ProjectNotFoundError} If the project does not exist.
+   */
   async deleteProject (logicalId: string) {
     try {
       const logicalIdParam = encodeURIComponent(logicalId)
       return await this.api.delete(`/next/projects/${logicalIdParam}`)
     } catch (err) {
-      if (isAxiosError(err)) {
-        if (err.response?.status === 404) {
-          throw new ProjectNotFoundError()
-        }
+      if (err instanceof NotFoundError) {
+        throw new ProjectNotFoundError(logicalId)
       }
 
       throw err
@@ -161,19 +214,38 @@ class Projects {
     )
   }
 
+  /**
+   * @throws {ProjectNotFoundError} If the project does not exist.
+   * @throws {NoImportableResourcesFoundError} If no importable resources were found.
+   */
   async createImportPlan (logicalId: string, options?: ImportPlanOptions) {
     const payload = {
       filters: options?.filters,
       friends: options?.friends,
     }
-    const logicalIdParam = encodeURIComponent(logicalId)
-    return await this.api.post<ImportPlan>(`/next/projects/${logicalIdParam}/imports`, payload, {
-      params: {
-        preview: options?.preview ?? false,
-      },
-    })
+    try {
+      const logicalIdParam = encodeURIComponent(logicalId)
+      return await this.api.post<ImportPlan>(`/next/projects/${logicalIdParam}/imports`, payload, {
+        params: {
+          preview: options?.preview ?? false,
+        },
+      })
+    } catch (err) {
+      if (err instanceof NotFoundError) {
+        if (/No importable resources were found/i.test(err.data.message)) {
+          throw new NoImportableResourcesFoundError()
+        }
+
+        throw new ProjectNotFoundError(logicalId)
+      }
+
+      throw err
+    }
   }
 
+  /**
+   * @throws {ProjectNotFoundError} If the project does not exist.
+   */
   async findImportPlans (logicalId: string, { onlyUnapplied = false, onlyUncommitted = false } = {}) {
     try {
       const logicalIdParam = encodeURIComponent(logicalId)
@@ -184,10 +256,8 @@ class Projects {
         },
       })
     } catch (err) {
-      if (isAxiosError(err)) {
-        if (err.response?.status === 404) {
-          throw new ProjectNotFoundError()
-        }
+      if (err instanceof NotFoundError) {
+        throw new ProjectNotFoundError(logicalId)
       }
 
       throw err
@@ -203,16 +273,64 @@ class Projects {
     })
   }
 
-  cancelImportPlan (importPlanId: string) {
-    return this.api.delete<void>(`/next/projects/imports/${importPlanId}`)
+  /**
+   * @throws {ImportPlanNotFoundError} If the import plan does not exist.
+   * @throws {InvalidImportPlanStateError} If the operation is performed out of order.
+   */
+  async cancelImportPlan (importPlanId: string) {
+    try {
+      return await this.api.delete<void>(`/next/projects/imports/${importPlanId}`)
+    } catch (err) {
+      if (err instanceof ForbiddenError) {
+        throw new InvalidImportPlanStateError()
+      }
+
+      if (err instanceof NotFoundError) {
+        throw new ImportPlanNotFoundError()
+      }
+
+      throw err
+    }
   }
 
-  applyImportPlan (importPlanId: string) {
-    return this.api.post<void>(`/next/projects/imports/${importPlanId}/apply`)
+  /**
+   * @throws {ImportPlanNotFoundError} If the import plan does not exist.
+   * @throws {InvalidImportPlanStateError} If the operation is performed out of order.
+   */
+  async applyImportPlan (importPlanId: string) {
+    try {
+      return await this.api.post<void>(`/next/projects/imports/${importPlanId}/apply`)
+    } catch (err) {
+      if (err instanceof ForbiddenError) {
+        throw new InvalidImportPlanStateError()
+      }
+
+      if (err instanceof NotFoundError) {
+        throw new ImportPlanNotFoundError()
+      }
+
+      throw err
+    }
   }
 
-  commitImportPlan (importPlanId: string) {
-    return this.api.post<void>(`/next/projects/imports/${importPlanId}/commit`)
+  /**
+   * @throws {ImportPlanNotFoundError} If the import plan does not exist.
+   * @throws {InvalidImportPlanStateError} If the operation is performed out of order.
+   */
+  async commitImportPlan (importPlanId: string) {
+    try {
+      return await this.api.post<void>(`/next/projects/imports/${importPlanId}/commit`)
+    } catch (err) {
+      if (err instanceof ForbiddenError) {
+        throw new InvalidImportPlanStateError()
+      }
+
+      if (err instanceof NotFoundError) {
+        throw new ImportPlanNotFoundError()
+      }
+
+      throw err
+    }
   }
 }
 

--- a/packages/cli/src/rest/test-sessions.ts
+++ b/packages/cli/src/rest/test-sessions.ts
@@ -1,7 +1,9 @@
-import type { AxiosInstance } from 'axios'
+import { type AxiosInstance } from 'axios'
 import { GitInformation } from '../services/util'
 import { RetryStrategy, SharedFile } from '../constructs'
 import { compressJSONPayload } from './util'
+import { SequenceId } from '../services/abstract-check-runner'
+import { ForbiddenError } from './errors'
 
 type RunTestSessionRequest = {
   name: string
@@ -33,20 +35,53 @@ export type TestResultsShortLinks = {
   screenshotLinks: string[]
 }
 
+export type TriggerTestSessionResponse = {
+  checks: Array<any>
+  testSessionId: string
+  testResultIds: Record<string, string>
+  sequenceIds: Record<string, SequenceId>
+}
+
+export class NoMatchingChecksError extends Error {
+  constructor (options?: ErrorOptions) {
+    super(`No matching checks found.`, options)
+    this.name = 'NoMatchingChecksError'
+  }
+}
+
 class TestSessions {
   api: AxiosInstance
   constructor (api: AxiosInstance) {
     this.api = api
   }
 
-  run (payload: RunTestSessionRequest) {
-    return this.api.post('/next/test-sessions/run', payload, {
+  async run (payload: RunTestSessionRequest) {
+    return await this.api.post('/next/test-sessions/run', payload, {
       transformRequest: compressJSONPayload,
     })
   }
 
-  trigger (payload: TriggerTestSessionRequest) {
-    return this.api.post('/next/test-sessions/trigger', payload)
+  /**
+   * @throws {NoMatchingChecksError} If no checks matched the request.
+   */
+  async trigger (payload: TriggerTestSessionRequest) {
+    try {
+      const resp = await this.api.post<TriggerTestSessionResponse>('/next/test-sessions/trigger', payload)
+
+      if (resp.data.checks.length === 0) {
+        // Currently the BE will never return an empty `checks` array, it returns a 403 instead.
+        // This is added to make the old CLI versions compatible if we ever change this, though.
+        throw new NoMatchingChecksError()
+      }
+
+      return resp
+    } catch (err) {
+      if (err instanceof ForbiddenError && err.data.errorCode === 'ERR_NO_MATCHING_CHECKS') {
+        throw new NoMatchingChecksError()
+      }
+
+      throw err
+    }
   }
 
   getShortLink (id: string) {

--- a/packages/cli/src/services/test-runner.ts
+++ b/packages/cli/src/services/test-runner.ts
@@ -75,28 +75,24 @@ export default class TestRunner extends AbstractCheckRunner {
         filePath: check.getSourceFile(),
       }
     })
-    try {
-      if (!checkRunJobs.length) {
-        throw new Error('Unable to find checks to run.')
-      }
-      const { data } = await testSessions.run({
-        name: this.projectBundle.project.name,
-        checkRunJobs,
-        project: { logicalId: this.projectBundle.project.logicalId },
-        sharedFiles: this.sharedFiles,
-        runLocation: this.location,
-        repoInfo: this.repoInfo,
-        environment: this.environment,
-        shouldRecord: this.shouldRecord,
-      })
-      const { testSessionId, sequenceIds } = data
-      const checks = this.checkBundles.map(({ construct: check }) => {
-        return { check, sequenceId: sequenceIds?.[check.logicalId] }
-      })
-      return { testSessionId, checks }
-    } catch (err: any) {
-      throw new Error(err.response?.data?.message ?? err.response?.data?.error ?? err.message)
+    if (!checkRunJobs.length) {
+      throw new Error('Unable to find checks to run.')
     }
+    const { data } = await testSessions.run({
+      name: this.projectBundle.project.name,
+      checkRunJobs,
+      project: { logicalId: this.projectBundle.project.logicalId },
+      sharedFiles: this.sharedFiles,
+      runLocation: this.location,
+      repoInfo: this.repoInfo,
+      environment: this.environment,
+      shouldRecord: this.shouldRecord,
+    })
+    const { testSessionId, sequenceIds } = data
+    const checks = this.checkBundles.map(({ construct: check }) => {
+      return { check, sequenceId: sequenceIds?.[check.logicalId] }
+    })
+    return { testSessionId, checks }
   }
 
   async processCheckResult (result: any) {

--- a/packages/cli/src/services/trigger-runner.ts
+++ b/packages/cli/src/services/trigger-runner.ts
@@ -3,8 +3,6 @@ import { testSessions } from '../rest/api'
 import AbstractCheckRunner, { RunLocation, SequenceId } from './abstract-check-runner'
 import { GitInformation } from './util'
 
-export class NoMatchingChecksError extends Error {}
-
 export default class TriggerRunner extends AbstractCheckRunner {
   shouldRecord: boolean
   location: RunLocation
@@ -45,43 +43,26 @@ export default class TriggerRunner extends AbstractCheckRunner {
     testSessionId?: string
     checks: Array<{ check: any, sequenceId: SequenceId }>
   }> {
-    try {
-      const { data } = await testSessions.trigger({
-        name: this.testSessionName ?? 'Triggered Session',
-        shouldRecord: this.shouldRecord,
-        runLocation: this.location,
-        checkRunSuiteId,
-        targetTags: this.targetTags,
-        environmentVariables: this.envVars,
-        repoInfo: this.repoInfo,
-        environment: this.environment,
-        testRetryStrategy: this.testRetryStrategy,
-      })
-      const {
-        checks,
-        testSessionId,
-        sequenceIds,
-      }: {
-        checks: Array<any>
-        testSessionId: string
-        testResultIds: Record<string, string>
-        sequenceIds: Record<string, SequenceId>
-      } = data
-      if (!checks.length) {
-        // Currently the BE will never return an empty `checks` array, it returns a 403 instead.
-        // This is added to make the old CLI versions compatible if we ever change this, though.
-        throw new NoMatchingChecksError()
-      }
-      const augmentedChecks = checks.map(check => ({
-        check,
-        sequenceId: sequenceIds?.[check.id],
-      }))
-      return { checks: augmentedChecks, testSessionId }
-    } catch (err: any) {
-      if (err.response?.data?.errorCode === 'ERR_NO_MATCHING_CHECKS') {
-        throw new NoMatchingChecksError()
-      }
-      throw new Error(err.response?.data?.message ?? err.message)
-    }
+    const { data } = await testSessions.trigger({
+      name: this.testSessionName ?? 'Triggered Session',
+      shouldRecord: this.shouldRecord,
+      runLocation: this.location,
+      checkRunSuiteId,
+      targetTags: this.targetTags,
+      environmentVariables: this.envVars,
+      repoInfo: this.repoInfo,
+      environment: this.environment,
+      testRetryStrategy: this.testRetryStrategy,
+    })
+    const {
+      checks,
+      testSessionId,
+      sequenceIds,
+    } = data
+    const augmentedChecks = checks.map(check => ({
+      check,
+      sequenceId: sequenceIds?.[check.id],
+    }))
+    return { checks: augmentedChecks, testSessionId }
   }
 }


### PR DESCRIPTION
This PR adds better handling for API errors. Most errors are now intercepted by a global handler which attempts to make the API responses a bit more digestible, and when necessary, API endpoints can provide more specialized errors too.

Slightly alters the output of some commands. I have plans to improve the overall CLI output in a separate PR.

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
