### PR TITLE
fix: guard against invalid versions in package.json when checking playwright version

### DIFF
--- a/packages/cli/src/services/util.ts
+++ b/packages/cli/src/services/util.ts
@@ -233,7 +233,13 @@ export async function getPlaywrightVersionFromPackage (cwd: string): Promise<str
     const range =
       packageJson.dependencies?.['@playwright/test']
       ?? packageJson.devDependencies?.['@playwright/test']
-    if (range && !semver.satisfies(version, range)) {
+
+    if (!range) {
+      return version
+    }
+
+    const validRange = semver.validRange(range)
+    if (validRange && !semver.satisfies(version, validRange)) {
       throw new Error(
         `Installed @playwright/test version ${version} does not satisfy the required range "${range}" in package.json. `
         + 'Please run your package manager\'s install command to sync node_modules.',


### PR DESCRIPTION
There is a possibility that the range is not valid as it could point to a local copy of the package or be something like "catalog:" with pnpm. For invalid ranges, satisfies() would return just false which we wouldn't want.

https://github.com/checkly/checkly-cli/pull/1231/changes#r2833281214

## Affected Components
* CLI