### PR TITLE
feat(cli): include workspace package.json files in code bundle cache hash

### DIFF
--- a/packages/cli/src/services/check-parser/__tests__/cache-hash.spec.ts
+++ b/packages/cli/src/services/check-parser/__tests__/cache-hash.spec.ts
@@ -1,0 +1,235 @@
+import { createHash } from 'node:crypto'
+
+import { describe, test, expect } from 'vitest'
+
+import {
+  canonicalizePackageJson,
+  composeCacheHash,
+  stableJsonEncode,
+} from '../cache-hash'
+
+const sha256 = (s: string): Buffer => createHash('sha256').update(s).digest()
+
+const buf = (s: string): Buffer => Buffer.from(s, 'utf8')
+
+describe('stableJsonEncode', () => {
+  test('sorts object keys', () => {
+    expect(stableJsonEncode({ b: 1, a: 2 })).toBe('{"a":2,"b":1}')
+  })
+
+  test('produces identical output regardless of source key order', () => {
+    expect(stableJsonEncode({ a: 1, b: { d: 4, c: 3 } }))
+      .toBe(stableJsonEncode({ b: { c: 3, d: 4 }, a: 1 }))
+  })
+
+  test('escapes HTML-significant characters', () => {
+    expect(stableJsonEncode('<&>')).toBe('"\\u003c\\u0026\\u003e"')
+  })
+
+  test('escapes U+2028 and U+2029', () => {
+    expect(stableJsonEncode('\u2028\u2029')).toBe('"\\u2028\\u2029"')
+  })
+
+  test('escapes control characters', () => {
+    expect(stableJsonEncode('\u0000\u0001')).toBe('"\\u0000\\u0001"')
+    expect(stableJsonEncode('\b\t\n\f\r')).toBe('"\\b\\t\\n\\f\\r"')
+  })
+
+  test('escapes quotes and backslashes', () => {
+    expect(stableJsonEncode('a"b\\c')).toBe('"a\\"b\\\\c"')
+  })
+
+  test('encodes primitives', () => {
+    expect(stableJsonEncode(null)).toBe('null')
+    expect(stableJsonEncode(true)).toBe('true')
+    expect(stableJsonEncode(false)).toBe('false')
+    expect(stableJsonEncode(42)).toBe('42')
+  })
+
+  test('encodes arrays preserving order', () => {
+    expect(stableJsonEncode([3, 1, 2])).toBe('[3,1,2]')
+  })
+
+  test('rejects non-finite numbers', () => {
+    expect(() => stableJsonEncode(NaN)).toThrow()
+    expect(() => stableJsonEncode(Infinity)).toThrow()
+  })
+})
+
+describe('canonicalizePackageJson', () => {
+  test('removes excluded top-level fields', () => {
+    const raw = buf('{"name":"x","version":"1.0.0"}')
+    expect(canonicalizePackageJson(raw, ['version']).toString('utf8'))
+      .toBe('{"name":"x"}')
+  })
+
+  test('produces identical output regardless of source key order or whitespace', () => {
+    const a = buf('{"name":"x","version":"1.0.0","main":"index.js"}')
+    const b = buf('{\n  "main": "index.js",\n  "version": "9.9.9",\n  "name": "x"\n}\n')
+    expect(canonicalizePackageJson(a, ['version']))
+      .toEqual(canonicalizePackageJson(b, ['version']))
+  })
+
+  test('only excludes top-level fields, not nested ones', () => {
+    const raw = buf('{"name":"x","version":"1.0.0","scripts":{"version":"echo 1"}}')
+    const canonical = canonicalizePackageJson(raw, ['version']).toString('utf8')
+    expect(canonical).toBe('{"name":"x","scripts":{"version":"echo 1"}}')
+  })
+
+  test('rejects non-object top-level values', () => {
+    expect(() => canonicalizePackageJson(buf('[]'), [])).toThrow()
+    expect(() => canonicalizePackageJson(buf('null'), [])).toThrow()
+    expect(() => canonicalizePackageJson(buf('"x"'), [])).toThrow()
+  })
+})
+
+describe('composeCacheHash', () => {
+  test('bumping the excluded version field does not change the hash', () => {
+    const v1 = buf('{"name":"x","version":"1.0.0"}')
+    const v2 = buf('{"name":"x","version":"2.0.0-deadbeef"}')
+    const lockfile = { name: 'package-lock.json', hash: sha256('lock') }
+    expect(composeCacheHash({
+      lockfile,
+      packageJsons: [{ path: 'package.json', raw: v1 }],
+      excludedFields: ['version'],
+    })).toBe(composeCacheHash({
+      lockfile,
+      packageJsons: [{ path: 'package.json', raw: v2 }],
+      excludedFields: ['version'],
+    }))
+  })
+
+  test('changing name or dependencies changes the hash', () => {
+    const a = buf('{"name":"a","version":"1.0.0"}')
+    const b = buf('{"name":"b","version":"1.0.0"}')
+    const lockfile = { name: 'package-lock.json', hash: sha256('lock') }
+    expect(composeCacheHash({
+      lockfile,
+      packageJsons: [{ path: 'package.json', raw: a }],
+      excludedFields: ['version'],
+    })).not.toBe(composeCacheHash({
+      lockfile,
+      packageJsons: [{ path: 'package.json', raw: b }],
+      excludedFields: ['version'],
+    }))
+  })
+
+  test('source key reordering does not change the hash', () => {
+    const a = buf('{"name":"x","version":"1.0.0","dependencies":{"a":"1","b":"2"}}')
+    const b = buf('{"dependencies":{"b":"2","a":"1"},"version":"1.0.0","name":"x"}')
+    const lockfile = { name: 'package-lock.json', hash: sha256('lock') }
+    expect(composeCacheHash({
+      lockfile,
+      packageJsons: [{ path: 'package.json', raw: a }],
+      excludedFields: ['version'],
+    })).toBe(composeCacheHash({
+      lockfile,
+      packageJsons: [{ path: 'package.json', raw: b }],
+      excludedFields: ['version'],
+    }))
+  })
+
+  test('adding a workspace package changes the hash', () => {
+    const root = buf('{"name":"root","version":"1.0.0"}')
+    const member = buf('{"name":"member","version":"1.0.0"}')
+    const lockfile = { name: 'package-lock.json', hash: sha256('lock') }
+    const without = composeCacheHash({
+      lockfile,
+      packageJsons: [{ path: 'package.json', raw: root }],
+      excludedFields: ['version'],
+    })
+    const withMember = composeCacheHash({
+      lockfile,
+      packageJsons: [
+        { path: 'package.json', raw: root },
+        { path: 'packages/member/package.json', raw: member },
+      ],
+      excludedFields: ['version'],
+    })
+    expect(without).not.toBe(withMember)
+  })
+
+  test('lockfile content change changes the hash', () => {
+    const root = buf('{"name":"root"}')
+    const a = composeCacheHash({
+      lockfile: { name: 'package-lock.json', hash: sha256('lock-a') },
+      packageJsons: [{ path: 'package.json', raw: root }],
+      excludedFields: ['version'],
+    })
+    const b = composeCacheHash({
+      lockfile: { name: 'package-lock.json', hash: sha256('lock-b') },
+      packageJsons: [{ path: 'package.json', raw: root }],
+      excludedFields: ['version'],
+    })
+    expect(a).not.toBe(b)
+  })
+
+  test('input order of packageJsons does not affect the hash', () => {
+    const root = buf('{"name":"root"}')
+    const a = buf('{"name":"a"}')
+    const b = buf('{"name":"b"}')
+    const lockfile = { name: 'package-lock.json', hash: sha256('lock') }
+    expect(composeCacheHash({
+      lockfile,
+      packageJsons: [
+        { path: 'packages/b/package.json', raw: b },
+        { path: 'package.json', raw: root },
+        { path: 'packages/a/package.json', raw: a },
+      ],
+      excludedFields: ['version'],
+    })).toBe(composeCacheHash({
+      lockfile,
+      packageJsons: [
+        { path: 'package.json', raw: root },
+        { path: 'packages/a/package.json', raw: a },
+        { path: 'packages/b/package.json', raw: b },
+      ],
+      excludedFields: ['version'],
+    }))
+  })
+
+  // Cross-language parity fixture. The same lockfile + package.json bytes
+  // and the same excluded fields must produce this exact digest in
+  // terraform-provider-checkly's composeBundleChecksum. If you change this
+  // fixture, mirror the change in the TF provider's test suite.
+  test('matches the cross-language parity fixture digest', () => {
+    const lockfileBytes = buf('{"lockfileVersion":3}\n')
+    const rootPackageJson = buf([
+      '{',
+      '  "name": "fixture-root",',
+      '  "version": "0.0.0-SNAPSHOT",',
+      '  "private": true,',
+      '  "workspaces": ["packages/*"],',
+      '  "devDependencies": {',
+      '    "@playwright/test": "1.50.0"',
+      '  }',
+      '}',
+      '',
+    ].join('\n'))
+    const memberPackageJson = buf([
+      '{',
+      '  "name": "@fixture/member",',
+      '  "version": "9.9.9",',
+      '  "main": "index.js",',
+      '  "dependencies": {',
+      '    "lodash": "^4.17.21"',
+      '  }',
+      '}',
+      '',
+    ].join('\n'))
+
+    const digest = composeCacheHash({
+      lockfile: {
+        name: 'package-lock.json',
+        hash: createHash('sha256').update(lockfileBytes).digest(),
+      },
+      packageJsons: [
+        { path: 'package.json', raw: rootPackageJson },
+        { path: 'packages/member/package.json', raw: memberPackageJson },
+      ],
+      excludedFields: ['version'],
+    })
+
+    expect(digest).toBe('4d3072de5db2f0f8a5e29b72013dd7e4dfb25686023931ee98050d58ba4503f8')
+  })
+})

