### PR TITLE
feat(cli): add status-pages get command (TIM-25)

### DIFF
--- a/packages/cli/src/commands/status-pages/get.ts
+++ b/packages/cli/src/commands/status-pages/get.ts
@@ -1,0 +1,56 @@
+import { Args } from '@oclif/core'
+import chalk from 'chalk'
+import { AuthCommand } from '../authCommand'
+import { outputFlag } from '../../helpers/flags'
+import * as api from '../../rest/api'
+import type { OutputFormat } from '../../formatters/render'
+import { formatStatusPageDetail } from '../../formatters/status-pages'
+
+export default class StatusPagesGet extends AuthCommand {
+  static hidden = false
+  static description = 'Get details of a status page, including its cards and services.'
+
+  static args = {
+    id: Args.string({
+      description: 'The ID of the status page to retrieve.',
+      required: true,
+    }),
+  }
+
+  static flags = {
+    output: outputFlag({ default: 'detail' }),
+  }
+
+  async run (): Promise<void> {
+    const { args, flags } = await this.parse(StatusPagesGet)
+    this.style.outputFormat = flags.output
+
+    try {
+      const statusPage = await api.statusPages.get(args.id)
+
+      if (flags.output === 'json') {
+        this.log(JSON.stringify(statusPage, null, 2))
+        return
+      }
+
+      const fmt: OutputFormat = flags.output === 'md' ? 'md' : 'terminal'
+
+      if (fmt === 'md') {
+        this.log(formatStatusPageDetail(statusPage, fmt))
+        return
+      }
+
+      const output: string[] = []
+      output.push(formatStatusPageDetail(statusPage, fmt))
+
+      // Navigation hints
+      output.push('')
+      output.push(`  ${chalk.dim('Back to list:')}   checkly status-pages list`)
+
+      this.log(output.join('\n'))
+    } catch (err: any) {
+      this.style.longError('Failed to get status page details.', err)
+      process.exitCode = 1
+    }
+  }
+}

