### PR TITLE
fix: remove double test line printed with pw-test [red-114]

### DIFF
--- a/packages/cli/src/commands/pw-test.ts
+++ b/packages/cli/src/commands/pw-test.ts
@@ -250,7 +250,9 @@ export default class PwTestCommand extends AuthCommand {
       return
     }
 
-    const reporters = createReporters(reporterTypes, location, verboseFlag)
+    const reporters = createReporters(reporterTypes, location, verboseFlag, {
+      showStreamingHeaders: false,
+    })
     const repoInfo = getGitInformation(project.repoUrl)
     const ciInfo = getCiInformation()
     // TODO: ADD PROPER RETRY STRATEGY HANDLING

--- a/packages/cli/src/reporters/abstract-list.ts
+++ b/packages/cli/src/reporters/abstract-list.ts
@@ -32,13 +32,16 @@ export default abstract class AbstractListReporter implements Reporter {
   verbose: boolean
   testSessionId?: string
   _isSchedulingDelayExceeded?: boolean
+  showStreamingHeaders: boolean
 
   constructor (
     runLocation: RunLocation,
     verbose: boolean,
+    options: { showStreamingHeaders?: boolean } = {},
   ) {
     this.runLocation = runLocation
     this.verbose = verbose
+    this.showStreamingHeaders = options.showStreamingHeaders ?? true
   }
 
   onBegin (checks: Array<{ check: any, sequenceId: SequenceId }>, testSessionId?: string): void {
@@ -114,7 +117,7 @@ export default abstract class AbstractListReporter implements Reporter {
     // Display the check title if this is the first time we're streaming logs for this check
     const isFirstLogBatch = !checkFile.hasStreamedLogs
     checkFile.hasStreamedLogs = true
-    if (isFirstLogBatch) {
+    if (isFirstLogBatch && this.showStreamingHeaders) {
       // For Playwright tests, we need to create a better display name
       const displayCheck = {
         ...check,

--- a/packages/cli/src/reporters/reporter.ts
+++ b/packages/cli/src/reporters/reporter.ts
@@ -19,23 +19,28 @@ export interface Reporter {
 
 export type ReporterType = 'list' | 'dot' | 'ci' | 'github' | 'json'
 
+export type ReporterOptions = {
+  showStreamingHeaders?: boolean
+}
+
 export const createReporters = (
   types: ReporterType[],
   runLocation: RunLocation,
   verbose: boolean,
+  options: ReporterOptions = {},
 ): Reporter[] => types.map(t => {
   switch (t) {
     case 'dot':
-      return new DotReporter(runLocation, verbose)
+      return new DotReporter(runLocation, verbose, options)
     case 'list':
-      return new ListReporter(runLocation, verbose)
+      return new ListReporter(runLocation, verbose, options)
     case 'ci':
-      return new CiReporter(runLocation, verbose)
+      return new CiReporter(runLocation, verbose, options)
     case 'github':
-      return new GithubReporter(runLocation, verbose)
+      return new GithubReporter(runLocation, verbose, options)
     case 'json':
-      return new JsonReporter(runLocation, verbose)
+      return new JsonReporter(runLocation, verbose, options)
     default:
-      return new ListReporter(runLocation, verbose)
+      return new ListReporter(runLocation, verbose, options)
   }
 })


### PR DESCRIPTION
## Affected Components
* [ ] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

In pw-test we can avoid having the double line on the logs, check [here](https://linear.app/checklyhq/issue/RED-114/remove-double-line-printed-with-pw-test) and Before screenshot. 

Before

<img width="590" height="490" alt="image" src="https://github.com/user-attachments/assets/2015c910-9d3a-42a5-9e8a-63313e95d27a" />

After

<img width="573" height="496" alt="image" src="https://github.com/user-attachments/assets/139f6548-7798-45a6-9343-eaf48f3f34f2" />