### PR TITLE
feat(cli): support CHECKLY_API_URL override for local env

### DIFF
--- a/packages/cli/src/services/config.ts
+++ b/packages/cli/src/services/config.ts
@@ -79,7 +79,7 @@ class ChecklyConfig {
 
   getApiUrl (): string {
     const environments = {
-      local: 'http://127.0.0.1:3000',
+      local: process.env.CHECKLY_API_URL || 'http://127.0.0.1:3000',
       development: 'https://api-dev.checklyhq.com',
       staging: 'https://api-test.checklyhq.com',
       production: 'https://api.checklyhq.com',


### PR DESCRIPTION
## Summary
- Allow overriding the local API URL via `CHECKLY_API_URL` when `CHECKLY_ENV=local`
- Enables local backend access through ngrok from remote coding sandboxes
- Only applies to `local` env — all other environments are unaffected (to ensure this does not break anything)

## Usage
```
CHECKLY_ENV=local CHECKLY_API_URL=https://<ngrok-id>.ngrok.io npx checkly test
```
