### PR TITLE
feat(cli): expand AI agent detection

### DIFF
--- a/packages/cli/src/helpers/__tests__/cli-mode.spec.ts
+++ b/packages/cli/src/helpers/__tests__/cli-mode.spec.ts
@@ -101,6 +101,12 @@ describe('detectOperator', () => {
     expect(detectOperator()).toBe('ci')
   })
 
+  it('prioritizes Cline over VS Code (Cline is a VS Code extension)', () => {
+    process.env.CLINE_ACTIVE = '1'
+    process.env.TERM_PROGRAM = 'vscode'
+    expect(detectOperator()).toBe('cline')
+  })
+
   it('prioritizes Claude Code over CI', () => {
     process.env.CLAUDECODE = '1'
     process.env.CI = 'true'

--- a/packages/cli/src/helpers/cli-mode.ts
+++ b/packages/cli/src/helpers/cli-mode.ts
@@ -14,7 +14,6 @@ const CI_OPERATORS: ReadonlySet<string> = new Set([
 export function detectOperator (): string {
   if (process.env.CLAUDECODE) return 'claude-code'
   if (process.env.CURSOR_TRACE_ID || process.env.CURSOR_AGENT) return 'cursor'
-  if (process.env.TERM_PROGRAM === 'vscode') return 'vscode'
   if (process.env.GITHUB_COPILOT) return 'github-copilot'
   if (process.env.AIDER) return 'aider'
   if (process.env.WINDSURF || process.env.CODEIUM_ENV) return 'windsurf'
@@ -22,6 +21,7 @@ export function detectOperator (): string {
   if (process.env.CODEX_SANDBOX || process.env.CODEX_THREAD_ID) return 'codex-cli'
   if (process.env.GEMINI_CLI) return 'gemini-cli'
   if (process.env.OPENCODE) return 'opencode'
+  if (process.env.TERM_PROGRAM === 'vscode') return 'vscode'
   if (process.env.GITHUB_ACTIONS) return 'github-actions'
   if (process.env.GITLAB_CI) return 'gitlab-ci'
   if (process.env.CI) return 'ci'


### PR DESCRIPTION
## Summary

Expands operator detection to cover AI coding agents we were missing compared to similar CLIs

- **Cline** — `CLINE_ACTIVE`
- **Codex CLI** — `CODEX_SANDBOX`, `CODEX_THREAD_ID`
- **Gemini CLI** — `GEMINI_CLI`
- **OpenCode** — `OPENCODE`
- **Cursor** — adds `CURSOR_AGENT` as fallback alongside existing `CURSOR_TRACE_ID`

All new operators map to `agent` CLI mode, so they get the same non-interactive confirmation flow as existing agents.

### Before / After

| Agent | Before | After |
|---|---|---|
| Cline | not detected | `CLINE_ACTIVE` |
| Codex CLI | not detected | `CODEX_SANDBOX` / `CODEX_THREAD_ID` |
| Gemini CLI | not detected | `GEMINI_CLI` |
| OpenCode | not detected | `OPENCODE` |
| Cursor | `CURSOR_TRACE_ID` only | `CURSOR_TRACE_ID` or `CURSOR_AGENT` |

### Context

Compared our detection with other CLIs. Other CLIs covered 7 agents; we covered 5. This PR closes the gap and adds a second env var for Cursor (Stripe uses `CURSOR_AGENT`, we used `CURSOR_TRACE_ID` — now we check both).


## Test plan

- [x] All 38 unit tests pass (`cli-mode.spec.ts`)
- [ ] Verify env vars are correct by testing inside each agent (or checking their docs)