### PR TITLE
ci: split e2e tests into separate job for parallel execution

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,13 +41,6 @@ jobs:
       - run: npm ci
       - run: npm run prepack
       - run: npm run test
-      - run: npm run test:e2e
-        env:
-          CHECKLY_ACCOUNT_NAME: ${{ secrets.E2E_CHECKLY_ACCOUNT_NAME }}
-          CHECKLY_ACCOUNT_ID: ${{ secrets.E2E_CHECKLY_ACCOUNT_ID }}
-          CHECKLY_API_KEY: ${{ secrets.E2E_CHECKLY_API_KEY }}
-          CHECKLY_EMPTY_ACCOUNT_ID: ${{ secrets.E2E_EMPTY_CHECKLY_ACCOUNT_ID }}
-          CHECKLY_EMPTY_API_KEY: ${{ secrets.E2E_EMPTY_CHECKLY_API_KEY }}
       - name: Save LLM rules as an artifact
         uses: actions/upload-artifact@v4
         with:
@@ -55,3 +48,30 @@ jobs:
           if-no-files-found: error
           path: packages/cli/dist/ai-context/*
           retention-days: 1
+  test-e2e:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest-x64]
+    name: test-e2e - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - run: npm config set fund false && npm set audit false
+      - run: npm ci
+      - run: npm run prepack
+      - run: npm run test:e2e
+        env:
+          CHECKLY_ACCOUNT_NAME: ${{ secrets.E2E_CHECKLY_ACCOUNT_NAME }}
+          CHECKLY_ACCOUNT_ID: ${{ secrets.E2E_CHECKLY_ACCOUNT_ID }}
+          CHECKLY_API_KEY: ${{ secrets.E2E_CHECKLY_API_KEY }}
+          CHECKLY_EMPTY_ACCOUNT_ID: ${{ secrets.E2E_EMPTY_CHECKLY_ACCOUNT_ID }}
+          CHECKLY_EMPTY_API_KEY: ${{ secrets.E2E_EMPTY_CHECKLY_API_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
           node-version: '20.x'
           cache: "npm"
           cache-dependency-path: package-lock.json
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 10
       - run: npm config set fund false && npm set audit false
@@ -62,7 +62,7 @@ jobs:
           node-version: '20.x'
           cache: "npm"
           cache-dependency-path: package-lock.json
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 10
       - run: npm config set fund false && npm set audit false


### PR DESCRIPTION
## Summary
- Split the `test` CI job into separate `test` and `test-e2e` jobs so unit tests and e2e tests run in parallel, reducing overall CI time
- Update `pnpm/action-setup` from v4 to v5

## Test plan
- [ ] Verify both `test` and `test-e2e` jobs appear in the PR checks
- [ ] Confirm unit tests and e2e tests run in parallel on both `ubuntu-latest` and `windows-latest-x64`
- [ ] Verify LLM rules artifact is still uploaded by the `test` job