### PR TITLE
fix: use dynamic import for archiver CommonJs

### DIFF
--- a/packages/cli/src/services/util.ts
+++ b/packages/cli/src/services/util.ts
@@ -8,7 +8,6 @@ import { parse } from 'dotenv'
 // @ts-ignore
 import { getProxyForUrl } from 'proxy-from-env'
 import { httpOverHttp, httpsOverHttp, httpOverHttps, httpsOverHttps } from 'tunnel'
-import archiver from 'archiver'
 import type { Archiver } from 'archiver'
 import { glob } from 'glob'
 import os from 'node:os'
@@ -210,6 +209,8 @@ export async function bundlePlayWrightProject (
   const outputFile = path.join(outputFolder, 'playwright-project.tar.gz')
   const output = fsSync.createWriteStream(outputFile)
 
+  // Dynamic import for CommonJs so it doesn't break when using checkly/playwright-reporter archiver
+  const { default: archiver } = await import('archiver')
   const archive = archiver('tar', {
     gzip: true,
     gzipOptions: {


### PR DESCRIPTION
## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
When using the checkly/playwright-reporter together with the CLI, since there are 2 versions of the same library using a different type (CommonJS, ESM) CLI breaks, by using a dynamic import we fix that issue.

The reporter uses a fork of archiver npm package https://github.com/checkly/node-archiver which allows us to know the byte offset (start/end) of the different files so then we can pick up exactly those files instead of unzipping everything.
