### PR TITLE
feat(cli): support bun.lock text-based lockfile from Bun 1.2

### DIFF
--- a/packages/cli/src/services/__tests__/util.spec.ts
+++ b/packages/cli/src/services/__tests__/util.spec.ts
@@ -35,7 +35,7 @@ describe('util', () => {
     const basePath = path.resolve('/project')
     const makePm = (name: string): PackageManager => ({
       name,
-      representativeLockfile: undefined,
+      representativeLockfiles: [],
       representativeConfigFile: undefined,
       installCommand: () => ({ executable: name, args: ['install'], unsafeDisplayCommand: `${name} install` }),
       execCommand: (args: string[]) => ({ executable: name, args, unsafeDisplayCommand: `${name} ${args.join(' ')}` }),

--- a/packages/cli/src/services/check-parser/package-files/package-manager.ts
+++ b/packages/cli/src/services/check-parser/package-files/package-manager.ts
@@ -29,7 +29,7 @@ export interface AddCommandOptions {
 
 export interface PackageManager {
   get name (): string
-  get representativeLockfile (): string | undefined
+  get representativeLockfiles (): string[]
   get representativeConfigFile (): string | undefined
   installCommand (): Runnable
   addCommand (options: AddCommandOptions): Runnable
@@ -44,9 +44,20 @@ export abstract class PackageManagerDetector {
   abstract get name (): string
   abstract detectUserAgent (userAgent: string): boolean
   abstract detectRuntime (): boolean
-  abstract get representativeLockfile (): string | undefined
+  abstract get representativeLockfiles (): string[]
   abstract get representativeConfigFile (): string | undefined
-  abstract detectLockfile (dir: string): Promise<string>
+
+  async detectLockfile (dir: string): Promise<string> {
+    for (const lockfile of this.representativeLockfiles) {
+      try {
+        return await accessR(path.join(dir, lockfile))
+      } catch {
+        continue
+      }
+    }
+    throw new NotDetectedError()
+  }
+
   abstract detectConfigFile (dir: string): Promise<string>
   abstract detectExecutable (lookup: PathLookup): Promise<void>
   abstract installCommand (): Runnable
@@ -71,16 +82,12 @@ export class NpmDetector extends PackageManagerDetector implements PackageManage
     return false
   }
 
-  get representativeLockfile (): string {
-    return 'package-lock.json'
+  get representativeLockfiles (): string[] {
+    return ['package-lock.json']
   }
 
   get representativeConfigFile (): undefined {
     return
-  }
-
-  async detectLockfile (dir: string): Promise<string> {
-    return await accessR(path.join(dir, this.representativeLockfile))
   }
 
   // eslint-disable-next-line require-await, @typescript-eslint/no-unused-vars
@@ -126,17 +133,12 @@ export class CNpmDetector extends PackageManagerDetector implements PackageManag
     return false
   }
 
-  get representativeLockfile (): undefined {
-    return
+  get representativeLockfiles (): string[] {
+    return []
   }
 
   get representativeConfigFile (): undefined {
     return
-  }
-
-  // eslint-disable-next-line require-await
-  async detectLockfile (): Promise<string> {
-    throw new NotDetectedError()
   }
 
   // eslint-disable-next-line require-await, @typescript-eslint/no-unused-vars
@@ -182,16 +184,12 @@ export class PNpmDetector extends PackageManagerDetector implements PackageManag
     return false
   }
 
-  get representativeLockfile (): string {
-    return 'pnpm-lock.yaml'
+  get representativeLockfiles (): string[] {
+    return ['pnpm-lock.yaml']
   }
 
   get representativeConfigFile (): string {
     return 'pnpm-workspace.yaml'
-  }
-
-  async detectLockfile (dir: string): Promise<string> {
-    return await accessR(path.join(dir, this.representativeLockfile))
   }
 
   async detectConfigFile (dir: string): Promise<string> {
@@ -307,16 +305,12 @@ export class YarnDetector extends PackageManagerDetector implements PackageManag
     return false
   }
 
-  get representativeLockfile (): string {
-    return 'yarn.lock'
+  get representativeLockfiles (): string[] {
+    return ['yarn.lock']
   }
 
   get representativeConfigFile (): undefined {
     return
-  }
-
-  async detectLockfile (dir: string): Promise<string> {
-    return await accessR(path.join(dir, this.representativeLockfile))
   }
 
   // eslint-disable-next-line require-await, @typescript-eslint/no-unused-vars
@@ -362,16 +356,12 @@ export class DenoDetector extends PackageManagerDetector implements PackageManag
     return process.versions.deno !== undefined
   }
 
-  get representativeLockfile (): string {
-    return 'deno.lock'
+  get representativeLockfiles (): string[] {
+    return ['deno.lock']
   }
 
   get representativeConfigFile (): string {
     return 'deno.json'
-  }
-
-  async detectLockfile (dir: string): Promise<string> {
-    return await accessR(path.join(dir, this.representativeLockfile))
   }
 
   async detectConfigFile (dir: string): Promise<string> {
@@ -460,16 +450,12 @@ export class BunDetector extends PackageManagerDetector implements PackageManage
     return process.versions.bun !== undefined
   }
 
-  get representativeLockfile (): string {
-    return 'bun.lockb'
+  get representativeLockfiles (): string[] {
+    return ['bun.lock', 'bun.lockb']
   }
 
   get representativeConfigFile (): undefined {
     return
-  }
-
-  async detectLockfile (dir: string): Promise<string> {
-    return await accessR(path.join(dir, this.representativeLockfile))
   }
 
   // eslint-disable-next-line require-await, @typescript-eslint/no-unused-vars
@@ -731,9 +717,7 @@ export async function detectNearestLockfile (
     }
   }
 
-  const lockfiles = detectors.reduce<string[]>((acc, detector) => {
-    return acc.concat(detector.representativeLockfile ?? [])
-  }, [])
+  const lockfiles = detectors.flatMap(detector => detector.representativeLockfiles)
 
   throw new NoLockfileFoundError(searchPaths, lockfiles)
 }

--- a/packages/cli/src/testing/fixture-sandbox.ts
+++ b/packages/cli/src/testing/fixture-sandbox.ts
@@ -115,6 +115,7 @@ export class FixtureSandbox {
 
       const { lockfile } = await detectNearestLockfile(root, {
         detectors: [packageManager.detector()],
+        root,
       })
 
       // Take a backup of the original package.json so that we can restore

--- a/packages/cli/src/testing/fixture-sandbox.ts
+++ b/packages/cli/src/testing/fixture-sandbox.ts
@@ -6,7 +6,7 @@ import Debug from 'debug'
 
 const debug = Debug('checkly:cli:testing:fixture-sandbox')
 
-import { detectNearestPackageJson, detectPackageManager, PackageManager } from '../services/check-parser/package-files/package-manager'
+import { detectNearestLockfile, detectNearestPackageJson, detectPackageManager, PackageManager } from '../services/check-parser/package-files/package-manager'
 
 export interface CreateFixtureSandboxOptions {
   /**
@@ -113,7 +113,9 @@ export class FixtureSandbox {
     if (installPackages && injectPackedSelf) {
       debug('Injecting containing package')
 
-      const lockfile = packageManager.representativeLockfile
+      const { lockfile } = await detectNearestLockfile(root, {
+        detectors: [packageManager.detector()],
+      })
 
       // Take a backup of the original package.json so that we can restore
       // it later.
@@ -123,12 +125,7 @@ export class FixtureSandbox {
       )
 
       // Same for the lockfile.
-      if (lockfile) {
-        await fs.cp(
-          path.join(root, lockfile),
-          path.join(root, `${lockfile}.backup`),
-        )
-      }
+      await fs.cp(lockfile, `${lockfile}.backup`)
 
       const packageJson = await detectNearestPackageJson(__dirname)
 
@@ -153,12 +150,7 @@ export class FixtureSandbox {
       )
 
       // Restore original lockfile.
-      if (lockfile) {
-        await fs.rename(
-          path.join(root, `${lockfile}.backup`),
-          path.join(root, lockfile),
-        )
-      }
+      await fs.rename(`${lockfile}.backup`, lockfile)
     }
 
     return new FixtureSandbox({


### PR DESCRIPTION
## Summary

Bun 1.2 changed from a binary lockfile (`bun.lockb`) to a text-based lockfile (`bun.lock`). This PR updates package manager detection to support both formats.

- Rename `representativeLockfile: string | undefined` to `representativeLockfiles: string[]` across the `PackageManager` interface, `PackageManagerDetector` abstract class, and all detector implementations
- `BunDetector` now returns `['bun.lock', 'bun.lockb']`, preferring the newer text-based format
- Move `detectLockfile` from per-detector implementations to a shared default in `PackageManagerDetector` that iterates the lockfile list in order
- Update `fixture-sandbox.ts` to use `detectNearestLockfile` scoped to the sandbox root

## Test plan

- [x] `npm run prepare --workspace packages/cli` builds successfully
- [x] `npm run test --workspace packages/cli` passes (860 tests)
- [x] `npm run lint` passes
- [ ] Manual: verify detection works with a project using `bun.lock` (Bun >= 1.2)
- [ ] Manual: verify detection still works with a project using `bun.lockb` (Bun < 1.2)
