### PR TITLE
chore: update vulnerable glob v10.4.5 to v10.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7618,9 +7618,9 @@
       "license": "ISC"
     },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -14564,7 +14564,7 @@
         "dotenv": "^16.5.0",
         "execa": "^9.5.3",
         "git-repo-info": "^2.1.1",
-        "glob": "^10.4.5",
+        "glob": "^10.5.0",
         "indent-string": "^4.0.0",
         "json-stream-stringify": "^3.1.6",
         "json5": "^2.2.3",
@@ -18907,7 +18907,7 @@
         "dotenv": "^16.5.0",
         "execa": "^9.5.3",
         "git-repo-info": "^2.1.1",
-        "glob": "^10.4.5",
+        "glob": "^10.5.0",
         "indent-string": "^4.0.0",
         "jiti": "^2.4.2",
         "json-stream-stringify": "^3.1.6",
@@ -20312,9 +20312,9 @@
       "dev": true
     },
     "glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "requires": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -94,7 +94,7 @@
     "dotenv": "^16.5.0",
     "execa": "^9.5.3",
     "git-repo-info": "^2.1.1",
-    "glob": "^10.4.5",
+    "glob": "^10.5.0",
     "indent-string": "^4.0.0",
     "json-stream-stringify": "^3.1.6",
     "json5": "^2.2.3",


### PR DESCRIPTION
## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

This PR updates the glob package from `10.4.5` to `10.5.0`. The former suffers from https://nvd.nist.gov/vuln/detail/CVE-2025-64756. We are a couple major versions behind due to glob 11 dropping support for anything below Node 20, so for now this is the safest and most compatible version to update to.

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
