### PR TITLE
fix: remove trailing spaces and dangling characters in --create-check [red-116]

### DIFF
--- a/packages/cli/src/commands/pw-test.ts
+++ b/packages/cli/src/commands/pw-test.ts
@@ -397,8 +397,8 @@ export default class PwTestCommand extends AuthCommand {
       : { locations: [runLocation || DEFAULT_REGION] }
 
     return {
-      logicalId: `playwright-check-${inputLogicalId}`,
-      name: `Playwright Test: ${input}`,
+      logicalId: inputLogicalId ? `playwright-check-${inputLogicalId}` : 'playwright-check',
+      name: input ? `Playwright Test: ${input}` : 'Playwright Test',
       testCommand,
       ...locationConfig,
       frequency,
@@ -458,6 +458,7 @@ export default class PwTestCommand extends AuthCommand {
   private static async getTestCommand (directoryPath: string, input: string): Promise<string | undefined> {
     const packageManager = await detectPackageManager(directoryPath)
     // Passing the input to the execCommand will return it quoted, which we want to avoid
-    return `${packageManager.execCommand(['playwright', 'test']).unsafeDisplayCommand} ${input}`
+    const baseCommand = packageManager.execCommand(['playwright', 'test']).unsafeDisplayCommand
+    return input ? `${baseCommand} ${input}` : baseCommand
   }
 }


### PR DESCRIPTION
… [red-116]

## Affected Components
* [ ] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

Remove trailing spaces and dangling characters with empty pw-test options, add conditions to remove spaces, ':', '-' if theres nothing to show after that: 

Before

<img width="769" height="432" alt="image" src="https://github.com/user-attachments/assets/11bab52a-adb6-42c7-9924-aa712c2870df" />

After

<img width="516" height="346" alt="image" src="https://github.com/user-attachments/assets/b9b3a13b-3c14-4e88-90b5-759a96d7afac" />
