### PR TITLE
feat: allow changing preferred file loader with the CHECKLY_PREFERRED_LOADER environment variable

### DIFF
--- a/packages/cli/src/loader/config.ts
+++ b/packages/cli/src/loader/config.ts
@@ -1,0 +1,9 @@
+export const preferredLoader = process.env.CHECKLY_PREFERRED_LOADER
+
+export function isPreferredLoader (name: string): boolean {
+  return preferredLoader === name
+}
+
+export function preferenceDelta (name: string): number {
+  return isPreferredLoader(name) ? 200 : 0
+}

--- a/packages/cli/src/loader/jiti.ts
+++ b/packages/cli/src/loader/jiti.ts
@@ -1,5 +1,6 @@
 import { FileLoader, FileLoaderOptions, UnsupportedFileLoaderError } from './loader'
 import { FileMatch } from './match'
+import { preferenceDelta } from './config'
 
 interface JitiExports {
   createJiti (id: string, userOptions?: any): Jiti
@@ -65,11 +66,14 @@ export class InitializedJitiFileLoaderState extends FileLoader {
 export type JitiFileLoaderOptions = FileLoaderOptions
 
 export class JitiFileLoader extends FileLoader {
+  static DEFAULT_PRIORITY = 500 + preferenceDelta('jiti')
+
   static state: FileLoader = new UninitializedJitiFileLoaderState()
 
   constructor (options?: JitiFileLoaderOptions) {
     super({
       match: FileMatch.standardFiles().complement(),
+      priority: JitiFileLoader.DEFAULT_PRIORITY,
       ...options,
     })
   }

--- a/packages/cli/src/loader/loader.ts
+++ b/packages/cli/src/loader/loader.ts
@@ -1,14 +1,33 @@
 import { FileMatch } from './match'
 
 export interface FileLoaderOptions {
+  /**
+   * The priority of the loader, used to resolve load order if multiple
+   * loaders are available.
+   *
+   * The higher the priority the earlier the load order.
+   */
+  priority?: number
   match?: FileMatch
 }
 
 export abstract class FileLoader {
+  static DEFAULT_PRIORITY = 1000
+
   protected fileMatcher: FileMatch
+  #priority: number
 
   constructor (options?: FileLoaderOptions) {
     this.fileMatcher = options?.match ?? FileMatch.any()
+    this.#priority = options?.priority ?? FileLoader.DEFAULT_PRIORITY
+  }
+
+  /**
+   * The priority of the loader, used to resolve load order if multiple
+   * loaders are available.
+   */
+  get priority () {
+    return this.#priority
   }
 
   /**

--- a/packages/cli/src/loader/mixed.ts
+++ b/packages/cli/src/loader/mixed.ts
@@ -8,7 +8,7 @@ export class MixedFileLoader extends FileLoader {
 
   constructor (...loaders: FileLoader[]) {
     super()
-    this.loaders = new Set(loaders)
+    this.loaders = new Set([...loaders].sort((a, b) => b.priority - a.priority))
   }
 
   isAuthoritativeFor (filePath: string): boolean {

--- a/packages/cli/src/loader/ts-node.ts
+++ b/packages/cli/src/loader/ts-node.ts
@@ -1,3 +1,4 @@
+import { preferenceDelta } from './config'
 import { FileLoader, FileLoaderOptions, UnsupportedFileLoaderError } from './loader'
 import { FileMatch } from './match'
 
@@ -85,11 +86,14 @@ export class InitializedTSNodeFileLoaderState extends FileLoader {
 export type TSNodeFileLoaderOptions = FileLoaderOptions
 
 export class TSNodeFileLoader extends FileLoader {
+  static DEFAULT_PRIORITY = 500 + preferenceDelta('ts-node')
+
   static state: FileLoader = new UninitializedTSNodeFileLoaderState()
 
   constructor (options?: TSNodeFileLoaderOptions) {
     super({
       match: FileMatch.standardFiles().complement(),
+      priority: TSNodeFileLoader.DEFAULT_PRIORITY,
       ...options,
     })
   }


### PR DESCRIPTION
Mostly useful for debugging. The only supported values currently are `jiti` and `ts-node`. By default, `jiti` will be preferred if available, but the environment variable makes it possible to prefer `ts-node` instead.

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
