### PR TITLE
fix: update reporter for changed check result format

### DIFF
--- a/packages/cli/src/reporters/util.ts
+++ b/packages/cli/src/reporters/util.ts
@@ -97,13 +97,13 @@ export function formatCheckResult (checkResult: any) {
           formatAssertions(checkResult.checkRunData.assertions),
         ])
       }
-      if (checkResult.logs?.setup.length) {
+      if (checkResult.logs?.setup?.length) {
         result.push([
           formatSectionTitle('Setup Script Logs'),
           formatLogs(checkResult.logs.setup),
         ])
       }
-      if (checkResult.logs?.teardown.length) {
+      if (checkResult.logs?.teardown?.length) {
         result.push([
           formatSectionTitle('Teardown Script Logs'),
           formatLogs(checkResult.logs.teardown),


### PR DESCRIPTION
The new check result format sometimes uses `null` instead of an empty array. It can cause the following error to manifest under certain circumstances:

    TypeError: Cannot read properties of null (reading 'length')

This change handles a null value too, preventing the error.

The error also broke our E2E tests.

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
