### PR TITLE
fix: exclude runtimeId from PlaywrightCheckProps

### DIFF
--- a/packages/cli/src/constructs/playwright-check.ts
+++ b/packages/cli/src/constructs/playwright-check.ts
@@ -21,7 +21,7 @@ import { Session } from './project'
 import { Ref } from './ref'
 import { ConfigDefaultsGetter, makeConfigDefaultsGetter } from './check-config'
 
-export interface PlaywrightCheckProps extends Omit<RuntimeCheckProps, 'retryStrategy' | 'doubleCheck'> {
+export interface PlaywrightCheckProps extends Omit<RuntimeCheckProps, 'retryStrategy' | 'doubleCheck' | 'runtimeId'> {
   /**
    * Path to the Playwright configuration file (playwright.config.js/ts).
    * This file defines test settings, browser configurations, and project structure.


### PR DESCRIPTION
The runtimeId property should not be configurable for Playwright checks since they use a fixed runtime.

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

Just fixing the typings for `PlaywrightCheck` as it doesn't use a runtime

Context: 

https://checklyhq.slack.com/archives/C04PFSV5W3B/p1770309102867809