### PR TITLE
feat: support comments in tsconfig.json files [SIM-97]

### DIFF
--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-json-text/lib/foo1.ts
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-json-text/lib/foo1.ts
@@ -1,0 +1,1 @@
+export const value = 1

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-json-text/src/entrypoint.ts
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-json-text/src/entrypoint.ts
@@ -1,0 +1,1 @@
+import { value } from '@/foo1'

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-json-text/tsconfig.json
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-json-text/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022", // Comment 
+    "module": "NodeNext",
+    /**
+     * Comment
+     */
+    "moduleResolution": "nodenext",
+    "esModuleInterop": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./lib/*"
+      ]
+    },
+  }
+}

--- a/packages/cli/src/services/check-parser/__tests__/check-parser.spec.ts
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser.spec.ts
@@ -134,6 +134,18 @@ describe('dependency-parser - parser()', () => {
     ])
   })
 
+  it('should parse typescript dependencies relying on tsconfig when tsconfig has comments', async () => {
+    const toAbsolutePath = (...filepath: string[]) => path.join(__dirname, 'check-parser-fixtures', 'tsconfig-json-text', ...filepath)
+    const parser = new Parser({
+      supportedNpmModules: defaultNpmModules,
+    })
+    const { dependencies } = await parser.parse(toAbsolutePath('src', 'entrypoint.ts'))
+    expect(dependencies.map(d => d.filePath).sort()).toEqual([
+      toAbsolutePath('lib', 'foo1.ts'),
+      toAbsolutePath('tsconfig.json'),
+    ])
+  })
+
   it('should parse typescript dependencies using tsconfig', async () => {
     const toAbsolutePath = (...filepath: string[]) => path.join(__dirname, 'check-parser-fixtures', 'tsconfig-paths-sample-project', ...filepath)
     const parser = new Parser({

--- a/packages/cli/src/services/check-parser/package-files/__tests__/json-text-source-file.spec.ts
+++ b/packages/cli/src/services/check-parser/package-files/__tests__/json-text-source-file.spec.ts
@@ -1,0 +1,106 @@
+import { vi, describe, it, expect, beforeAll, afterAll } from 'vitest'
+
+import { FileMeta, SourceFile } from '../source-file'
+import { JsonTextSourceFile } from '../json-text-source-file'
+import { beforeEach } from 'node:test'
+
+const plainJsonFixture = ''
+  + `{\n`
+  + `  "foo": "bar",\n`
+  + `  "trailing-comma": "no"\n`
+  + `}\n`
+
+const jsonTextFixture = ''
+  + `{\n`
+  + `  "foo": "bar", // Foo bar.\n`
+  + `  "trailing-comma": "yes",\n`
+  + `}\n`
+
+describe('JsonTextSourceFile', () => {
+  describe('when typescript is NOT available', () => {
+    beforeAll(() => {
+      JsonTextSourceFile.reset()
+    })
+
+    beforeAll(() => {
+      vi.doMock('typescript', () => {
+        class ModuleNotFoundError extends Error {
+          code = 'MODULE_NOT_FOUND'
+
+          constructor (moduleName: string) {
+            super(`Cannot find module '${moduleName}'`)
+          }
+        }
+
+        throw new ModuleNotFoundError('typescript')
+      })
+    })
+
+    afterAll(() => {
+      vi.doUnmock('typescript')
+    })
+
+    it('should fail to load a JSON text file', async () => {
+      const sourceFile = new SourceFile(
+        FileMeta.fromFilePath('foo.json'),
+        jsonTextFixture,
+      )
+
+      await expect(JsonTextSourceFile.loadFromSourceFile(sourceFile)).resolves.toBeUndefined()
+    })
+
+    it('should successfully load a plain JSON file', async () => {
+      const sourceFile = new SourceFile(
+        FileMeta.fromFilePath('foo.json'),
+        plainJsonFixture,
+      )
+
+      await expect(JsonTextSourceFile.loadFromSourceFile(sourceFile)).resolves.toEqual(
+        expect.objectContaining({
+          data: {
+            'foo': 'bar',
+            'trailing-comma': 'no',
+          },
+        }),
+      )
+    })
+  })
+
+  describe('when typescript is available', () => {
+    beforeAll(() => {
+      JsonTextSourceFile.reset()
+    })
+
+    it('should successfully load a JSON text file', async () => {
+      const sourceFile = new SourceFile(
+        FileMeta.fromFilePath('foo.json'),
+        jsonTextFixture,
+      )
+
+      await expect(JsonTextSourceFile.loadFromSourceFile(sourceFile)).resolves.toEqual(
+        expect.objectContaining({
+          data: {
+            'foo': 'bar',
+            'trailing-comma': 'yes',
+          },
+        }),
+      )
+    })
+
+    it('should successfully load a plain JSON file', async () => {
+      const sourceFile = new SourceFile(
+        FileMeta.fromFilePath('foo.json'),
+        plainJsonFixture,
+      )
+
+      await expect(JsonTextSourceFile.loadFromSourceFile(sourceFile)).resolves.toEqual(
+        expect.objectContaining({
+          data: {
+            'foo': 'bar',
+            'trailing-comma': 'no',
+          },
+        }),
+      )
+    })
+  })
+})

--- a/packages/cli/src/services/check-parser/package-files/jsconfig-json-file.ts
+++ b/packages/cli/src/services/check-parser/package-files/jsconfig-json-file.ts
@@ -21,7 +21,8 @@ export class JSConfigFile extends TSConfigFile {
     return path.join(dirPath, JSConfigFile.FILENAME)
   }
 
-  static loadFromJsonSourceFile (jsonFile: JsonSourceFile<Schema>): JSConfigFile | undefined {
+  // eslint-disable-next-line require-await
+  static async loadFromJsonSourceFile (jsonFile: JsonSourceFile<Schema>): Promise<JSConfigFile | undefined> {
     return new JSConfigFile(jsonFile)
   }
 }

--- a/packages/cli/src/services/check-parser/package-files/json-source-file.ts
+++ b/packages/cli/src/services/check-parser/package-files/json-source-file.ts
@@ -16,7 +16,8 @@ export class JsonSourceFile<Schema> {
     return this.sourceFile.meta
   }
 
-  static loadFromSourceFile<Schema> (sourceFile: SourceFile): JsonSourceFile<Schema> | undefined {
+  // eslint-disable-next-line require-await
+  static async loadFromSourceFile<Schema> (sourceFile: SourceFile): Promise<JsonSourceFile<Schema> | undefined> {
     try {
       const data: Schema = JSON.parse(sourceFile.contents)
 

--- a/packages/cli/src/services/check-parser/package-files/json-text-source-file-parser.ts
+++ b/packages/cli/src/services/check-parser/package-files/json-text-source-file-parser.ts
@@ -1,0 +1,59 @@
+import { FileMeta, SourceFile } from './source-file'
+import { SourceFileParserFuncState, SourceFileParser } from './source-file-parser'
+
+class UninitializedJsonTextSourceFileParserState extends SourceFileParser {
+  private static init?: Promise<void>
+
+  async #parser (): Promise<SourceFileParser> {
+    try {
+      const { parseJsonText, convertToObject } = await import('typescript')
+
+      const parser = new SourceFileParserFuncState(<T>(sourceFile: SourceFile) => {
+        const errors: any[] = []
+        const parsed = parseJsonText(sourceFile.meta.filePath, sourceFile.contents)
+        const object: T = convertToObject(parsed, errors)
+        return object
+      })
+
+      // Make sure it actually works.
+      await parser.parseSourceFile(new SourceFile(
+        FileMeta.fromFilePath('x.json'),
+        '{} // Comment',
+      ))
+
+      return parser
+    } catch {
+      return new SourceFileParserFuncState(<T>(sourceFile: SourceFile) => {
+        const data: T = JSON.parse(sourceFile.contents)
+        return data
+      })
+    }
+  }
+
+  async parseSourceFile<T = unknown> (sourceFile: SourceFile): Promise<T> {
+    UninitializedJsonTextSourceFileParserState.init ??= (async () => {
+      JsonTextSourceFileParser.state = await this.#parser()
+    })()
+
+    await UninitializedJsonTextSourceFileParserState.init
+
+    return await JsonTextSourceFileParser.state.parseSourceFile(sourceFile)
+  }
+
+  static reset () {
+    UninitializedJsonTextSourceFileParserState.init = undefined
+  }
+}
+
+export class JsonTextSourceFileParser extends SourceFileParser {
+  static state: SourceFileParser = new UninitializedJsonTextSourceFileParserState()
+
+  async parseSourceFile<T = unknown> (sourceFile: SourceFile): Promise<T> {
+    return await JsonTextSourceFileParser.state.parseSourceFile<T>(sourceFile)
+  }
+
+  static reset () {
+    JsonTextSourceFileParser.state = new UninitializedJsonTextSourceFileParserState()
+    UninitializedJsonTextSourceFileParserState.reset()
+  }
+}

--- a/packages/cli/src/services/check-parser/package-files/json-text-source-file.ts
+++ b/packages/cli/src/services/check-parser/package-files/json-text-source-file.ts
@@ -1,0 +1,21 @@
+import { JsonSourceFile } from './json-source-file'
+import { JsonTextSourceFileParser } from './json-text-source-file-parser'
+import { SourceFile } from './source-file'
+
+export class JsonTextSourceFile<Schema> extends JsonSourceFile<Schema> {
+  static #parser = new JsonTextSourceFileParser()
+
+  static async loadFromSourceFile<Schema> (sourceFile: SourceFile): Promise<JsonTextSourceFile<Schema> | undefined> {
+    try {
+      const data: Schema = await this.#parser.parseSourceFile(sourceFile)
+
+      return new JsonTextSourceFile(sourceFile, data)
+    } catch {
+      // Ignore.
+    }
+  }
+
+  static reset () {
+    JsonTextSourceFileParser.reset()
+  }
+}

--- a/packages/cli/src/services/check-parser/package-files/package-json-file.ts
+++ b/packages/cli/src/services/check-parser/package-files/package-json-file.ts
@@ -100,7 +100,8 @@ export class PackageJsonFile {
     return new PackageJsonFile(jsonFile)
   }
 
-  static loadFromJsonSourceFile (jsonFile: JsonSourceFile<Schema>): PackageJsonFile | undefined {
+  // eslint-disable-next-line require-await
+  static async loadFromJsonSourceFile (jsonFile: JsonSourceFile<Schema>): Promise<PackageJsonFile | undefined> {
     return new PackageJsonFile(jsonFile)
   }
 

--- a/packages/cli/src/services/check-parser/package-files/source-file-parser.ts
+++ b/packages/cli/src/services/check-parser/package-files/source-file-parser.ts
@@ -1,0 +1,19 @@
+import { SourceFile } from './source-file'
+
+export abstract class SourceFileParser {
+  abstract parseSourceFile<T = unknown> (sourceFile: SourceFile): Promise<T>
+}
+export type SourceFileParserFunc = <T = unknown> (sourceFile: SourceFile) => Promise<T>
+
+export class SourceFileParserFuncState extends SourceFileParser {
+  parser: SourceFileParserFunc
+
+  constructor (parser: SourceFileParserFunc) {
+    super()
+    this.parser = parser
+  }
+
+  async parseSourceFile<T = unknown> (sourceFile: SourceFile): Promise<T> {
+    return await this.parser<T>(sourceFile)
+  }
+}

--- a/packages/cli/src/services/check-parser/package-files/tsconfig-json-file.ts
+++ b/packages/cli/src/services/check-parser/package-files/tsconfig-json-file.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 
 import { SourceFile } from './source-file'
-import { JsonSourceFile } from './json-source-file'
+import { JsonTextSourceFile } from './json-text-source-file'
 import { PathResolver, ResolveResult } from './paths'
 
 type Module =
@@ -66,7 +66,7 @@ export class TSConfigFile {
   static #id = 0
   readonly id = ++TSConfigFile.#id
 
-  jsonFile: JsonSourceFile<Schema>
+  jsonFile: JsonTextSourceFile<Schema>
   basePath: string
   moduleResolution: string
   baseUrl?: string
@@ -74,7 +74,7 @@ export class TSConfigFile {
 
   relatedSourceFiles: SourceFile[] = []
 
-  protected constructor (jsonFile: JsonSourceFile<Schema>) {
+  protected constructor (jsonFile: JsonTextSourceFile<Schema>) {
     this.jsonFile = jsonFile
 
     this.basePath = jsonFile.meta.dirname
@@ -93,7 +93,8 @@ export class TSConfigFile {
     return this.jsonFile.meta
   }
 
-  static loadFromJsonSourceFile (jsonFile: JsonSourceFile<Schema>): TSConfigFile | undefined {
+  // eslint-disable-next-line require-await
+  static async loadFromJsonTextSourceFile (jsonFile: JsonTextSourceFile<Schema>): Promise<TSConfigFile | undefined> {
     return new TSConfigFile(jsonFile)
   }
 


### PR DESCRIPTION
This PR adds support for loading `tsconfig.json` files that aren't pure JSON, but include comments, trailing commas and what have you. It uses `parseJsonText` and `convertToObject` from `typescript`. If `typescript` is not available, the loader falls back to regular `JSON.parse`.

## Affected Components
* [x] CLI
* [ ] Create CLI
* [x] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
