### PR TITLE
fix: package files should not be included when parsing browser, api or multi-step checks

### DIFF
--- a/packages/cli/src/constructs/__tests__/api-check.spec.ts
+++ b/packages/cli/src/constructs/__tests__/api-check.spec.ts
@@ -57,10 +57,6 @@ describe('ApiCheck', () => {
       payload: expect.objectContaining({
         sharedFiles: [
           expect.objectContaining({
-            path: 'package.json',
-            content: fs.readFileSync(fixt.abspath('package.json'), 'utf8'),
-          }),
-          expect.objectContaining({
             path: 'test-cases/test-script-dependencies/dep1.js',
             content: fs.readFileSync(fixt.abspath('test-cases/test-script-dependencies/dep1.js'), 'utf8'),
           }),
@@ -79,7 +75,6 @@ describe('ApiCheck', () => {
               setupScriptDependencies: [
                 0,
                 1,
-                2,
               ],
             }),
           }),
@@ -92,7 +87,6 @@ describe('ApiCheck', () => {
               tearDownScriptDependencies: [
                 0,
                 1,
-                2,
               ],
             }),
           }),

--- a/packages/cli/src/constructs/__tests__/browser-check.spec.ts
+++ b/packages/cli/src/constructs/__tests__/browser-check.spec.ts
@@ -57,10 +57,6 @@ describe('BrowserCheck', () => {
       payload: expect.objectContaining({
         sharedFiles: [
           expect.objectContaining({
-            path: 'package.json',
-            content: fs.readFileSync(fixt.abspath('package.json'), 'utf8'),
-          }),
-          expect.objectContaining({
             path: 'test-cases/test-code-dependencies/dep1.js',
             content: fs.readFileSync(fixt.abspath('test-cases/test-code-dependencies/dep1.js'), 'utf8'),
           }),
@@ -80,7 +76,6 @@ describe('BrowserCheck', () => {
               dependencies: [
                 0,
                 1,
-                2,
               ],
             }),
           }),

--- a/packages/cli/src/services/check-parser/__tests__/check-parser.spec.ts
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser.spec.ts
@@ -27,323 +27,684 @@ describe('dependency-parser - parser()', () => {
     await fixt?.destroy()
   })
 
-  it('should handle JS file with no dependencies', async () => {
-    const parser = new Parser({
-      supportedNpmModules: defaultNpmModules,
-    })
-    const { dependencies } = await parser.parse(fixt.abspath('no-dependencies.js'))
-    expect(dependencies.map(d => d.filePath)).toHaveLength(0)
-  })
-
-  it('should handle JS file with dependencies', async () => {
-    const toAbsolutePath = (...filepath: string[]) => fixt.abspath('simple-example', ...filepath)
-    const parser = new Parser({
-      supportedNpmModules: defaultNpmModules,
-    })
-    const { dependencies } = await parser.parse(toAbsolutePath('entrypoint.js'))
-    expect(dependencies.map(d => d.filePath).sort()).toEqual([
-      toAbsolutePath('dep1.js'),
-      toAbsolutePath('dep2.js'),
-      toAbsolutePath('dep3.js'),
-      toAbsolutePath('module-package', 'main.js'),
-      toAbsolutePath('module-package', 'package.json'),
-      toAbsolutePath('module', 'index.js'),
-    ])
-  })
-
-  it('should report a missing entrypoint file', async () => {
-    const missingEntrypoint = fixt.abspath('does-not-exist.js')
-    expect.assertions(1)
-    try {
+  describe('unrestricted mode', () => {
+    it('should handle JS file with no dependencies', async () => {
       const parser = new Parser({
         supportedNpmModules: defaultNpmModules,
+        restricted: false,
       })
-      await parser.parse(missingEntrypoint)
-    } catch (err) {
-      expect(err).toMatchObject({ missingFiles: [missingEntrypoint] })
-    }
-  })
+      const { dependencies } = await parser.parse(fixt.abspath('no-dependencies.js'))
+      expect(dependencies.map(d => d.filePath)).toHaveLength(0)
+    })
 
-  it('should report missing check dependencies', async () => {
-    expect.assertions(1)
-    try {
+    it('should handle JS file with dependencies', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('simple-example', ...filepath)
       const parser = new Parser({
         supportedNpmModules: defaultNpmModules,
+        restricted: false,
       })
-      await parser.parse(fixt.abspath('missing-dependencies.js'))
-    } catch (err) {
-      expect(err).toMatchObject({
-        missingFiles: [
-          fixt.abspath('does-not-exist.js'),
-          fixt.abspath('does-not-exist2.js'),
-        ],
-      })
-    }
-  })
-
-  it('should report syntax errors', async () => {
-    const entrypoint = fixt.abspath('syntax-error.js')
-    expect.assertions(1)
-    try {
-      const parser = new Parser({
-        supportedNpmModules: defaultNpmModules,
-      })
-      await parser.parse(entrypoint)
-    } catch (err) {
-      expect(err).toMatchObject({
-        parseErrors: [
-          { file: entrypoint, error: 'Unexpected token (4:70)' },
-        ],
-      })
-    }
-  })
-
-  it('should report unsupported dependencies', async () => {
-    const entrypoint = fixt.abspath('unsupported-dependencies.js')
-    expect.assertions(1)
-    try {
-      const parser = new Parser({
-        supportedNpmModules: defaultNpmModules,
-      })
-      await parser.parse(entrypoint)
-    } catch (err) {
-      expect(err).toMatchObject({
-        unsupportedNpmDependencies: [{
-          file: entrypoint,
-          unsupportedDependencies: ['left-pad', 'right-pad'],
-        }],
-      })
-    }
-  })
-
-  it('should allow unsupported dependencies if configured to do so', async () => {
-    const entrypoint = fixt.abspath('unsupported-dependencies.js')
-    const parser = new Parser({
-      supportedNpmModules: defaultNpmModules,
-      checkUnsupportedModules: false,
-    })
-    await parser.parse(entrypoint)
-  })
-
-  it('should handle circular dependencies', async () => {
-    const toAbsolutePath = (...filepath: string[]) => fixt.abspath('circular-dependencies', ...filepath)
-    const parser = new Parser({
-      supportedNpmModules: defaultNpmModules,
-    })
-    const { dependencies } = await parser.parse(toAbsolutePath('entrypoint.js'))
-
-    // Circular dependencies are allowed in Node.js
-    // We just need to test that parsing the dependencies doesn't loop indefinitely
-    // https://nodejs.org/api/modules.html#modules_cycles
-    expect(dependencies.map(d => d.filePath).sort()).toEqual([
-      toAbsolutePath('dep1.js'),
-      toAbsolutePath('dep2.js'),
-    ])
-  })
-
-  it('should parse typescript dependencies', async () => {
-    const toAbsolutePath = (...filepath: string[]) => fixt.abspath('typescript-example', ...filepath)
-    const parser = new Parser({
-      supportedNpmModules: defaultNpmModules,
-    })
-    const { dependencies } = await parser.parse(toAbsolutePath('entrypoint.ts'))
-    expect(dependencies.map(d => d.filePath).sort()).toEqual([
-      toAbsolutePath('dep1.ts'),
-      toAbsolutePath('dep2.ts'),
-      toAbsolutePath('dep3.ts'),
-      toAbsolutePath('dep4.js'),
-      toAbsolutePath('dep5.ts'),
-      toAbsolutePath('dep6.ts'),
-      toAbsolutePath('module-package', 'main.js'),
-      toAbsolutePath('module-package', 'package.json'),
-      toAbsolutePath('module', 'index.ts'),
-      toAbsolutePath('pages/external.first.page.js'),
-      toAbsolutePath('pages/external.second.page.ts'),
-      toAbsolutePath('type.ts'),
-    ])
-  })
-
-  it('should parse typescript dependencies relying on tsconfig when tsconfig has comments', async () => {
-    const toAbsolutePath = (...filepath: string[]) => fixt.abspath('tsconfig-json-text', ...filepath)
-    const parser = new Parser({
-      supportedNpmModules: defaultNpmModules,
-    })
-    const { dependencies } = await parser.parse(toAbsolutePath('src', 'entrypoint.ts'))
-    expect(dependencies.map(d => d.filePath).sort()).toEqual([
-      toAbsolutePath('lib', 'foo1.ts'),
-      toAbsolutePath('tsconfig.json'),
-    ])
-  })
-
-  it('should parse typescript dependencies using tsconfig paths', async () => {
-    const toAbsolutePath = (...filepath: string[]) => fixt.abspath('tsconfig-paths-sample-project', ...filepath)
-    const parser = new Parser({
-      supportedNpmModules: defaultNpmModules,
-    })
-    const { dependencies } = await parser.parse(toAbsolutePath('src', 'entrypoint.ts'))
-    expect(dependencies.map(d => d.filePath).sort()).toEqual([
-      toAbsolutePath('lib1', 'file1.ts'),
-      toAbsolutePath('lib1', 'file2.ts'),
-      toAbsolutePath('lib1', 'folder', 'file1.ts'),
-      toAbsolutePath('lib1', 'folder', 'file2.ts'),
-      toAbsolutePath('lib1', 'index.ts'),
-      toAbsolutePath('lib1', 'package.json'),
-      toAbsolutePath('lib1', 'tsconfig.json'),
-      toAbsolutePath('lib2', 'index.ts'),
-      toAbsolutePath('lib3', 'foo', 'bar.ts'),
-      toAbsolutePath('lib3', 'jsconfig.json'),
-      toAbsolutePath('package.json'),
-      toAbsolutePath('tsconfig.json'),
-    ])
-  })
-
-  it('should parse typescript dependencies using tsconfig paths relative to baseUrl', async () => {
-    const toAbsolutePath = (...filepath: string[]) => fixt.abspath('tsconfig-paths-baseurl-relative', ...filepath)
-    const parser = new Parser({
-      supportedNpmModules: defaultNpmModules,
-    })
-    const { dependencies } = await parser.parse(toAbsolutePath('src', 'entrypoint.ts'))
-    expect(dependencies.map(d => d.filePath).sort()).toEqual([
-      toAbsolutePath('package.json'),
-      toAbsolutePath('src', 'lib1', 'file1.ts'),
-      toAbsolutePath('src', 'lib1', 'file2.ts'),
-      toAbsolutePath('src', 'lib1', 'folder', 'file1.ts'),
-      toAbsolutePath('src', 'lib1', 'folder', 'file2.ts'),
-      toAbsolutePath('src', 'lib1', 'index.ts'),
-      toAbsolutePath('src', 'lib1', 'package.json'),
-      toAbsolutePath('src', 'lib1', 'tsconfig.json'),
-      toAbsolutePath('src', 'lib2', 'index.ts'),
-      toAbsolutePath('src', 'lib3', 'foo', 'bar.ts'),
-      toAbsolutePath('src', 'lib3', 'jsconfig.json'),
-      toAbsolutePath('tsconfig.json'),
-    ])
-  })
-
-  it('should always include tsconfig even if not needed', async () => {
-    const toAbsolutePath = (...filepath: string[]) => fixt.abspath('tsconfig-paths-unused', ...filepath)
-    const parser = new Parser({
-      supportedNpmModules: defaultNpmModules,
-    })
-    const { dependencies } = await parser.parse(toAbsolutePath('src', 'entrypoint.ts'))
-    expect(dependencies.map(d => d.filePath).sort()).toEqual([
-      toAbsolutePath('tsconfig.json'),
-    ])
-  })
-
-  it('should support importing ts extensions if allowed', async () => {
-    const toAbsolutePath = (...filepath: string[]) => fixt.abspath('tsconfig-allow-importing-ts-extensions', ...filepath)
-    const parser = new Parser({
-      supportedNpmModules: defaultNpmModules,
-    })
-    const { dependencies } = await parser.parse(toAbsolutePath('src', 'entrypoint.ts'))
-    expect(dependencies.map(d => d.filePath).sort()).toEqual([
-      toAbsolutePath('src', 'dep1.ts'),
-      toAbsolutePath('src', 'dep2.ts'),
-      toAbsolutePath('src', 'dep3.ts'),
-      toAbsolutePath('tsconfig.json'),
-    ])
-  })
-
-  it('should not import TS files from a JS file', async () => {
-    const toAbsolutePath = (...filepath: string[]) => fixt.abspath('no-import-ts-from-js', ...filepath)
-    const parser = new Parser({
-      supportedNpmModules: defaultNpmModules,
-    })
-    expect.assertions(1)
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { dependencies } = await parser.parse(toAbsolutePath('entrypoint.js'))
-    } catch (err) {
-      expect(err).toMatchObject({
-        missingFiles: [
-          toAbsolutePath('dep1'),
-          toAbsolutePath('dep1.ts'),
-          toAbsolutePath('dep1.js'),
-        ],
+      expect(dependencies.map(d => d.filePath).sort()).toEqual([
+        toAbsolutePath('dep1.js'),
+        toAbsolutePath('dep2.js'),
+        toAbsolutePath('dep3.js'),
+        toAbsolutePath('module-package', 'main.js'),
+        toAbsolutePath('module-package', 'package.json'),
+        toAbsolutePath('module', 'index.js'),
+      ])
+    })
+
+    it('should report a missing entrypoint file', async () => {
+      const missingEntrypoint = fixt.abspath('does-not-exist.js')
+      expect.assertions(1)
+      try {
+        const parser = new Parser({
+          supportedNpmModules: defaultNpmModules,
+          restricted: false,
+        })
+        await parser.parse(missingEntrypoint)
+      } catch (err) {
+        expect(err).toMatchObject({ missingFiles: [missingEntrypoint] })
+      }
+    })
+
+    it('should report missing check dependencies', async () => {
+      expect.assertions(1)
+      try {
+        const parser = new Parser({
+          supportedNpmModules: defaultNpmModules,
+          restricted: false,
+        })
+        await parser.parse(fixt.abspath('missing-dependencies.js'))
+      } catch (err) {
+        expect(err).toMatchObject({
+          missingFiles: [
+            fixt.abspath('does-not-exist.js'),
+            fixt.abspath('does-not-exist2.js'),
+          ],
+        })
+      }
+    })
+
+    it('should report syntax errors', async () => {
+      const entrypoint = fixt.abspath('syntax-error.js')
+      expect.assertions(1)
+      try {
+        const parser = new Parser({
+          supportedNpmModules: defaultNpmModules,
+          restricted: false,
+        })
+        await parser.parse(entrypoint)
+      } catch (err) {
+        expect(err).toMatchObject({
+          parseErrors: [
+            { file: entrypoint, error: 'Unexpected token (4:70)' },
+          ],
+        })
+      }
+    })
+
+    it('should report unsupported dependencies', async () => {
+      const entrypoint = fixt.abspath('unsupported-dependencies.js')
+      expect.assertions(1)
+      try {
+        const parser = new Parser({
+          supportedNpmModules: defaultNpmModules,
+          restricted: false,
+        })
+        await parser.parse(entrypoint)
+      } catch (err) {
+        expect(err).toMatchObject({
+          unsupportedNpmDependencies: [{
+            file: entrypoint,
+            unsupportedDependencies: ['left-pad', 'right-pad'],
+          }],
+        })
+      }
+    })
+
+    it('should allow unsupported dependencies if configured to do so', async () => {
+      const entrypoint = fixt.abspath('unsupported-dependencies.js')
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        checkUnsupportedModules: false,
+        restricted: false,
       })
-    }
-  })
-
-  it('should import JS files from a TS file', async () => {
-    const toAbsolutePath = (...filepath: string[]) => fixt.abspath('import-js-from-ts', ...filepath)
-    const parser = new Parser({
-      supportedNpmModules: defaultNpmModules,
+      await parser.parse(entrypoint)
     })
-    const { dependencies } = await parser.parse(toAbsolutePath('entrypoint.ts'))
-    expect(dependencies.map(d => d.filePath).sort()).toEqual([
-      toAbsolutePath('dep1.js'),
-      toAbsolutePath('dep2.js'),
-      toAbsolutePath('dep3.ts'),
-    ])
-  })
 
-  it('should handle ES Modules', async () => {
-    const toAbsolutePath = (...filepath: string[]) => fixt.abspath('esmodules-example', ...filepath)
-    const parser = new Parser({
-      supportedNpmModules: defaultNpmModules,
+    it('should handle circular dependencies', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('circular-dependencies', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: false,
+      })
+      const { dependencies } = await parser.parse(toAbsolutePath('entrypoint.js'))
+
+      // Circular dependencies are allowed in Node.js
+      // We just need to test that parsing the dependencies doesn't loop indefinitely
+      // https://nodejs.org/api/modules.html#modules_cycles
+      expect(dependencies.map(d => d.filePath).sort()).toEqual([
+        toAbsolutePath('dep1.js'),
+        toAbsolutePath('dep2.js'),
+      ])
     })
-    const { dependencies } = await parser.parse(toAbsolutePath('entrypoint.js'))
-    expect(dependencies.map(d => d.filePath).sort()).toEqual([
-      toAbsolutePath('dep1.js'),
-      toAbsolutePath('dep2.js'),
-      toAbsolutePath('dep3.js'),
-      toAbsolutePath('dep5.js'),
-      toAbsolutePath('dep6.js'),
-    ])
-  })
 
-  it('should handle Common JS and ES Modules', async () => {
-    const toAbsolutePath = (...filepath: string[]) => fixt.abspath('common-esm-example', ...filepath)
-    const parser = new Parser({
-      supportedNpmModules: defaultNpmModules,
+    it('should parse typescript dependencies', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('typescript-example', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: false,
+      })
+      const { dependencies } = await parser.parse(toAbsolutePath('entrypoint.ts'))
+      expect(dependencies.map(d => d.filePath).sort()).toEqual([
+        toAbsolutePath('dep1.ts'),
+        toAbsolutePath('dep2.ts'),
+        toAbsolutePath('dep3.ts'),
+        toAbsolutePath('dep4.js'),
+        toAbsolutePath('dep5.ts'),
+        toAbsolutePath('dep6.ts'),
+        toAbsolutePath('module-package', 'main.js'),
+        toAbsolutePath('module-package', 'package.json'),
+        toAbsolutePath('module', 'index.ts'),
+        toAbsolutePath('pages/external.first.page.js'),
+        toAbsolutePath('pages/external.second.page.ts'),
+        toAbsolutePath('type.ts'),
+      ])
     })
-    const { dependencies } = await parser.parse(toAbsolutePath('entrypoint.mjs'))
-    expect(dependencies.map(d => d.filePath).sort()).toEqual([
-      toAbsolutePath('dep1.js'),
-      toAbsolutePath('dep2.mjs'),
-      toAbsolutePath('dep3.mjs'),
-      toAbsolutePath('dep4.mjs'),
-      toAbsolutePath('dep5.mjs'),
-      toAbsolutePath('dep6.mjs'),
-    ])
-  })
 
-  it('should handle node: prefix for built-ins', async () => {
-    const toAbsolutePath = (...filepath: string[]) => fixt.abspath('builtin-with-node-prefix', ...filepath)
-    const parser = new Parser({
-      supportedNpmModules: defaultNpmModules,
+    it('should parse typescript dependencies relying on tsconfig when tsconfig has comments', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('tsconfig-json-text', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: false,
+      })
+      const { dependencies } = await parser.parse(toAbsolutePath('src', 'entrypoint.ts'))
+      expect(dependencies.map(d => d.filePath).sort()).toEqual([
+        toAbsolutePath('lib', 'foo1.ts'),
+        toAbsolutePath('tsconfig.json'),
+      ])
     })
-    await parser.parse(toAbsolutePath('entrypoint.ts'))
-  })
 
-  /*
+    it('should parse typescript dependencies using tsconfig paths', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('tsconfig-paths-sample-project', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: false,
+      })
+      const { dependencies } = await parser.parse(toAbsolutePath('src', 'entrypoint.ts'))
+      expect(dependencies.map(d => d.filePath).sort()).toEqual([
+        toAbsolutePath('lib1', 'file1.ts'),
+        toAbsolutePath('lib1', 'file2.ts'),
+        toAbsolutePath('lib1', 'folder', 'file1.ts'),
+        toAbsolutePath('lib1', 'folder', 'file2.ts'),
+        toAbsolutePath('lib1', 'index.ts'),
+        toAbsolutePath('lib1', 'package.json'),
+        toAbsolutePath('lib1', 'tsconfig.json'),
+        toAbsolutePath('lib2', 'index.ts'),
+        toAbsolutePath('lib3', 'foo', 'bar.ts'),
+        toAbsolutePath('lib3', 'jsconfig.json'),
+        toAbsolutePath('package.json'),
+        toAbsolutePath('tsconfig.json'),
+      ])
+    })
+
+    it('should parse typescript dependencies using tsconfig paths relative to baseUrl', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('tsconfig-paths-baseurl-relative', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: false,
+      })
+      const { dependencies } = await parser.parse(toAbsolutePath('src', 'entrypoint.ts'))
+      expect(dependencies.map(d => d.filePath).sort()).toEqual([
+        toAbsolutePath('package.json'),
+        toAbsolutePath('src', 'lib1', 'file1.ts'),
+        toAbsolutePath('src', 'lib1', 'file2.ts'),
+        toAbsolutePath('src', 'lib1', 'folder', 'file1.ts'),
+        toAbsolutePath('src', 'lib1', 'folder', 'file2.ts'),
+        toAbsolutePath('src', 'lib1', 'index.ts'),
+        toAbsolutePath('src', 'lib1', 'package.json'),
+        toAbsolutePath('src', 'lib1', 'tsconfig.json'),
+        toAbsolutePath('src', 'lib2', 'index.ts'),
+        toAbsolutePath('src', 'lib3', 'foo', 'bar.ts'),
+        toAbsolutePath('src', 'lib3', 'jsconfig.json'),
+        toAbsolutePath('tsconfig.json'),
+      ])
+    })
+
+    it('should always include tsconfig even if not needed', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('tsconfig-paths-unused', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: false,
+      })
+      const { dependencies } = await parser.parse(toAbsolutePath('src', 'entrypoint.ts'))
+      expect(dependencies.map(d => d.filePath).sort()).toEqual([
+        toAbsolutePath('tsconfig.json'),
+      ])
+    })
+
+    it('should support importing ts extensions if allowed', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('tsconfig-allow-importing-ts-extensions', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: false,
+      })
+      const { dependencies } = await parser.parse(toAbsolutePath('src', 'entrypoint.ts'))
+      expect(dependencies.map(d => d.filePath).sort()).toEqual([
+        toAbsolutePath('src', 'dep1.ts'),
+        toAbsolutePath('src', 'dep2.ts'),
+        toAbsolutePath('src', 'dep3.ts'),
+        toAbsolutePath('tsconfig.json'),
+      ])
+    })
+
+    it('should not import TS files from a JS file', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('no-import-ts-from-js', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: false,
+      })
+      expect.assertions(1)
+      try {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { dependencies } = await parser.parse(toAbsolutePath('entrypoint.js'))
+      } catch (err) {
+        expect(err).toMatchObject({
+          missingFiles: [
+            toAbsolutePath('dep1'),
+            toAbsolutePath('dep1.ts'),
+            toAbsolutePath('dep1.js'),
+          ],
+        })
+      }
+    })
+
+    it('should import JS files from a TS file', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('import-js-from-ts', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: false,
+      })
+      const { dependencies } = await parser.parse(toAbsolutePath('entrypoint.ts'))
+      expect(dependencies.map(d => d.filePath).sort()).toEqual([
+        toAbsolutePath('dep1.js'),
+        toAbsolutePath('dep2.js'),
+        toAbsolutePath('dep3.ts'),
+      ])
+    })
+
+    it('should handle ES Modules', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('esmodules-example', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: false,
+      })
+      const { dependencies } = await parser.parse(toAbsolutePath('entrypoint.js'))
+      expect(dependencies.map(d => d.filePath).sort()).toEqual([
+        toAbsolutePath('dep1.js'),
+        toAbsolutePath('dep2.js'),
+        toAbsolutePath('dep3.js'),
+        toAbsolutePath('dep5.js'),
+        toAbsolutePath('dep6.js'),
+      ])
+    })
+
+    it('should handle Common JS and ES Modules', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('common-esm-example', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: false,
+      })
+      const { dependencies } = await parser.parse(toAbsolutePath('entrypoint.mjs'))
+      expect(dependencies.map(d => d.filePath).sort()).toEqual([
+        toAbsolutePath('dep1.js'),
+        toAbsolutePath('dep2.mjs'),
+        toAbsolutePath('dep3.mjs'),
+        toAbsolutePath('dep4.mjs'),
+        toAbsolutePath('dep5.mjs'),
+        toAbsolutePath('dep6.mjs'),
+      ])
+    })
+
+    it('should handle node: prefix for built-ins', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('builtin-with-node-prefix', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: false,
+      })
+      await parser.parse(toAbsolutePath('entrypoint.ts'))
+    })
+
+    /*
    * There is an unhandled edge-case when require() is reassigned.
    * Even though the check might execute fine, we throw an error for a missing dependency.
    * We could address this by keeping track of assignments as we walk the AST.
    */
-  it.skip('should ignore cases where require is reassigned', async () => {
-    const entrypoint = fixt.abspath('reassign-require.js')
-    const parser = new Parser({
-      supportedNpmModules: defaultNpmModules,
+    it.skip('should ignore cases where require is reassigned', async () => {
+      const entrypoint = fixt.abspath('reassign-require.js')
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: false,
+      })
+      await parser.parse(entrypoint)
     })
-    await parser.parse(entrypoint)
+
+    // Checks run on Checkly are wrapped to support top level await.
+    // For consistency with checks created via the UI, the CLI should support this as well.
+    it('should allow top-level await', async () => {
+      const entrypoint = fixt.abspath('top-level-await.js')
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: false,
+      })
+      await parser.parse(entrypoint)
+    })
+
+    it('should allow top-level await in TypeScript', async () => {
+      const entrypoint = fixt.abspath('top-level-await.ts')
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: false,
+      })
+      await parser.parse(entrypoint)
+    })
   })
 
-  // Checks run on Checkly are wrapped to support top level await.
-  // For consistency with checks created via the UI, the CLI should support this as well.
-  it('should allow top-level await', async () => {
-    const entrypoint = fixt.abspath('top-level-await.js')
-    const parser = new Parser({
-      supportedNpmModules: defaultNpmModules,
+  describe('restricted mode', () => {
+    it('should handle JS file with no dependencies', async () => {
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: true,
+      })
+      const { dependencies } = await parser.parse(fixt.abspath('no-dependencies.js'))
+      expect(dependencies.map(d => d.filePath)).toHaveLength(0)
     })
-    await parser.parse(entrypoint)
-  })
 
-  it('should allow top-level await in TypeScript', async () => {
-    const entrypoint = fixt.abspath('top-level-await.ts')
-    const parser = new Parser({
-      supportedNpmModules: defaultNpmModules,
+    it('should handle JS file with dependencies', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('simple-example', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: true,
+      })
+      const { dependencies } = await parser.parse(toAbsolutePath('entrypoint.js'))
+      expect(dependencies.map(d => d.filePath).sort()).toEqual([
+        toAbsolutePath('dep1.js'),
+        toAbsolutePath('dep2.js'),
+        toAbsolutePath('dep3.js'),
+        toAbsolutePath('module-package', 'main.js'),
+        toAbsolutePath('module-package', 'package.json'),
+        toAbsolutePath('module', 'index.js'),
+      ])
     })
-    await parser.parse(entrypoint)
+
+    it('should report a missing entrypoint file', async () => {
+      const missingEntrypoint = fixt.abspath('does-not-exist.js')
+      expect.assertions(1)
+      try {
+        const parser = new Parser({
+          supportedNpmModules: defaultNpmModules,
+          restricted: true,
+        })
+        await parser.parse(missingEntrypoint)
+      } catch (err) {
+        expect(err).toMatchObject({ missingFiles: [missingEntrypoint] })
+      }
+    })
+
+    it('should report missing check dependencies', async () => {
+      expect.assertions(1)
+      try {
+        const parser = new Parser({
+          supportedNpmModules: defaultNpmModules,
+          restricted: true,
+        })
+        await parser.parse(fixt.abspath('missing-dependencies.js'))
+      } catch (err) {
+        expect(err).toMatchObject({
+          missingFiles: [
+            fixt.abspath('does-not-exist.js'),
+            fixt.abspath('does-not-exist2.js'),
+          ],
+        })
+      }
+    })
+
+    it('should report syntax errors', async () => {
+      const entrypoint = fixt.abspath('syntax-error.js')
+      expect.assertions(1)
+      try {
+        const parser = new Parser({
+          supportedNpmModules: defaultNpmModules,
+          restricted: true,
+        })
+        await parser.parse(entrypoint)
+      } catch (err) {
+        expect(err).toMatchObject({
+          parseErrors: [
+            { file: entrypoint, error: 'Unexpected token (4:70)' },
+          ],
+        })
+      }
+    })
+
+    it('should report unsupported dependencies', async () => {
+      const entrypoint = fixt.abspath('unsupported-dependencies.js')
+      expect.assertions(1)
+      try {
+        const parser = new Parser({
+          supportedNpmModules: defaultNpmModules,
+          restricted: true,
+        })
+        await parser.parse(entrypoint)
+      } catch (err) {
+        expect(err).toMatchObject({
+          unsupportedNpmDependencies: [{
+            file: entrypoint,
+            unsupportedDependencies: ['left-pad', 'right-pad'],
+          }],
+        })
+      }
+    })
+
+    it('should allow unsupported dependencies if configured to do so', async () => {
+      const entrypoint = fixt.abspath('unsupported-dependencies.js')
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        checkUnsupportedModules: false,
+        restricted: true,
+      })
+      await parser.parse(entrypoint)
+    })
+
+    it('should handle circular dependencies', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('circular-dependencies', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: true,
+      })
+      const { dependencies } = await parser.parse(toAbsolutePath('entrypoint.js'))
+
+      // Circular dependencies are allowed in Node.js
+      // We just need to test that parsing the dependencies doesn't loop indefinitely
+      // https://nodejs.org/api/modules.html#modules_cycles
+      expect(dependencies.map(d => d.filePath).sort()).toEqual([
+        toAbsolutePath('dep1.js'),
+        toAbsolutePath('dep2.js'),
+      ])
+    })
+
+    it('should parse typescript dependencies', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('typescript-example', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: true,
+      })
+      const { dependencies } = await parser.parse(toAbsolutePath('entrypoint.ts'))
+      expect(dependencies.map(d => d.filePath).sort()).toEqual([
+        toAbsolutePath('dep1.ts'),
+        toAbsolutePath('dep2.ts'),
+        toAbsolutePath('dep3.ts'),
+        toAbsolutePath('dep4.js'),
+        toAbsolutePath('dep5.ts'),
+        toAbsolutePath('dep6.ts'),
+        toAbsolutePath('module-package', 'main.js'),
+        toAbsolutePath('module-package', 'package.json'),
+        toAbsolutePath('module', 'index.ts'),
+        toAbsolutePath('pages/external.first.page.js'),
+        toAbsolutePath('pages/external.second.page.ts'),
+        toAbsolutePath('type.ts'),
+      ])
+    })
+
+    it('should parse typescript dependencies relying on tsconfig when tsconfig has comments', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('tsconfig-json-text', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: true,
+      })
+      const { dependencies } = await parser.parse(toAbsolutePath('src', 'entrypoint.ts'))
+      expect(dependencies.map(d => d.filePath).sort()).toEqual([
+        toAbsolutePath('lib', 'foo1.ts'),
+        toAbsolutePath('tsconfig.json'),
+      ])
+    })
+
+    it('should parse typescript dependencies using tsconfig paths', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('tsconfig-paths-sample-project', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: true,
+      })
+      const { dependencies } = await parser.parse(toAbsolutePath('src', 'entrypoint.ts'))
+      expect(dependencies.map(d => d.filePath).sort()).toEqual([
+        toAbsolutePath('lib1', 'file1.ts'),
+        toAbsolutePath('lib1', 'file2.ts'),
+        toAbsolutePath('lib1', 'folder', 'file1.ts'),
+        toAbsolutePath('lib1', 'folder', 'file2.ts'),
+        toAbsolutePath('lib1', 'index.ts'),
+        toAbsolutePath('lib1', 'package.json'),
+        toAbsolutePath('lib1', 'tsconfig.json'),
+        toAbsolutePath('lib2', 'index.ts'),
+        toAbsolutePath('lib3', 'foo', 'bar.ts'),
+        toAbsolutePath('tsconfig.json'),
+      ])
+    })
+
+    it('should parse typescript dependencies using tsconfig paths relative to baseUrl', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('tsconfig-paths-baseurl-relative', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: true,
+      })
+      const { dependencies } = await parser.parse(toAbsolutePath('src', 'entrypoint.ts'))
+      expect(dependencies.map(d => d.filePath).sort()).toEqual([
+        toAbsolutePath('src', 'lib1', 'file1.ts'),
+        toAbsolutePath('src', 'lib1', 'file2.ts'),
+        toAbsolutePath('src', 'lib1', 'folder', 'file1.ts'),
+        toAbsolutePath('src', 'lib1', 'folder', 'file2.ts'),
+        toAbsolutePath('src', 'lib1', 'index.ts'),
+        toAbsolutePath('src', 'lib1', 'package.json'),
+        toAbsolutePath('src', 'lib1', 'tsconfig.json'),
+        toAbsolutePath('src', 'lib2', 'index.ts'),
+        toAbsolutePath('src', 'lib3', 'foo', 'bar.ts'),
+        toAbsolutePath('tsconfig.json'),
+      ])
+    })
+
+    it('should not include tsconfig if not needed', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('tsconfig-paths-unused', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: true,
+      })
+      const { dependencies } = await parser.parse(toAbsolutePath('src', 'entrypoint.ts'))
+      expect(dependencies.map(d => d.filePath).sort()).toEqual([])
+    })
+
+    it('should support importing ts extensions if allowed', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('tsconfig-allow-importing-ts-extensions', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: true,
+      })
+      const { dependencies } = await parser.parse(toAbsolutePath('src', 'entrypoint.ts'))
+      expect(dependencies.map(d => d.filePath).sort()).toEqual([
+        toAbsolutePath('src', 'dep1.ts'),
+        toAbsolutePath('src', 'dep2.ts'),
+        toAbsolutePath('src', 'dep3.ts'),
+      ])
+    })
+
+    it('should not import TS files from a JS file', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('no-import-ts-from-js', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: true,
+      })
+      expect.assertions(1)
+      try {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { dependencies } = await parser.parse(toAbsolutePath('entrypoint.js'))
+      } catch (err) {
+        expect(err).toMatchObject({
+          missingFiles: [
+            toAbsolutePath('dep1'),
+            toAbsolutePath('dep1.ts'),
+            toAbsolutePath('dep1.js'),
+          ],
+        })
+      }
+    })
+
+    it('should import JS files from a TS file', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('import-js-from-ts', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: true,
+      })
+      const { dependencies } = await parser.parse(toAbsolutePath('entrypoint.ts'))
+      expect(dependencies.map(d => d.filePath).sort()).toEqual([
+        toAbsolutePath('dep1.js'),
+        toAbsolutePath('dep2.js'),
+        toAbsolutePath('dep3.ts'),
+      ])
+    })
+
+    it('should handle ES Modules', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('esmodules-example', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: true,
+      })
+      const { dependencies } = await parser.parse(toAbsolutePath('entrypoint.js'))
+      expect(dependencies.map(d => d.filePath).sort()).toEqual([
+        toAbsolutePath('dep1.js'),
+        toAbsolutePath('dep2.js'),
+        toAbsolutePath('dep3.js'),
+        toAbsolutePath('dep5.js'),
+        toAbsolutePath('dep6.js'),
+      ])
+    })
+
+    it('should handle Common JS and ES Modules', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('common-esm-example', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: true,
+      })
+      const { dependencies } = await parser.parse(toAbsolutePath('entrypoint.mjs'))
+      expect(dependencies.map(d => d.filePath).sort()).toEqual([
+        toAbsolutePath('dep1.js'),
+        toAbsolutePath('dep2.mjs'),
+        toAbsolutePath('dep3.mjs'),
+        toAbsolutePath('dep4.mjs'),
+        toAbsolutePath('dep5.mjs'),
+        toAbsolutePath('dep6.mjs'),
+      ])
+    })
+
+    it('should handle node: prefix for built-ins', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('builtin-with-node-prefix', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: true,
+      })
+      await parser.parse(toAbsolutePath('entrypoint.ts'))
+    })
+
+    /*
+   * There is an unhandled edge-case when require() is reassigned.
+   * Even though the check might execute fine, we throw an error for a missing dependency.
+   * We could address this by keeping track of assignments as we walk the AST.
+   */
+    it.skip('should ignore cases where require is reassigned', async () => {
+      const entrypoint = fixt.abspath('reassign-require.js')
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: true,
+      })
+      await parser.parse(entrypoint)
+    })
+
+    // Checks run on Checkly are wrapped to support top level await.
+    // For consistency with checks created via the UI, the CLI should support this as well.
+    it('should allow top-level await', async () => {
+      const entrypoint = fixt.abspath('top-level-await.js')
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: true,
+      })
+      await parser.parse(entrypoint)
+    })
+
+    it('should allow top-level await in TypeScript', async () => {
+      const entrypoint = fixt.abspath('top-level-await.ts')
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: true,
+      })
+      await parser.parse(entrypoint)
+    })
   })
 })