--- a/packages/cli/src/formatters/__tests__/status-pages.spec.ts
+++ b/packages/cli/src/formatters/__tests__/status-pages.spec.ts
@@ -5,6 +5,7 @@ import {
   formatStatusPagesCompact,
   formatCursorPaginationInfo,
   formatCursorNavigationHints,
+  formatStatusPageDetail,
 } from '../status-pages'
 import {
   simpleStatusPage,
@@ -137,5 +138,80 @@ describe('formatCursorNavigationHints', () => {
   it('omits next page when no cursor', () => {
     const result = stripAnsi(formatCursorNavigationHints(null))
     expect(result).not.toContain('--cursor')
+  })
+})
+
+describe('formatStatusPageDetail', () => {
+  describe('terminal', () => {
+    it('renders the page name as title', () => {
+      const result = stripAnsi(formatStatusPageDetail(simpleStatusPage, 'terminal'))
+      expect(result).toContain('Acme Status')
+    })
+
+    it('shows url field', () => {
+      const result = stripAnsi(formatStatusPageDetail(simpleStatusPage, 'terminal'))
+      expect(result).toContain('status.acme.com')
+    })
+
+    it('shows private field as no for public pages', () => {
+      const result = stripAnsi(formatStatusPageDetail(simpleStatusPage, 'terminal'))
+      expect(result).toContain('no')
+    })
+
+    it('shows private field as yes for private pages', () => {
+      const result = stripAnsi(formatStatusPageDetail(privateStatusPage, 'terminal'))
+      expect(result).toContain('yes')
+    })
+
+    it('shows theme', () => {
+      const result = stripAnsi(formatStatusPageDetail(simpleStatusPage, 'terminal'))
+      expect(result).toContain('AUTO')
+    })
+
+    it('shows the page ID', () => {
+      const result = stripAnsi(formatStatusPageDetail(simpleStatusPage, 'terminal'))
+      expect(result).toContain('a1b2c3d4-e5f6-7890-abcd-ef1234567890')
+    })
+
+    it('includes a services table with card and service names', () => {
+      const result = stripAnsi(formatStatusPageDetail(simpleStatusPage, 'terminal'))
+      expect(result).toContain('CARD')
+      expect(result).toContain('SERVICE')
+      expect(result).toContain('Infrastructure')
+      expect(result).toContain('API Gateway')
+      expect(result).toContain('Database Cluster')
+      expect(result).toContain('CDN')
+      expect(result).toContain('Web Applications')
+      expect(result).toContain('Dashboard')
+      expect(result).toContain('Marketing Site')
+    })
+
+    it('includes service IDs in the table', () => {
+      const result = stripAnsi(formatStatusPageDetail(simpleStatusPage, 'terminal'))
+      expect(result).toContain('svc-1111')
+      expect(result).toContain('svc-5555')
+    })
+
+    it('shows no services message for pages with no cards', () => {
+      const result = stripAnsi(formatStatusPageDetail(noCardsStatusPage, 'terminal'))
+      expect(result).toContain('No services')
+    })
+  })
+
+  describe('md', () => {
+    it('renders markdown detail fields', () => {
+      const result = formatStatusPageDetail(simpleStatusPage, 'md')
+      expect(result).toContain('# Acme Status')
+      expect(result).toContain('| Field | Value |')
+      expect(result).toContain('status.acme.com')
+    })
+
+    it('renders a markdown services table', () => {
+      const result = formatStatusPageDetail(simpleStatusPage, 'md')
+      expect(result).toContain('## Services')
+      expect(result).toContain('| Card |')
+      expect(result).toContain('| Service |')
+      expect(result).toContain('API Gateway')
+    })
   })
 })

--- a/packages/cli/src/formatters/status-pages.ts
+++ b/packages/cli/src/formatters/status-pages.ts
@@ -3,8 +3,10 @@ import type { StatusPage } from '../rest/status-pages'
 import {
   type OutputFormat,
   type ColumnDef,
+  type DetailField,
   truncateToWidth,
   renderTable,
+  renderDetailFields,
 } from './render'
 
 // --- Expanded row type: one row per service, all fields repeated ---
@@ -187,5 +189,102 @@ export function formatCursorNavigationHints (nextId: string | null): string {
   if (nextId) {
     lines.push(`  ${chalk.dim('Next page:')}    checkly status-pages list --cursor ${nextId}`)
   }
+  return lines.join('\n')
+}
+
+// --- Detail view for a single status page ---
+
+interface ServiceRow {
+  card: string
+  service: string
+  serviceId: string
+}
+
+function flattenServices (sp: StatusPage): ServiceRow[] {
+  const rows: ServiceRow[] = []
+  for (const card of sp.cards) {
+    for (const svc of card.services) {
+      rows.push({ card: card.name, service: svc.name, serviceId: svc.id })
+    }
+  }
+  return rows
+}
+
+const statusPageDetailFields: DetailField<StatusPage>[] = [
+  {
+    label: 'URL',
+    value: sp => sp.customDomain ?? sp.url,
+  },
+  {
+    label: 'Private',
+    value: (sp, fmt) => {
+      if (fmt === 'md') return sp.isPrivate ? 'yes' : 'no'
+      return sp.isPrivate ? chalk.yellow('yes') : 'no'
+    },
+  },
+  {
+    label: 'Theme',
+    value: sp => sp.defaultTheme,
+  },
+  {
+    label: 'Cards',
+    value: sp => String(sp.cards.length),
+  },
+  {
+    label: 'ID',
+    value: sp => sp.id,
+  },
+]
+
+function buildServiceColumns (format: OutputFormat): ColumnDef<ServiceRow>[] {
+  if (format === 'md') {
+    return [
+      { header: 'Card', value: r => r.card },
+      { header: 'Service', value: r => r.service },
+      { header: 'Service ID', value: r => r.serviceId },
+    ]
+  }
+
+  const termWidth = process.stdout.columns || 120
+  const cardWidth = Math.min(24, Math.floor(termWidth * 0.22))
+  const serviceWidth = Math.min(28, Math.floor(termWidth * 0.26))
+
+  return [
+    { header: 'Card', width: cardWidth, value: r => truncateToWidth(r.card, cardWidth - 2) },
+    { header: 'Service', width: serviceWidth, value: r => truncateToWidth(r.service, serviceWidth - 2) },
+    { header: 'Service ID', value: r => chalk.dim(r.serviceId) },
+  ]
+}
+
+export function formatStatusPageDetail (sp: StatusPage, format: OutputFormat): string {
+  const lines: string[] = []
+
+  lines.push(renderDetailFields(sp.name, statusPageDetailFields, sp, format))
+
+  const serviceRows = flattenServices(sp)
+
+  if (serviceRows.length === 0) {
+    if (format === 'md') {
+      lines.push('')
+      lines.push('## Services')
+      lines.push('')
+      lines.push('No services configured.')
+    } else {
+      lines.push('')
+      lines.push(chalk.dim('No services configured.'))
+    }
+  } else {
+    const columns = buildServiceColumns(format)
+    if (format === 'md') {
+      lines.push('')
+      lines.push('## Services')
+      lines.push('')
+    } else {
+      lines.push('')
+      lines.push(chalk.bold('SERVICES'))
+    }
+    lines.push(renderTable(columns, serviceRows, format))
+  }
+
   return lines.join('\n')
 }


### PR DESCRIPTION
## Summary

- Add `checkly status-pages get <id>` command showing page metadata + cards/services table (TIM-25)
- Command support `--output table|json|md` / `--output detail|json|md`
- 26 formatter unit tests covering expanded, compact, detail, pagination, and markdown output

## Test plan

- [x] `npx vitest --run src/formatters/__tests__/status-pages.spec.ts` — 26 tests pass
- [x] `npm run prepare:dist` — builds without errors
- [x] `CHECKLY_SKIP_AUTH=1 node bin/run status-pages list --help` — shows correct flags
- [x] `CHECKLY_SKIP_AUTH=1 node bin/run status-pages get --help` — shows correct args/flags
- [x] Manual test against live account: `checkly status-pages list`
- [x] Manual test against live account: `checkly status-pages get <id>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)