### PR TITLE
fix: search for lockfile in parent directiories

### DIFF
--- a/packages/cli/src/services/check-parser/package-files/resolver.ts
+++ b/packages/cli/src/services/check-parser/package-files/resolver.ts
@@ -8,6 +8,7 @@ import { isBuiltinPath, isLocalPath, PathResult } from './paths'
 import { FileLoader, LoadFile } from './loader'
 import { JsonSourceFile } from './json-source-file'
 import { LookupContext } from './lookup'
+import { walkUp, WalkUpOptions } from './walk'
 
 class PackageFilesCache {
   #sourceFileCache = new FileLoader(SourceFile.loadFromFilePath)
@@ -140,48 +141,6 @@ export type Dependencies = {
   external: ExternalDependency[]
   missing: MissingDependency[]
   local: LocalDependency[]
-}
-
-export interface WalkUpOptions {
-  root?: string
-  isDir?: boolean
-}
-
-async function walkUp (
-  filePath: string,
-  find: (dirPath: string) => Promise<boolean>,
-  options?: WalkUpOptions,
-): Promise<boolean> {
-  let currentPath = filePath
-
-  if (options?.isDir === true) {
-    // To keep things simple, just add a dummy component.
-    currentPath = path.join(currentPath, 'z')
-  }
-
-  while (true) {
-    const prevPath = currentPath
-
-    currentPath = path.dirname(prevPath)
-
-    // Bail out if we reach root.
-    if (prevPath === currentPath) {
-      break
-    }
-
-    const found = await find(currentPath)
-    if (found) {
-      return true
-    }
-
-    // Stop if we reach the user-specified root directory.
-    // TODO: I don't like a string comparison for this but it'll do for now.
-    if (currentPath === options?.root) {
-      break
-    }
-  }
-
-  return false
 }
 
 export class PackageFilesResolver {

--- a/packages/cli/src/services/check-parser/package-files/walk.ts
+++ b/packages/cli/src/services/check-parser/package-files/walk.ts
@@ -1,0 +1,58 @@
+import { resolve, dirname } from 'node:path'
+
+export interface WalkUpOptions extends LineageOptions {
+  isDir?: boolean
+}
+
+export async function walkUp (
+  filePath: string,
+  find: (dirPath: string) => Promise<boolean>,
+  options?: WalkUpOptions,
+): Promise<boolean> {
+  let startPath = filePath
+
+  if (options?.isDir !== true) {
+    startPath = dirname(startPath)
+  }
+
+  for (const dirPath of lineage(startPath, options)) {
+    const found = await find(dirPath)
+    if (found) {
+      return true
+    }
+  }
+
+  return false
+}
+
+export interface LineageOptions {
+  root?: string
+}
+
+export function* lineage (path: string, options?: LineageOptions): Generator<string, void> {
+  let currentPath = resolve(path)
+
+  const stopRoot = options?.root && resolve(options.root)
+
+  // Lineage includes the starting path itself.
+  yield currentPath
+
+  while (true) {
+    const prevPath = currentPath
+
+    // Stop if we reach the user-specified root directory.
+    // TODO: I don't like a string comparison for this but it'll do for now.
+    if (prevPath === stopRoot) {
+      return
+    }
+
+    currentPath = dirname(prevPath)
+
+    // Bail out if we reach root.
+    if (prevPath === currentPath) {
+      return
+    }
+
+    yield currentPath
+  }
+}


### PR DESCRIPTION
PW native checks were looking for a lockfile in the same directory where the PW config is located, which doesn't quite work as expected when using workspaces. Now parent folders are also used to search for a lockfile.

Similarly, package manager detection did not consider parent folders when attempting to detect the presence of a lockfile. Now they are checked.

Note that this functionality is not tested very well, so changes need to be made carefully.

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
