### PR TITLE
fix: erroneous validation for the retryStrategy.onlyOn property [SIM-131]

### DIFF
--- a/packages/cli/src/constructs/check.ts
+++ b/packages/cli/src/constructs/check.ts
@@ -296,23 +296,25 @@ export abstract class Check extends Construct {
   protected async validateRetryStrategyOnlyOn (diagnostics: Diagnostics): Promise<void> {
     if (this.retryStrategy) {
       const retryStrategy = this.retryStrategy as RetryStrategy
-      if (retryStrategy.onlyOn === 'NETWORK_ERROR') {
-        if (!this.supportsOnlyOnNetworkErrorRetryStrategy()) {
+      if (retryStrategy.onlyOn) {
+        if (retryStrategy.onlyOn === 'NETWORK_ERROR') {
+          if (!this.supportsOnlyOnNetworkErrorRetryStrategy()) {
+            diagnostics.add(new InvalidPropertyValueDiagnostic(
+              'retryStrategy',
+              new Error(
+                `Using "NETWORK_ERROR" with "onlyOn" is only supported in the `
+                + `ApiCheck and UrlMonitor constructs.`,
+              ),
+            ))
+          }
+        } else {
           diagnostics.add(new InvalidPropertyValueDiagnostic(
             'retryStrategy',
             new Error(
-              `Using "NETWORK_ERROR" with "onlyOn" is only supported in the `
-              + `ApiCheck and UrlMonitor constructs.`,
+              `Unsupported value "${retryStrategy.onlyOn}" for "onlyOn".`,
             ),
           ))
         }
-      } else {
-        diagnostics.add(new InvalidPropertyValueDiagnostic(
-          'retryStrategy',
-          new Error(
-            `Unsupported value "${retryStrategy.onlyOn}" for "onlyOn".`,
-          ),
-        ))
       }
     }
   }


### PR DESCRIPTION
Somehow, a huge validation error snuck through our tests. I'll add tests later to make sure this never happens again.

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