--- a/packages/cli/src/services/check-parser/bundler.ts
+++ b/packages/cli/src/services/check-parser/bundler.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'node:crypto'
 import { createReadStream, createWriteStream, WriteStream } from 'node:fs'
 import fs from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -10,6 +9,7 @@ import Debug from 'debug'
 import * as uuid from 'uuid'
 
 import { checklyStorage } from '../../rest/api'
+import { computeWorkspaceCacheHash } from './cache-hash'
 import { File } from './parser'
 import { Workspace } from './package-files/workspace'
 
@@ -262,11 +262,7 @@ export class Bundler {
       tempDir,
     } = options
 
-    const cacheHashFile = workspace.lockfile.isOk()
-      ? workspace.lockfile.ok()
-      : workspace.root.packageJsonPath
-
-    const cacheHash = await getCacheHash(cacheHashFile)
+    const cacheHash = await computeWorkspaceCacheHash(workspace)
 
     return new Bundler({
       tempDir,
@@ -331,13 +327,6 @@ async function createArchiver (): Promise<Archiver> {
   } else {
     throw new Error('Unable to initialize archiver: neither TarArchive nor default export found')
   }
-}
-
-export async function getCacheHash (lockFile: string): Promise<string> {
-  const fileBuffer = await fs.readFile(lockFile)
-  const hash = createHash('sha256')
-  hash.update(fileBuffer)
-  return hash.digest('hex')
 }
 
 export class BundlePathMarker {

--- a/packages/cli/src/services/check-parser/cache-hash.ts
+++ b/packages/cli/src/services/check-parser/cache-hash.ts
@@ -1,0 +1,222 @@
+import { createHash } from 'node:crypto'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+import { Workspace } from './package-files/workspace'
+
+export interface PackageJsonInput {
+  /**
+   * Path used to identify this package.json in the hash. Should be a
+   * forward-slash relative path matching the file's location in the
+   * eventual archive (e.g. "package.json" or "packages/cli/package.json").
+   */
+  path: string
+  raw: Buffer
+}
+
+export interface LockfileInput {
+  /**
+   * Basename of the lockfile (e.g. "package-lock.json").
+   */
+  name: string
+  /**
+   * Raw 32-byte SHA-256 digest of the lockfile contents.
+   */
+  hash: Buffer
+}
+
+export interface ComposeCacheHashInput {
+  lockfile?: LockfileInput
+  packageJsons: PackageJsonInput[]
+  excludedFields: string[]
+}
+
+const PACKAGE_JSON_EXCLUDED_FIELDS = ['version']
+
+/**
+ * Encodes a value as JSON in a way that's stable across runs and machines.
+ *
+ * Differences from {@link JSON.stringify}:
+ * - Object keys are sorted (byte-wise / code-point order) before
+ *   serialization. This is the load-bearing difference — without it, two
+ *   equivalent package.json files written in different key orders would
+ *   produce different hashes.
+ * - HTML-significant characters (`<`, `>`, `&`) are escaped as
+ *   `\u003c`/`\u003e`/`\u0026`.
+ * - U+2028 and U+2029 are escaped as `\u2028`/`\u2029`.
+ * - No whitespace between tokens.
+ * - Numbers use {@link String}; floating-point edge cases may differ from
+ *   other encoders. Package.json content is effectively never numeric
+ *   outside config blobs, so this is negligible in practice.
+ */
+export function stableJsonEncode (value: unknown): string {
+  if (value === null) {
+    return 'null'
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false'
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new Error(`Cannot encode non-finite number: ${value}`)
+    }
+    return String(value)
+  }
+  if (typeof value === 'string') {
+    return encodeString(value)
+  }
+  if (Array.isArray(value)) {
+    return '[' + value.map(stableJsonEncode).join(',') + ']'
+  }
+  if (typeof value === 'object') {
+    const obj = value as Record<string, unknown>
+    const keys = Object.keys(obj).sort()
+    return '{' + keys.map(key => {
+      return encodeString(key) + ':' + stableJsonEncode(obj[key])
+    }).join(',') + '}'
+  }
+  throw new Error(`Unsupported value type: ${typeof value}`)
+}
+
+const STRING_ESCAPES: Record<number, string> = {
+  0x22: '\\"',
+  0x5c: '\\\\',
+  0x08: '\\b',
+  0x09: '\\t',
+  0x0a: '\\n',
+  0x0c: '\\f',
+  0x0d: '\\r',
+  0x3c: '\\u003c', // <
+  0x3e: '\\u003e', // >
+  0x26: '\\u0026', // &
+  0x2028: '\\u2028',
+  0x2029: '\\u2029',
+}
+
+function encodeString (s: string): string {
+  let out = '"'
+  for (let i = 0; i < s.length; i++) {
+    const code = s.charCodeAt(i)
+    const escape = STRING_ESCAPES[code]
+    if (escape !== undefined) {
+      out += escape
+    } else if (code < 0x20) {
+      out += '\\u' + code.toString(16).padStart(4, '0')
+    } else {
+      out += s[i]
+    }
+  }
+  out += '"'
+  return out
+}
+
+/**
+ * Parses a package.json, removes the named top-level fields, and re-encodes
+ * the result via {@link stableJsonEncode}.
+ */
+export function canonicalizePackageJson (raw: Buffer, excludedFields: string[]): Buffer {
+  const obj = JSON.parse(raw.toString('utf8'))
+  if (obj === null || typeof obj !== 'object' || Array.isArray(obj)) {
+    throw new Error('package.json must contain a JSON object at the top level')
+  }
+  for (const field of excludedFields) {
+    delete obj[field]
+  }
+  return Buffer.from(stableJsonEncode(obj), 'utf8')
+}
+
+/**
+ * Combines a lockfile digest and a set of canonicalized package.json
+ * entries into a single SHA-256 hex digest.
+ *
+ * Each record contributes:
+ *   uint64-be(label length) || label bytes ||
+ *   uint64-be(content length) || content bytes
+ *
+ * Records are written in the following order:
+ *   1. The lockfile record (if present), labeled `lockfile:<basename>`,
+ *      whose content is the raw 32-byte SHA-256 digest of the lockfile.
+ *   2. One record per package.json sorted byte-wise by path, labeled
+ *      `package.json:<relative/path>`, whose content is the canonicalized
+ *      package.json bytes.
+ */
+export function composeCacheHash (input: ComposeCacheHashInput): string {
+  const hash = createHash('sha256')
+
+  const writeRecord = (label: string, content: Buffer): void => {
+    const labelBytes = Buffer.from(label, 'utf8')
+    hash.update(uint64BE(labelBytes.length))
+    hash.update(labelBytes)
+    hash.update(uint64BE(content.length))
+    hash.update(content)
+  }
+
+  if (input.lockfile) {
+    writeRecord(`lockfile:${input.lockfile.name}`, input.lockfile.hash)
+  }
+
+  const sorted = [...input.packageJsons].sort((a, b) => {
+    if (a.path < b.path) return -1
+    if (a.path > b.path) return 1
+    return 0
+  })
+
+  for (const entry of sorted) {
+    const canonical = canonicalizePackageJson(entry.raw, input.excludedFields)
+    writeRecord(`package.json:${entry.path}`, canonical)
+  }
+
+  return hash.digest('hex')
+}
+
+function uint64BE (n: number): Buffer {
+  const buf = Buffer.alloc(8)
+  buf.writeBigUInt64BE(BigInt(n))
+  return buf
+}
+
+/**
+ * Reads the workspace lockfile and every workspace package.json (root +
+ * member packages) and returns the inputs needed by {@link composeCacheHash}.
+ *
+ * Paths are normalized to forward slashes and made relative to the
+ * workspace root so that they match what ends up in the bundle archive.
+ */
+export async function loadWorkspaceCacheHashInputs (
+  workspace: Workspace,
+): Promise<{ lockfile?: LockfileInput, packageJsons: PackageJsonInput[] }> {
+  const allPackages = [workspace.root, ...workspace.packages]
+
+  const packageJsons = await Promise.all(allPackages.map(async pkg => {
+    const raw = await fs.readFile(pkg.packageJsonPath)
+    const rel = path.relative(workspace.root.path, pkg.packageJsonPath)
+    return {
+      path: rel.split(path.sep).join('/'),
+      raw,
+    }
+  }))
+
+  let lockfile: LockfileInput | undefined
+  if (workspace.lockfile.isOk()) {
+    const lockfilePath = workspace.lockfile.ok()
+    const lockfileBytes = await fs.readFile(lockfilePath)
+    lockfile = {
+      name: path.basename(lockfilePath),
+      hash: createHash('sha256').update(lockfileBytes).digest(),
+    }
+  }
+
+  return { lockfile, packageJsons }
+}
+
+/**
+ * Convenience wrapper that loads workspace inputs and composes the cache
+ * hash with the standard set of excluded package.json fields.
+ */
+export async function computeWorkspaceCacheHash (workspace: Workspace): Promise<string> {
+  const inputs = await loadWorkspaceCacheHashInputs(workspace)
+  return composeCacheHash({
+    ...inputs,
+    excludedFields: PACKAGE_JSON_EXCLUDED_FIELDS,
+  })
+}


### PR DESCRIPTION
## Summary

- Extends the playwright code bundle cache hash to cover every workspace package.json (root + member packages) in addition to the lockfile, with the top-level `version` field stripped so CI-driven version bumps don't invalidate the cache.
- New `cache-hash.ts` module exposes a stable JSON encoder (sorted keys, HTML-significant + line/paragraph separators escaped), a package.json canonicalizer, and `composeCacheHash` which combines records using length-prefixed `lockfile:<basename>` and `package.json:<rel/path>` blocks (8-byte BE length + label, 8-byte BE length + content).
- The byte layout mirrors `composeBundleChecksum` in terraform-provider-checkly ([#364](https://github.com/checkly/terraform-provider-checkly/pull/364)) so identical inputs produce identical SHA-256 digests in both codebases. A hard-coded fixture digest is asserted in tests; mirror it into the TF provider test suite to lock in cross-language parity.

Linear: [SIM-227](https://linear.app/checkly/issue/SIM-227)

## Test plan

- [ ] Existing check-parser unit tests pass (`npx vitest run src/services/check-parser/`).
- [ ] New `cache-hash.spec.ts` covers: stable encoder behavior, version-stripping canonicalization, source key reordering, lockfile change sensitivity, workspace-member addition, input order independence, and a fixed parity fixture digest.
- [ ] Mirror the parity fixture into terraform-provider-checkly tests and confirm both sides produce `4d3072de5db2f0f8a5e29b72013dd7e4dfb25686023931ee98050d58ba4503f8`.
- [ ] Sanity-check a real playwright deploy: bundle hash should be stable across reruns when only `version` changes; a dependency edit in any workspace package.json should change the hash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)