### PR TITLE
fix: allow use of CheckGroupRef in the Checkly config file

### DIFF
--- a/packages/cli/src/constructs/check-group-ref.ts
+++ b/packages/cli/src/constructs/check-group-ref.ts
@@ -36,6 +36,10 @@ export class CheckGroupRef extends Construct {
     return {}
   }
 
+  allowInChecklyConfig () {
+    return true
+  }
+
   synthesize () {
     return null
   }


### PR DESCRIPTION
## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

`CheckGroupRef` was mistakenly not allowed to be used in a Checkly configuration file. The reason why constructs are not allowed in the config file by default is that many of them require information from the configuration file, such as default values, which are not available until the configuration file has been fully loaded. However, there is no such concern for `CheckGroupRef` because it does not rely on any additional data from the configuration file.

I verified both the presence of the issue and the effectiveness of the fix manually. In the interest of pushing this change out ASAP no time was spent on adding tests.

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
