### PR TITLE
fix: correct Claude Code operator env var name

### DIFF
--- a/packages/cli/src/rest/__tests__/api.spec.ts
+++ b/packages/cli/src/rest/__tests__/api.spec.ts
@@ -3,7 +3,7 @@ import { detectOperator } from '../api'
 
 describe('detectOperator', () => {
   const envVarsToClean = [
-    'CLAUDE_CODE',
+    'CLAUDECODE',
     'CURSOR_TRACE_ID',
     'TERM_PROGRAM',
     'GITHUB_COPILOT',
@@ -26,7 +26,7 @@ describe('detectOperator', () => {
   })
 
   it('detects Claude Code', () => {
-    process.env.CLAUDE_CODE = '1'
+    process.env.CLAUDECODE = '1'
     expect(detectOperator()).toBe('claude-code')
   })
 
@@ -81,7 +81,7 @@ describe('detectOperator', () => {
   })
 
   it('prioritizes Claude Code over CI', () => {
-    process.env.CLAUDE_CODE = '1'
+    process.env.CLAUDECODE = '1'
     process.env.CI = 'true'
     expect(detectOperator()).toBe('claude-code')
   })

--- a/packages/cli/src/rest/api.ts
+++ b/packages/cli/src/rest/api.ts
@@ -55,7 +55,7 @@ export async function validateAuthentication (): Promise<Account | undefined> {
 }
 
 export function detectOperator (): string {
-  if (process.env.CLAUDE_CODE) return 'claude-code'
+  if (process.env.CLAUDECODE) return 'claude-code'
   if (process.env.CURSOR_TRACE_ID) return 'cursor'
   if (process.env.TERM_PROGRAM === 'vscode') return 'vscode'
   if (process.env.GITHUB_COPILOT) return 'github-copilot'


### PR DESCRIPTION
## Summary
- Wrong env var name: `CLAUDE_CODE` → `CLAUDECODE`

## Test plan
- [x] Unit tests updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)