### PR TITLE
fix: include path resolution should run from root

### DIFF
--- a/packages/cli/src/services/util.ts
+++ b/packages/cli/src/services/util.ts
@@ -320,9 +320,8 @@ export async function loadPlaywrightProjectFiles (
     prefix,
   })
   for (const includePattern of include) {
-    archive.glob(includePattern, { cwd: dir }, {
+    archive.glob(includePattern, { cwd: root }, {
       ...entryDefaults,
-      prefix,
     })
   }
   for (const filePath of extraFiles) {


### PR DESCRIPTION
## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer

When a Playwright config is located in a subdirectory and users specify `include` patterns in their Checkly config, the paths were being resolved relative to the Playwright config directory instead of the project root.

### Example Scenario

```
/project/
├── checkly.config.ts          # Checkly config at root
├── shared/
│   └── helpers.ts             # File to include
└── tests/
    └── playwright.config.ts   # Playwright config in subdirectory
```

**In `checkly.config.ts`:**
```typescript
{
  playwrightConfig: 'tests/playwright.config.ts',
  include: ['shared/helpers.ts']  // Relative to project root
}
```

### Before the Fix ❌
The `include` pattern was resolved relative to the Playwright config directory (`/project/tests/`), so it would look for:
- `/project/tests/shared/helpers.ts` → **File not found**

### After the Fix ✅
The `include` pattern is now resolved relative to the project root (`/project/`), so it correctly finds:
- `/project/shared/helpers.ts` → **File found**