--- a/packages/cli/src/services/check-parser/package-files/resolver.ts
+++ b/packages/cli/src/services/check-parser/package-files/resolver.ts
@@ -441,31 +441,43 @@ export class PackageFilesResolver {
       }
     }
 
-    if (packageJson) {
-      resolved.local.push({
-        kind: 'nearest-package-json-file',
-        importPath: filePath,
-        sourceFile: packageJson.jsonFile.sourceFile,
-        packageJsonFile: packageJson,
-      })
-    }
+    // As above, only add nearest package files if we are not running in
+    // restricted mode.
+    //
+    // Including these files not only increases the size of the deployment,
+    // but can also affect the way Node.js treats the code files. Mainly,
+    // the package.json file can define whether the package uses CJS or ESM.
+    // Since our legacy runners do not support ESM, this leads into a
+    // compatibility issue. For tsconfig files, they will get included anyway
+    // if they are necessary for TypeScript file resolution, so including them
+    // here is not necessary in restricted mode.
+    if (!this.restricted) {
+      if (packageJson) {
+        resolved.local.push({
+          kind: 'nearest-package-json-file',
+          importPath: filePath,
+          sourceFile: packageJson.jsonFile.sourceFile,
+          packageJsonFile: packageJson,
+        })
+      }
 
-    if (tsconfigJson) {
-      resolved.local.push({
-        kind: 'nearest-tsconfig-file',
-        importPath: filePath,
-        sourceFile: tsconfigJson.jsonFile.sourceFile,
-        configFile: tsconfigJson,
-      })
-    }
+      if (tsconfigJson) {
+        resolved.local.push({
+          kind: 'nearest-tsconfig-file',
+          importPath: filePath,
+          sourceFile: tsconfigJson.jsonFile.sourceFile,
+          configFile: tsconfigJson,
+        })
+      }
 
-    if (jsconfigJson) {
-      resolved.local.push({
-        kind: 'nearest-tsconfig-file',
-        importPath: filePath,
-        sourceFile: jsconfigJson.jsonFile.sourceFile,
-        configFile: jsconfigJson,
-      })
+      if (jsconfigJson) {
+        resolved.local.push({
+          kind: 'nearest-tsconfig-file',
+          importPath: filePath,
+          sourceFile: jsconfigJson.jsonFile.sourceFile,
+          configFile: jsconfigJson,
+        })
+      }
     }
 
     const usedNeighbors = new Set<Package>()


### PR DESCRIPTION
## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

In version 7.x, we started including these files for all check types even though they were truly only needed for playwright checks. This change was intentional to keep the two parsing modes more in line with each other, and even though the older check types could not make use of the extra files, it was thought that including them would do no harm. However, especially package.json can in fact have a large effect: it can define whether the package uses CJS or ESM. Since our non-playwright runners only support CJS, this created a conflict if a check using CJS was deployed from within a package configured to use ESM.

We now return to the earlier mode for the other check types where these files are not included by default.

Fixes #1224.

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->
