### PR TITLE
fix: status summary for pw-test

### DIFF
--- a/packages/cli/src/reporters/abstract-list.ts
+++ b/packages/cli/src/reporters/abstract-list.ts
@@ -107,6 +107,10 @@ export default abstract class AbstractListReporter implements Reporter {
     const checkFile = this.checkFilesMap!.get(check.getSourceFile?.())!.get(sequenceId)!
     const logList = logs || []
 
+    // Clearing the summary first, printing logs second and finally adding the summary again at the end will ensure
+    // the summary sticks to the bottom of the users screen with logs streaming in above.
+    this._clearSummary()
+
     // Display the check title if this is the first time we're streaming logs for this check
     const isFirstLogBatch = !checkFile.hasStreamedLogs
     checkFile.hasStreamedLogs = true
@@ -132,6 +136,8 @@ export default abstract class AbstractListReporter implements Reporter {
         printLn(indentString(formattedLine, 4))
       })
     })
+
+    this._printSummary()
   }
 
   // Clear the summary which was printed by _printStatus from stdout


### PR DESCRIPTION
The status summary was overwriting log messages instead of the previous status summary. Now the summary sticks to the bottom of the screen with logs steaming in above it.

<img width="1914" height="784" alt="Screenshot 2025-11-07 at 20 01 41" src="https://github.com/user-attachments/assets/9ee7961d-cf6d-44e0-9582-e13a85b2ea9e" />

## Affected Components
* CLI `pw-test` command