### PR TITLE
feat: invalidate code bundle when installCommmand changes

### DIFF
--- a/packages/cli/src/constructs/playwright-check.ts
+++ b/packages/cli/src/constructs/playwright-check.ts
@@ -396,12 +396,12 @@ export class PlaywrightCheck extends RuntimeCheck {
     return `${testCommand} --config ${quotedPath}${projectArg}${tagArg}`
   }
 
-  static async bundleProject (playwrightConfigPath: string, include: string[]) {
+  static async bundleProject (playwrightConfigPath: string, include: string[], installCommand?: string) {
     let dir = ''
     try {
       const {
         outputFile, browsers, relativePlaywrightConfigPath, cacheHash, playwrightVersion,
-      } = await bundlePlayWrightProject(playwrightConfigPath, include)
+      } = await bundlePlayWrightProject(playwrightConfigPath, include, installCommand)
       dir = outputFile
       const { data: { key } } = await PlaywrightCheck.uploadPlaywrightProject(dir)
       return { key, browsers, relativePlaywrightConfigPath, cacheHash, playwrightVersion }
@@ -432,7 +432,7 @@ export class PlaywrightCheck extends RuntimeCheck {
       cacheHash,
       playwrightVersion,
       relativePlaywrightConfigPath,
-    } = await PlaywrightCheck.bundleProject(this.playwrightConfigPath, this.include ?? [])
+    } = await PlaywrightCheck.bundleProject(this.playwrightConfigPath, this.include ?? [], this.installCommand)
 
     const testCommand = PlaywrightCheck.buildTestCommand(
       this.testCommand,

--- a/packages/cli/src/services/__tests__/util.spec.ts
+++ b/packages/cli/src/services/__tests__/util.spec.ts
@@ -181,6 +181,17 @@ describe('util', () => {
       await expect(fs.access(nodeModulesPath)).rejects.toThrow()
     }, 30000)
 
+    it('should produce different cacheHash when installCommand is provided', async () => {
+      const fixtureDir = path.join(__dirname, 'fixtures', 'playwright-bundle-test')
+      const playwrightConfigPath = path.join(fixtureDir, 'playwright.config.ts')
+      Session.ignoreDirectoriesMatch = []
+
+      const resultWithout = await bundlePlayWrightProject(playwrightConfigPath, [])
+      const resultWith = await bundlePlayWrightProject(playwrightConfigPath, [], 'npm ci')
+
+      expect(resultWith.cacheHash).not.toEqual(resultWithout.cacheHash)
+    }, 30000)
+
     it('should exclude node_modules with broad patterns despite include', async () => {
       const fixtureDir = path.join(__dirname, 'fixtures', 'playwright-bundle-test')
       const playwrightConfigPath = path.join(fixtureDir, 'playwright.config.ts')

--- a/packages/cli/src/services/util.ts
+++ b/packages/cli/src/services/util.ts
@@ -191,6 +191,7 @@ export function normalizeVersion (v?: string | undefined): string | undefined {
 export async function bundlePlayWrightProject (
   playwrightConfig: string,
   include: string[],
+  installCommand?: string,
 ): Promise<{
   outputFile: string
   browsers: string[]
@@ -229,7 +230,7 @@ export async function bundlePlayWrightProject (
   const playwrightVersion = getPlaywrightVersionFromPackage(dir)
 
   const [cacheHash] = await Promise.all([
-    getCacheHash(lockfile),
+    getCacheHash(lockfile, installCommand),
     loadPlaywrightProjectFiles(dir, pwConfigParsed, include, archive, lockfile),
   ])
 
@@ -251,10 +252,13 @@ export async function bundlePlayWrightProject (
   })
 }
 
-export async function getCacheHash (lockFile: string): Promise<string> {
+async function getCacheHash (lockFile: string, installCommand?: string): Promise<string> {
   const fileBuffer = await readFile(lockFile)
   const hash = createHash('sha256')
   hash.update(fileBuffer)
+  if (installCommand) {
+    hash.update(installCommand)
+  }
   return hash.digest('hex')
 }
 


### PR DESCRIPTION
Taking the installCommand into account when computing the code bundle hash will ensure we don't reuse the cache in case the installCommand changes.

See also:

- [Linear Ticket: Automatically refresh cache when installCommand Changes](https://linear.app/checklyhq/issue/RED-110/automatically-refresh-the-cache-hash-when-installcommand-changes)
- https://github.com/checkly/checkly-runners/pull/3009

## Affected Components
* CLI