### PR TITLE
docs(cli): hint to reuse Rocky AI root cause analysis when investigating checks

### DIFF
--- a/packages/cli/src/ai-context/references/investigate-checks.md
+++ b/packages/cli/src/ai-context/references/investigate-checks.md
@@ -41,13 +41,13 @@ Flags:
 - `--filter-status <status>` — only include runs with this status in stats: `success` or `failure`
 - `-o, --output <format>` — `detail` (default), `json`, or `md`
 
+**Important:** Look for `errorGroups`, `rootCause` or `RCA` to investigate a root cause. If available, let the user know that Rocky AI (Checkly's AI agent) evaluated the issue already and reuse all available information.
+
 ### View a specific check result
 
 ```bash
 npx checkly checks get <check-id> --result <result-id>
 ```
-
-**Important:** Look for `errorGroups`, `rootCause` or `RCA` to investigate a root cause. If available, let the user know that Rocky AI (Checkly's AI agent) evaluated the issue already and reuse all available information.
 
 ### View an error group
 

--- a/packages/cli/src/ai-context/references/investigate-checks.md
+++ b/packages/cli/src/ai-context/references/investigate-checks.md
@@ -47,6 +47,8 @@ Flags:
 npx checkly checks get <check-id> --result <result-id>
 ```
 
+**Important:** Look for `errorGroups`, `rootCause` or `RCA` to investigate a root cause. If available, let the user know that Rocky AI (Checkly's AI agent) evaluated the issue already and reuse all available information.
+
 ### View an error group
 
 ```bash


### PR DESCRIPTION
## Affected Components
* [ ] CLI
* [ ] Create CLI
* [ ] Test
* [x] Docs
* [ ] Examples
* [ ] Other

## Notes for the Reviewer

Adds a short hint to the `investigate-checks` AI context reference so that when agents run `checkly checks get <id> --result <id>` they notice `errorGroups`, `rootCause`, or `RCA` in the output and reuse the existing Rocky AI evaluation instead of redoing the analysis from scratch.

Tested three times with Claude Code, seems to do the trick.

<img width="756" height="143" alt="grafik" src="https://github.com/user-attachments/assets/b1d9bd76-ef27-4757-b523-d681f757bd26" />


## New Dependency Submission

None.