### PR TITLE
docs(cli): document --status and missing flags in investigate-checks context

### DIFF
--- a/packages/cli/src/ai-context/references/investigate-checks.md
+++ b/packages/cli/src/ai-context/references/investigate-checks.md
@@ -7,13 +7,17 @@ List and inspect deployed checks in your Checkly account.
 ```bash
 npx checkly checks list
 npx checkly checks list --tag production --type PLAYWRIGHT
+npx checkly checks list --status failing
 npx checkly checks list --search "Homepage" --output json
 ```
 
 Flags:
-- `--tag <tag>` — filter by tag
-- `--type <type>` — filter by check type (`API`, `BROWSER`, `PLAYWRIGHT`, `MULTI_STEP`)
-- `--search <name>` — filter by name
+- `-t, --tag <tag>` — filter by tag (repeat for multiple)
+- `--type <type>` — filter by check type (`API`, `BROWSER`, `HEARTBEAT`, `MULTI_STEP`, `PLAYWRIGHT`, `TCP`, `ICMP`, `DNS`, `URL`, `AGENTIC`)
+- `-s, --search <name>` — filter by name (case-insensitive partial match)
+- `--status <status>` — filter by current status: `passing`, `failing`, or `degraded`
+- `-l, --limit <n>` — max checks to return (1-100, default 25)
+- `-p, --page <n>` — page number
 - `-o, --output <format>` — `table` (default), `json`, or `md`
 
 ## Get check details
@@ -21,9 +25,21 @@ Flags:
 ```bash
 npx checkly checks get <check-id>
 npx checkly checks get <check-id> --output json
+npx checkly checks get <check-id> --stats-range last7Days --group-by location
 ```
 
-Shows check configuration, recent results, and error groups.
+Shows check configuration, recent results, error groups, and analytics stats.
+
+Flags:
+- `-r, --result <result-id>` — drill into a specific result (see below)
+- `-e, --error-group <error-group-id>` — show full details for a specific error group
+- `--results-limit <n>` — number of recent results to show (default 10)
+- `--results-cursor <cursor>` — paginate results using the cursor from previous output
+- `--stats-range <range>` — analytics range: `last24Hours` (default), `last7Days`, `last30Days`, `thisWeek`, `thisMonth`, `lastWeek`, `lastMonth`
+- `--group-by <dimension>` — group stats by `location` or `statusCode`
+- `--metrics <list>` — comma-separated list of metrics to show (overrides defaults)
+- `--filter-status <status>` — only include runs with this status in stats: `success` or `failure`
+- `-o, --output <format>` — `detail` (default), `json`, or `md`
 
 ### View a specific check result
 


### PR DESCRIPTION
## Summary

- The AI context reference for `checks list` was missing the `--status` flag (added in #1244 but never documented), so agents using the CLI through the skills system couldn't discover it.
- Same file was also missing `--limit`/`--page` on `list` and had no formal flag list for `checks get` (results pagination, analytics range, group-by, metrics, filter-status).
- This PR updates `packages/cli/src/ai-context/references/investigate-checks.md` only — no code changes.

Public docs on checklyhq.com will be updated separately.

## Test plan

- [x] Manual diff review of updated reference against actual command flag definitions in `checks/list.ts` and `checks/get.ts`
- [x] Verified `--status` values (`passing`, `failing`, `degraded`) match `list.ts:49`
- [x] Verified check type list matches `constants.ts` (`CheckTypes`)
- [x] Verified `--stats-range` values match `quickRangeValues` in `rest/analytics.ts`
- [x] Type-check passes (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)