### PR TITLE
feat: add guardrail for playwright install warning [red-79]

### DIFF
--- a/packages/cli/src/constructs/__tests__/playwright-check.spec.ts
+++ b/packages/cli/src/constructs/__tests__/playwright-check.spec.ts
@@ -445,6 +445,80 @@ describe('PlaywrightCheck', () => {
         }),
       ]))
     })
+
+    it('should warn when installCommand contains playwright install', async () => {
+      Session.basePath = path.resolve(__dirname, './fixtures/playwright-check')
+      Session.project = new Project('project-id', {
+        name: 'Test Project',
+        repoUrl: 'https://github.com/checkly/checkly-cli',
+      })
+
+      const check = new PlaywrightCheck('foo', {
+        name: 'Test Check',
+        playwrightConfigPath: path.resolve(__dirname, './fixtures/playwright-check/playwright.config.ts'),
+        installCommand: 'npm ci && npx playwright install chromium',
+      })
+
+      const diags = new Diagnostics()
+      await check.validate(diags)
+
+      expect(diags.isFatal()).toEqual(false)
+      expect(diags.observations).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          title: 'Unnecessary browser installation detected',
+          message: expect.stringContaining('installCommand contains "playwright install"'),
+        }),
+      ]))
+    })
+
+    it('should warn when testCommand contains playwright install', async () => {
+      Session.basePath = path.resolve(__dirname, './fixtures/playwright-check')
+      Session.project = new Project('project-id', {
+        name: 'Test Project',
+        repoUrl: 'https://github.com/checkly/checkly-cli',
+      })
+
+      const check = new PlaywrightCheck('foo', {
+        name: 'Test Check',
+        playwrightConfigPath: path.resolve(__dirname, './fixtures/playwright-check/playwright.config.ts'),
+        testCommand: 'npx playwright install && npx playwright test',
+      })
+
+      const diags = new Diagnostics()
+      await check.validate(diags)
+
+      expect(diags.isFatal()).toEqual(false)
+      expect(diags.observations).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          title: 'Unnecessary browser installation detected',
+          message: expect.stringContaining('testCommand contains "playwright install"'),
+        }),
+      ]))
+    })
+
+    it('should not warn when commands do not contain playwright install', async () => {
+      Session.basePath = path.resolve(__dirname, './fixtures/playwright-check')
+      Session.project = new Project('project-id', {
+        name: 'Test Project',
+        repoUrl: 'https://github.com/checkly/checkly-cli',
+      })
+
+      const check = new PlaywrightCheck('foo', {
+        name: 'Test Check',
+        playwrightConfigPath: path.resolve(__dirname, './fixtures/playwright-check/playwright.config.ts'),
+        installCommand: 'npm ci',
+        testCommand: 'npx playwright test',
+      })
+
+      const diags = new Diagnostics()
+      await check.validate(diags)
+
+      expect(diags.observations).not.toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          title: 'Unnecessary browser installation detected',
+        }),
+      ]))
+    })
   })
 
   describe('defaults', () => {

--- a/packages/cli/src/constructs/playwright-check.ts
+++ b/packages/cli/src/constructs/playwright-check.ts
@@ -313,6 +313,28 @@ export class PlaywrightCheck extends RuntimeCheck {
     }
   }
 
+  protected validateBrowserInstallCommand (diagnostics: Diagnostics): void {
+    const playwrightInstallPattern = /playwright\s+install/i
+
+    const commands = [
+      { name: 'installCommand', value: this.installCommand },
+      { name: 'testCommand', value: this.testCommand },
+    ]
+
+    for (const { name, value } of commands) {
+      if (value && playwrightInstallPattern.test(value)) {
+        diagnostics.add(new WarningDiagnostic({
+          title: 'Unnecessary browser installation detected',
+          message:
+            `The ${name} contains "playwright install" which is not needed. `
+            + `Checkly automatically installs browsers based on your pwProjects configuration. `
+            + `Consider removing the browser installation from ${name}.`,
+        }))
+        break
+      }
+    }
+  }
+
   async validate (diagnostics: Diagnostics): Promise<void> {
     await super.validate(diagnostics)
     await this.validateRetryStrategy(diagnostics)
@@ -328,6 +350,7 @@ export class PlaywrightCheck extends RuntimeCheck {
     }
 
     await this.validateHeadlessMode(diagnostics)
+    this.validateBrowserInstallCommand(diagnostics)
 
     this.#validateGroupReferences(diagnostics)
   }


### PR DESCRIPTION
## Affected Components
* [ ] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

Adds a CLI warning when installCommand or testCommand contains playwright install, informing users that Checkly handles browser installation automatically via pwProjects configuration.

<img width="576" height="210" alt="image" src="https://github.com/user-attachments/assets/b8206114-1753-422b-b2e3-fa590b12c8b7" />
<img width="526" height="134" alt="image" src="https://github.com/user-attachments/assets/aec7a72c-647c-4ded-b865-89cc46212c6a" />

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
