### PR TITLE
docs(cli): document 1-4 minute reminder intervals [SP-140]

### DIFF
--- a/packages/cli/src/constructs/alert-escalation-policy.ts
+++ b/packages/cli/src/constructs/alert-escalation-policy.ts
@@ -24,7 +24,7 @@ export type Reminders = {
   /**
    * Interval between reminder notifications in minutes.
    * @defaultValue 5
-   * @enum [5, 10, 15, 30]
+   * @enum [1, 2, 3, 4, 5, 10, 15, 30]
    */
   interval?: number
 }


### PR DESCRIPTION
## Summary
- Updates the JSDoc `@enum` annotation on `Reminders.interval` to include the newly-allowed 1-4 minute values.
- Purely documentation — the TypeScript type is `number` so runtime already accepted these values. This keeps IDE tooltips and generated docs in sync with the backend, which now accepts shorter reminder intervals as part of SP-140.

## Test plan
- [ ] CI lint + build pass
- [ ] IDE tooltip on `Reminders.interval` shows the updated enum list