### PR TITLE
feat: allow passing playwright config path at a check level

### DIFF
--- a/packages/cli/src/services/checkly-config-loader.ts
+++ b/packages/cli/src/services/checkly-config-loader.ts
@@ -35,7 +35,7 @@ export type CheckConfigDefaults =
 export type PlaywrightSlimmedProp = Pick<PlaywrightCheckProps, 'name' | 'activated'
   | 'muted' | 'shouldFail' | 'locations' | 'tags' | 'frequency' | 'environmentVariables'
   | 'alertChannels' | 'privateLocations' | 'retryStrategy' | 'alertEscalationPolicy'
-  | 'pwProjects' | 'pwTags' | 'installCommand' | 'testCommand' | 'groupName' | 'runParallel'> & { logicalId: string }
+  | 'pwProjects' | 'pwTags' | 'installCommand' | 'testCommand' | 'groupName' | 'runParallel'> & { logicalId: string, playwrightConfigPath?: string }
 
 export type ChecklyConfig = {
   /**

--- a/packages/cli/src/services/project-parser.ts
+++ b/packages/cli/src/services/project-parser.ts
@@ -1,7 +1,6 @@
 import * as path from 'path'
 import {
-  findFilesWithPattern,
-
+  findFilesWithPattern, getPlaywrightConfigPath,
   pathToPosix,
 } from './util'
 import {
@@ -121,21 +120,15 @@ async function loadPlaywrightChecks (
   playwrightConfigPath?: string,
   include?: string | string[],
 ) {
-  if (!playwrightConfigPath) {
-    return
-  }
-
-  // Resolve the playwrightConfigPath relative to the project directory
-  const resolvedPlaywrightConfigPath = path.resolve(directory, playwrightConfigPath)
-
   if (playwrightChecks?.length) {
     try {
-      setCheckFilePaths(playwrightConfigPath, directory)
       for (const playwrightCheckProps of playwrightChecks) {
+        const configPath = getPlaywrightConfigPath(playwrightCheckProps, playwrightConfigPath, directory)
+        setCheckFilePaths(configPath, directory)
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const playwrightCheck = new PlaywrightCheck(playwrightCheckProps.logicalId, {
           ...playwrightCheckProps,
-          playwrightConfigPath: resolvedPlaywrightConfigPath,
+          playwrightConfigPath: configPath,
           include,
         })
       }
@@ -144,7 +137,11 @@ async function loadPlaywrightChecks (
     }
   } else {
     try {
+      if (!playwrightConfigPath) {
+        return
+      }
       setCheckFilePaths(playwrightConfigPath, directory)
+      const resolvedPlaywrightConfigPath = path.resolve(directory, playwrightConfigPath)
       const basePath = path.basename(resolvedPlaywrightConfigPath)
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const playwrightCheck = new PlaywrightCheck(basePath, {

--- a/packages/cli/src/services/util.ts
+++ b/packages/cli/src/services/util.ts
@@ -358,3 +358,17 @@ export async function writeChecklyConfigFile (dir: string, config: ChecklyConfig
 
   await fs.writeFile(configFile, configContent, { encoding: 'utf-8' })
 }
+
+export function getPlaywrightConfigPath (
+  playwrightCheckProps: PlaywrightSlimmedProp,
+  playwrightConfigPath: string | undefined,
+  dir: string,
+): string {
+  if (playwrightCheckProps.playwrightConfigPath) {
+    return path.resolve(dir, playwrightCheckProps.playwrightConfigPath)
+  } else if (playwrightConfigPath) {
+    return path.resolve(dir, playwrightConfigPath)
+  } else {
+    throw new Error('No Playwright config path provided.')
+  }
+}


### PR DESCRIPTION
## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
1. Allow passing playwright config path at a check level
2. if no config path is provided at check level fallback to general config path
3. If no config path is provided, fail.

This also allows the user not to define a `playwrightConfigPath` at the top level and just define them at check level if they want.
