### PR TITLE
fix: always include pnpm-workspace.yaml for Playwright checks if present

### DIFF
--- a/packages/cli/src/services/util.ts
+++ b/packages/cli/src/services/util.ts
@@ -303,7 +303,7 @@ export async function loadPlaywrightProjectFiles (
     archive.glob(includePattern, { cwd: path.join(dir, '/') }, { mode })
   }
   for (const filePath of extraFiles) {
-    archive.file(filePath, { name: filePath, mode })
+    archive.file(path.resolve(dir, filePath), { name: filePath, mode })
   }
 }
 


### PR DESCRIPTION
Earlier, it was included because we added lockfiles using a glob pattern which happened to match the workspace file as well. Now that we are only including the lockfile we detect, we have to add the workspace file manually.

Done in an extremely simple manner because proper workspace support will follow soon.

I have verified that there's no harm calling `.file('<path>')` if the file doesn't exist - it just won't get added.

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
