### PR TITLE
fix: error out if node_modules doesn't contain correct @playwright/test version

### DIFF
--- a/packages/cli/src/constructs/api-check.ts
+++ b/packages/cli/src/constructs/api-check.ts
@@ -11,7 +11,6 @@ import { DeprecatedPropertyDiagnostic, InvalidPropertyValueDiagnostic } from './
 import { ApiCheckBundle, ApiCheckBundleProps } from './api-check-bundle'
 import { Assertion } from './api-assertion'
 import { validateResponseTimes } from './internal/common-diagnostics'
-import { Runtime } from '../runtimes'
 
 /**
  * Default configuration that can be applied to API checks.

--- a/packages/cli/src/services/__tests__/util.spec.ts
+++ b/packages/cli/src/services/__tests__/util.spec.ts
@@ -30,17 +30,17 @@ describe('util', () => {
   })
 
   describe('getPlaywrightVersionFromPackage()', () => {
-    it('should throw error when playwright package is not found', () => {
+    it('should throw error when playwright package is not found', async () => {
       // Use a directory that doesn't have playwright installed
       const nonExistentDir = '/tmp/non-existent-dir'
-      expect(() => getPlaywrightVersionFromPackage(nonExistentDir))
-        .toThrow('Could not find @playwright/test package. Make sure it is installed.')
+      await expect(getPlaywrightVersionFromPackage(nonExistentDir))
+        .rejects.toThrow('Could not find @playwright/test package. Make sure it is installed.')
     })
 
-    it('should get version from installed playwright package', () => {
+    it('should get version from installed playwright package', async () => {
       // Use the current working directory which should have playwright installed
       const currentDir = process.cwd()
-      const version = getPlaywrightVersionFromPackage(currentDir)
+      const version = await getPlaywrightVersionFromPackage(currentDir)
 
       // Should return a valid semver version
       expect(version).toMatch(/^\d+\.\d+\.\d+/)


### PR DESCRIPTION
The version of @playwright/test in node_modules might be out of sync with what is required in package.json/package-lock.json. In those rare cases the cli will report an incorrect playwright version to the API which will cause checks to fail as checks rely on the playwright version noted in lock files.

## Affected Components
* CLI