### PR TITLE
fix(e2e): use unique domain for status page e2e test to prevent conflicts

### DIFF
--- a/packages/cli/e2e/__tests__/fixtures/deploy-project/status-page.check.ts
+++ b/packages/cli/e2e/__tests__/fixtures/deploy-project/status-page.check.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-new */
 
 import { StatusPage, StatusPageService } from 'checkly/constructs'
+import { v4 as uuidv4 } from 'uuid'
 
 export const fooService = new StatusPageService('foo-service', {
   name: 'Foo',
@@ -12,7 +13,7 @@ export const barService = new StatusPageService('bar-service', {
 
 new StatusPage('test-page-1', {
   name: 'Test Status Page 1',
-  url: 'checkly-internal-test-status-page-18671',
+  url: `cli-e2e-test-1-${uuidv4()}`,
   cards: [{
     name: 'Card 1',
     services: [


### PR DESCRIPTION
Using a unique domain prevents conflicts in parallel runs and helps work around an issue where the backend sometimes fails to delete the domain.