### PR TITLE
feat(cli): add description field to StatusPage construct [SP-124]

### DIFF
--- a/packages/cli/src/constructs/status-page-codegen.ts
+++ b/packages/cli/src/constructs/status-page-codegen.ts
@@ -12,6 +12,7 @@ export interface StatusPageCardResource {
 export interface StatusPageResource {
   id: string
   name: string
+  description?: string
   url: string
   cards: StatusPageCardResource[]
   customDomain?: string
@@ -42,6 +43,9 @@ export class StatusPageCodegen extends Codegen<StatusPageResource> {
         builder.string(logicalId)
         builder.object(builder => {
           builder.string('name', resource.name)
+          if (resource.description) {
+            builder.string('description', resource.description)
+          }
           builder.string('url', resource.url)
 
           builder.array('cards', builder => {

--- a/packages/cli/src/constructs/status-page.ts
+++ b/packages/cli/src/constructs/status-page.ts
@@ -22,6 +22,10 @@ export interface StatusPageProps {
    */
   name: string
   /**
+   * An optional description displayed on the status page. Maximum 500 characters.
+   */
+  description?: string
+  /**
    * The URL of the status page.
    */
   url: string
@@ -56,6 +60,7 @@ export interface StatusPageProps {
  */
 export class StatusPage extends Construct {
   name: string
+  description?: string
   cards: StatusPageCardProps[]
   url: string
   customDomain?: string
@@ -77,6 +82,7 @@ export class StatusPage extends Construct {
   constructor (logicalId: string, props: StatusPageProps) {
     super(StatusPage.__checklyType, logicalId)
     this.name = props.name
+    this.description = props.description
     this.url = props.url
     this.cards = props.cards
     this.customDomain = props.customDomain
@@ -95,6 +101,7 @@ export class StatusPage extends Construct {
   synthesize (): any | null {
     return {
       name: this.name,
+      description: this.description,
       url: this.url,
       customDomain: this.customDomain,
       logo: this.logo,

--- a/packages/cli/src/rest/status-pages.ts
+++ b/packages/cli/src/rest/status-pages.ts
@@ -17,6 +17,7 @@ export interface StatusPageCard {
 export interface StatusPage {
   id: string
   name: string
+  description?: string | null
   url: string
   customDomain: string | null
   isPrivate: boolean


### PR DESCRIPTION
## Summary
- Add optional `description` property to `StatusPageProps` interface and `StatusPage` class
- Include `description` in `synthesize()` API payload
- Add `description` to codegen and REST API type

## Test plan
- [ ] Verify `description` can be set in StatusPage construct
- [ ] Verify `checkly deploy` sends description to API
- [ ] Verify `checkly import` generates description in code when present