### PR TITLE
Add alert-channels list, get, and logs commands

### DIFF
--- a/packages/cli/e2e/__tests__/help.spec.ts
+++ b/packages/cli/e2e/__tests__/help.spec.ts
@@ -54,6 +54,7 @@ describe('help', () => {
 
     expect(stdout).toContain(`ADDITIONAL COMMANDS
   account          View and manage your Checkly account.
+  alert-channels   List and inspect alert channels in your Checkly account.
   api              Make an authenticated HTTP request to the Checkly API.
   checks           List and inspect checks in your Checkly account.
   destroy          Destroy your project with all its related resources.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -71,6 +71,9 @@
       "account": {
         "description": "View and manage your Checkly account."
       },
+      "alert-channels": {
+        "description": "List and inspect alert channels in your Checkly account."
+      },
       "checks": {
         "description": "List and inspect checks in your Checkly account."
       },

--- a/packages/cli/src/commands/__tests__/command-metadata.spec.ts
+++ b/packages/cli/src/commands/__tests__/command-metadata.spec.ts
@@ -7,6 +7,9 @@ import ChecksGet from '../checks/get.js'
 import ChecksStats from '../checks/stats.js'
 import StatusPagesList from '../status-pages/list.js'
 import StatusPagesGet from '../status-pages/get.js'
+import AlertChannelsList from '../alert-channels/list.js'
+import AlertChannelsGet from '../alert-channels/get.js'
+import AlertChannelsLogs from '../alert-channels/logs.js'
 import IncidentsList from '../incidents/list.js'
 import IncidentsCreate from '../incidents/create.js'
 import IncidentsUpdate from '../incidents/update.js'
@@ -43,6 +46,9 @@ const commands: Array<[string, typeof BaseCommand]> = [
   ['api', Api],
   ['account members', AccountMembers],
   ['account plan', AccountPlan],
+  ['alert-channels list', AlertChannelsList],
+  ['alert-channels get', AlertChannelsGet],
+  ['alert-channels logs', AlertChannelsLogs],
   ['checks list', ChecksList],
   ['checks get', ChecksGet],
   ['checks stats', ChecksStats],

--- a/packages/cli/src/commands/alert-channels/__tests__/alert-channels.spec.ts
+++ b/packages/cli/src/commands/alert-channels/__tests__/alert-channels.spec.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../rest/api', () => ({
+  alertChannels: { getAllPaginated: vi.fn(), get: vi.fn() },
+  alertNotifications: { getAll: vi.fn() },
+}))
+
+import * as api from '../../../rest/api.js'
+import AlertChannelsList from '../list.js'
+import AlertChannelsGet from '../get.js'
+import AlertChannelsLogs from '../logs.js'
+
+function createCommandContext (parsed: unknown) {
+  const logged: string[] = []
+  return {
+    parse: vi.fn().mockResolvedValue(parsed),
+    log: vi.fn((msg?: string) => {
+      if (msg) logged.push(msg)
+    }),
+    style: { outputFormat: undefined, longError: vi.fn() },
+    logged,
+  }
+}
+
+const alertChannelFixture = {
+  id: 123,
+  type: 'EMAIL',
+  config: { address: 'alerts@example.com' },
+  subscriptions: [],
+  sendRecovery: true,
+  sendFailure: true,
+  sendDegraded: false,
+  sslExpiry: false,
+  sslExpiryThreshold: 30,
+  autoSubscribe: false,
+  created_at: '2026-03-01T10:00:00.000Z',
+  updated_at: '2026-03-02T10:00:00.000Z',
+}
+
+const alertLogFixture = {
+  id: 'log-1',
+  type: 'EMAIL',
+  status: 'SUCCESS',
+  notificationResult: 'sent',
+  timestamp: '2026-03-01T10:00:00.000Z',
+  checkType: 'API',
+  checkId: 'chk-1',
+  checkName: 'Homepage API',
+  checkAlertId: 'alert-1',
+  alertChannelId: 123,
+  checkResultId: 'result-1',
+}
+
+describe('alert-channels commands', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.exitCode = undefined
+    vi.mocked(api.alertChannels.getAllPaginated).mockResolvedValue({
+      alertChannels: [alertChannelFixture],
+      total: 37,
+      page: 2,
+      limit: 10,
+    } as any)
+    vi.mocked(api.alertChannels.get).mockResolvedValue(alertChannelFixture as any)
+    vi.mocked(api.alertNotifications.getAll).mockResolvedValue({
+      data: [alertLogFixture],
+      total: 37,
+      page: 2,
+      limit: 10,
+    } as any)
+  })
+
+  it('list -o json returns raw channel data with pagination metadata', async () => {
+    const ctx = createCommandContext({
+      flags: { limit: 10, page: 2, output: 'json' },
+    })
+
+    await AlertChannelsList.prototype.run.call(ctx as any)
+
+    expect(api.alertChannels.getAllPaginated).toHaveBeenCalledWith({ limit: 10, page: 2 })
+    expect(JSON.parse(ctx.logged[0])).toEqual({
+      data: [alertChannelFixture],
+      pagination: { page: 2, limit: 10, total: 37, totalPages: 4 },
+    })
+  })
+
+  it('get <id> -o json returns raw channel JSON', async () => {
+    const ctx = createCommandContext({
+      args: { id: '123' },
+      flags: { output: 'json' },
+    })
+
+    await AlertChannelsGet.prototype.run.call(ctx as any)
+
+    expect(api.alertChannels.get).toHaveBeenCalledWith(123)
+    expect(JSON.parse(ctx.logged[0])).toEqual(alertChannelFixture)
+  })
+
+  it('get <id> includes navigation hints in terminal output', async () => {
+    const ctx = createCommandContext({
+      args: { id: '123' },
+      flags: { output: 'detail' },
+    })
+
+    await AlertChannelsGet.prototype.run.call(ctx as any)
+
+    expect(ctx.logged[0]).toContain('checkly alert-channels logs 123')
+    expect(ctx.logged[0]).toContain('checkly alert-channels list')
+  })
+
+  it('logs <id> --status failed --from <ts> --to <ts> sends expected query params', async () => {
+    const ctx = createCommandContext({
+      args: { id: '123' },
+      flags: {
+        limit: 10,
+        page: 2,
+        from: 1772359200,
+        to: 1772445600,
+        status: 'failed',
+        output: 'table',
+      },
+    })
+
+    await AlertChannelsLogs.prototype.run.call(ctx as any)
+
+    expect(api.alertNotifications.getAll).toHaveBeenCalledWith({
+      alertChannelId: 123,
+      limit: 10,
+      page: 2,
+      from: 1772359200,
+      to: 1772445600,
+      hasFailures: true,
+    })
+  })
+
+  it('logs <id> -o json includes pagination metadata', async () => {
+    const ctx = createCommandContext({
+      args: { id: '123' },
+      flags: {
+        limit: 10,
+        page: 2,
+        from: undefined,
+        to: undefined,
+        status: undefined,
+        output: 'json',
+      },
+    })
+
+    await AlertChannelsLogs.prototype.run.call(ctx as any)
+
+    expect(JSON.parse(ctx.logged[0])).toEqual({
+      data: [alertLogFixture],
+      pagination: { page: 2, limit: 10, total: 37, totalPages: 4 },
+    })
+  })
+
+  it('all alert channel commands are read-only and idempotent', () => {
+    expect(AlertChannelsList.readOnly).toBe(true)
+    expect(AlertChannelsList.destructive).toBe(false)
+    expect(AlertChannelsList.idempotent).toBe(true)
+    expect(AlertChannelsGet.readOnly).toBe(true)
+    expect(AlertChannelsGet.destructive).toBe(false)
+    expect(AlertChannelsGet.idempotent).toBe(true)
+    expect(AlertChannelsLogs.readOnly).toBe(true)
+    expect(AlertChannelsLogs.destructive).toBe(false)
+    expect(AlertChannelsLogs.idempotent).toBe(true)
+  })
+})

--- a/packages/cli/src/commands/alert-channels/get.ts
+++ b/packages/cli/src/commands/alert-channels/get.ts
@@ -1,0 +1,59 @@
+import { Args } from '@oclif/core'
+import chalk from 'chalk'
+import { AuthCommand } from '../authCommand.js'
+import { outputFlag } from '../../helpers/flags.js'
+import { parsePositiveInteger } from '../../helpers/number.js'
+import * as api from '../../rest/api.js'
+import type { OutputFormat } from '../../formatters/render.js'
+import { formatAlertChannelDetail } from '../../formatters/alert-channels.js'
+
+export default class AlertChannelsGet extends AuthCommand {
+  static hidden = false
+  static readOnly = true
+  static idempotent = true
+  static description = 'Get details of an alert channel.'
+
+  static args = {
+    id: Args.string({
+      description: 'The alert channel ID to retrieve.',
+      required: true,
+    }),
+  }
+
+  static flags = {
+    output: outputFlag({ default: 'detail' }),
+  }
+
+  async run (): Promise<void> {
+    const { args, flags } = await this.parse(AlertChannelsGet)
+    this.style.outputFormat = flags.output
+
+    try {
+      const id = parsePositiveInteger(args.id, 'Alert channel ID')
+      const alertChannel = await api.alertChannels.get(id)
+
+      if (flags.output === 'json') {
+        this.log(JSON.stringify(alertChannel, null, 2))
+        return
+      }
+
+      const fmt: OutputFormat = flags.output === 'md' ? 'md' : 'terminal'
+
+      if (fmt === 'md') {
+        this.log(formatAlertChannelDetail(alertChannel, fmt))
+        return
+      }
+
+      const output: string[] = []
+      output.push(formatAlertChannelDetail(alertChannel, fmt))
+      output.push('')
+      output.push(`  ${chalk.dim('View logs:')}    checkly alert-channels logs ${id}`)
+      output.push(`  ${chalk.dim('Back to list:')} checkly alert-channels list`)
+
+      this.log(output.join('\n'))
+    } catch (err: any) {
+      this.style.longError('Failed to get alert channel details.', err)
+      process.exitCode = 1
+    }
+  }
+}

--- a/packages/cli/src/commands/alert-channels/list.ts
+++ b/packages/cli/src/commands/alert-channels/list.ts
@@ -1,0 +1,77 @@
+import { Flags } from '@oclif/core'
+import { AuthCommand } from '../authCommand.js'
+import { outputFlag } from '../../helpers/flags.js'
+import { validateIntegerRange } from '../../helpers/number.js'
+import * as api from '../../rest/api.js'
+import type { OutputFormat } from '../../formatters/render.js'
+import {
+  formatAlertChannelNavigationHints,
+  formatAlertChannelPaginationInfo,
+  formatAlertChannels,
+} from '../../formatters/alert-channels.js'
+
+export default class AlertChannelsList extends AuthCommand {
+  static hidden = false
+  static readOnly = true
+  static idempotent = true
+  static description = 'List all alert channels in your account.'
+
+  static flags = {
+    limit: Flags.integer({
+      char: 'l',
+      description: 'Number of alert channels to return (1-100).',
+      default: 25,
+    }),
+    page: Flags.integer({
+      char: 'p',
+      description: 'Page number.',
+      default: 1,
+    }),
+    output: outputFlag({ default: 'table' }),
+  }
+
+  async run (): Promise<void> {
+    const { flags } = await this.parse(AlertChannelsList)
+    this.style.outputFormat = flags.output
+
+    try {
+      const limit = validateIntegerRange(flags.limit, 'Limit', 1, 100)
+      const page = validateIntegerRange(flags.page, 'Page', 1, Number.MAX_SAFE_INTEGER)
+      const paginated = await api.alertChannels.getAllPaginated({ limit, page })
+      const pagination = { page, limit, total: paginated.total }
+
+      if (flags.output === 'json') {
+        const totalPages = Math.ceil(paginated.total / limit)
+        this.log(JSON.stringify({
+          data: paginated.alertChannels,
+          pagination: { page, limit, total: paginated.total, totalPages },
+        }, null, 2))
+        return
+      }
+
+      if (paginated.total === 0) {
+        this.log('No alert channels found.')
+        return
+      }
+
+      const fmt: OutputFormat = flags.output === 'md' ? 'md' : 'terminal'
+
+      if (fmt === 'md') {
+        this.log(formatAlertChannels(paginated.alertChannels, fmt))
+        return
+      }
+
+      const output: string[] = []
+      output.push(formatAlertChannels(paginated.alertChannels, fmt))
+      output.push('')
+      output.push(formatAlertChannelPaginationInfo(pagination))
+      output.push('')
+      output.push(formatAlertChannelNavigationHints(pagination))
+
+      this.log(output.join('\n'))
+    } catch (err: any) {
+      this.style.longError('Failed to list alert channels.', err)
+      process.exitCode = 1
+    }
+  }
+}

--- a/packages/cli/src/commands/alert-channels/logs.ts
+++ b/packages/cli/src/commands/alert-channels/logs.ts
@@ -1,0 +1,104 @@
+import { Args, Flags } from '@oclif/core'
+import chalk from 'chalk'
+import { AuthCommand } from '../authCommand.js'
+import { outputFlag } from '../../helpers/flags.js'
+import {
+  parseNonNegativeInteger,
+  parsePositiveInteger,
+  validateIntegerRange,
+} from '../../helpers/number.js'
+import * as api from '../../rest/api.js'
+import type { AlertNotificationListParams } from '../../rest/alert-notifications.js'
+import type { OutputFormat } from '../../formatters/render.js'
+import { formatAlertNotificationLogs } from '../../formatters/alert-channels.js'
+
+export default class AlertChannelsLogs extends AuthCommand {
+  static hidden = false
+  static readOnly = true
+  static idempotent = true
+  static description = 'List notification logs for an alert channel.'
+
+  static args = {
+    id: Args.string({
+      description: 'The alert channel ID to retrieve logs for.',
+      required: true,
+    }),
+  }
+
+  static flags = {
+    limit: Flags.integer({
+      char: 'l',
+      description: 'Number of logs to return (1-100).',
+      default: 25,
+    }),
+    page: Flags.integer({
+      char: 'p',
+      description: 'Page number.',
+      default: 1,
+    }),
+    from: Flags.integer({
+      description: 'Unix timestamp for the start of the log window.',
+    }),
+    to: Flags.integer({
+      description: 'Unix timestamp for the end of the log window.',
+    }),
+    status: Flags.string({
+      char: 's',
+      description: 'Filter logs by status.',
+      options: ['failed'],
+    }),
+    output: outputFlag({ default: 'table' }),
+  }
+
+  async run (): Promise<void> {
+    const { args, flags } = await this.parse(AlertChannelsLogs)
+    this.style.outputFormat = flags.output
+
+    try {
+      const id = parsePositiveInteger(args.id, 'Alert channel ID')
+      const limit = validateIntegerRange(flags.limit, 'Limit', 1, 100)
+      const page = parsePositiveInteger(flags.page, 'Page')
+
+      const params: AlertNotificationListParams = {
+        alertChannelId: id,
+        limit,
+        page,
+      }
+      if (flags.from !== undefined) params.from = parseNonNegativeInteger(flags.from, 'From')
+      if (flags.to !== undefined) params.to = parseNonNegativeInteger(flags.to, 'To')
+      if (flags.status === 'failed') params.hasFailures = true
+
+      const logs = await api.alertNotifications.getAll(params)
+      const totalPages = Math.ceil(logs.total / limit)
+
+      if (flags.output === 'json') {
+        this.log(JSON.stringify({
+          data: logs.data,
+          pagination: { page, limit, total: logs.total, totalPages },
+        }, null, 2))
+        return
+      }
+
+      const fmt: OutputFormat = flags.output === 'md' ? 'md' : 'terminal'
+      if (fmt === 'md') {
+        this.log(formatAlertNotificationLogs(logs.data, fmt))
+        return
+      }
+
+      if (logs.data.length === 0) {
+        this.log('No alert channel logs found.')
+        return
+      }
+
+      const output: string[] = []
+      output.push(formatAlertNotificationLogs(logs.data, fmt))
+      output.push('')
+      output.push(chalk.dim(`Showing ${logs.data.length} of ${logs.total} logs (page ${page}/${totalPages})`))
+
+      this.log(output.join('\n'))
+    } catch (err: any) {
+      this.style.longError('Failed to list alert channel logs.', err)
+      process.exitCode = 1
+    }
+  }
+}

--- a/packages/cli/src/formatters/__tests__/alert-channels.spec.ts
+++ b/packages/cli/src/formatters/__tests__/alert-channels.spec.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest'
+import type { AlertChannel } from '../../rest/alert-channels.js'
+import type { AlertNotification } from '../../rest/alert-notifications.js'
+import { stripAnsi } from '../render.js'
+import {
+  formatAlertChannelDetail,
+  formatAlertChannels,
+  formatAlertNotificationLogs,
+} from '../alert-channels.js'
+
+const baseChannel = {
+  id: 123,
+  sendFailure: true,
+  sendRecovery: true,
+  sendDegraded: false,
+  sslExpiry: true,
+  sslExpiryThreshold: 7,
+  autoSubscribe: false,
+  subscriptions: [
+    { checkId: 'chk-1', check: { name: 'Homepage API' } },
+    { groupId: 42, group: { name: 'Checkout group' } },
+  ],
+  created_at: '2026-03-01T10:00:00.000Z',
+  updated_at: '2026-03-02T10:00:00.000Z',
+} satisfies Partial<AlertChannel>
+
+describe('formatAlertChannels', () => {
+  it('renders a list of alert channels with type, name, subscription count, created date, and id', () => {
+    const channels = [
+      { ...baseChannel, type: 'EMAIL', config: { address: 'alerts@example.com' } },
+      { ...baseChannel, id: 456, type: 'SLACK_APP', config: { slackChannels: ['#alerts', '@oncall'] } },
+    ] as AlertChannel[]
+
+    const result = stripAnsi(formatAlertChannels(channels, 'terminal'))
+
+    expect(result).toContain('TYPE')
+    expect(result).toContain('NAME')
+    expect(result).toContain('SUBS')
+    expect(result).toContain('email')
+    expect(result).toContain('slack app')
+    expect(result).toContain('alerts@example.com')
+    expect(result).toContain('2')
+    expect(result).toContain('2026-03-01 10:00:00 UTC')
+    expect(result).toContain('123')
+  })
+})
+
+describe('formatAlertChannelDetail', () => {
+  it.each([
+    ['Email', { ...baseChannel, type: 'EMAIL', config: { address: 'alerts@example.com' } }],
+    ['Slack', { ...baseChannel, type: 'SLACK', config: { url: 'https://hooks.slack.com/services/secret', channel: '#alerts' } }],
+    ['Slack app', { ...baseChannel, type: 'SLACK_APP', config: { slackChannels: ['#alerts', '@oncall'] } }],
+    ['Webhook', { ...baseChannel, type: 'WEBHOOK', config: { name: 'Deploy hook', url: 'https://example.com/webhook-secret' } }],
+    ['PagerDuty', { ...baseChannel, type: 'PAGERDUTY', config: { serviceName: 'On-call', serviceKey: 'pd-secret' } }],
+    ['Opsgenie', { ...baseChannel, type: 'OPSGENIE', config: { name: 'Ops', apiKey: 'ops-secret', region: 'EU', priority: 'P1' } }],
+  ])('renders %s alert channel detail', (_label, channel) => {
+    const result = stripAnsi(formatAlertChannelDetail(channel as AlertChannel, 'terminal'))
+
+    expect(result).toContain('Enabled events:')
+    expect(result).toContain('failure, recovery')
+    expect(result).toContain('SSL expiry:')
+    expect(result).toContain('yes (7 days)')
+    expect(result).toContain('SUBSCRIPTIONS')
+    expect(result).toContain('Homepage API')
+    expect(result).toContain('123')
+  })
+
+  it.each(['terminal', 'md'] as const)('does not print secret-bearing config fields in %s output', format => {
+    const channel: AlertChannel = {
+      ...baseChannel,
+      type: 'WEBHOOK',
+      config: {
+        name: 'Secure webhook',
+        url: 'https://example.com/private-token',
+        webhookSecret: 'signing-secret',
+        headers: [{ key: 'Authorization', value: 'Bearer secret' }],
+        apiKey: 'api-secret',
+        serviceKey: 'service-secret',
+      },
+    } as AlertChannel
+
+    const result = stripAnsi(formatAlertChannelDetail(channel, format))
+
+    expect(result).toContain('Secure webhook')
+    expect(result).not.toContain('https://example.com/private-token')
+    expect(result).not.toContain('signing-secret')
+    expect(result).not.toContain('Authorization')
+    expect(result).not.toContain('api-secret')
+    expect(result).not.toContain('service-secret')
+  })
+
+  it('renders an empty subscription state', () => {
+    const channel: AlertChannel = {
+      ...baseChannel,
+      type: 'EMAIL',
+      config: { address: 'alerts@example.com' },
+      subscriptions: [],
+    } as AlertChannel
+
+    expect(stripAnsi(formatAlertChannelDetail(channel, 'terminal'))).toContain('No subscriptions configured.')
+  })
+
+  it('does not render an empty name column when subscriptions only include IDs', () => {
+    const channel: AlertChannel = {
+      ...baseChannel,
+      type: 'EMAIL',
+      config: { address: 'alerts@example.com' },
+      subscriptions: [
+        { checkId: '0056ce7a-52f6-4315-a2d6-0392369abac5' },
+      ],
+    } as AlertChannel
+
+    const result = formatAlertChannelDetail(channel, 'md')
+
+    expect(result).toContain('| Type | ID |')
+    expect(result).not.toContain('| Type | Name | ID |')
+    expect(result).not.toContain('| check | - |')
+  })
+
+  it('renders subscription names when the API provides top-level names', () => {
+    const channel: AlertChannel = {
+      ...baseChannel,
+      type: 'EMAIL',
+      config: { address: 'alerts@example.com' },
+      subscriptions: [
+        { checkId: '0056ce7a-52f6-4315-a2d6-0392369abac5', checkName: 'Homepage API' },
+        { groupId: 42, groupName: 'Checkout group' },
+      ],
+    } as AlertChannel
+
+    const result = formatAlertChannelDetail(channel, 'md')
+
+    expect(result).toContain('| Type | Name | ID |')
+    expect(result).toContain('| check | Homepage API | 0056ce7a-52f6-4315-a2d6-0392369abac5 |')
+    expect(result).toContain('| group | Checkout group | 42 |')
+  })
+})
+
+describe('formatAlertNotificationLogs', () => {
+  it('renders success, failure, and in-progress statuses with truncated messages', () => {
+    const longMessage = 'Webhook response body '.repeat(10)
+    const logs: AlertNotification[] = [
+      {
+        id: 'log-1',
+        type: 'EMAIL',
+        status: 'SUCCESS',
+        alertChannelId: 123,
+        timestamp: '2026-03-01T10:00:00.000Z',
+        checkId: 'chk-1',
+        checkName: 'Homepage API',
+        checkResultId: 'res-1',
+        notificationResult: 'sent',
+      },
+      {
+        id: 'log-2',
+        type: 'WEBHOOK',
+        status: 'FAILURE',
+        alertChannelId: 123,
+        timestamp: '2026-03-01T10:01:00.000Z',
+        checkId: 'chk-2',
+        checkResultId: 'res-2',
+        notificationResult: longMessage,
+      },
+      {
+        id: 'log-3',
+        type: 'SLACK',
+        status: 'IN_PROGRESS',
+        alertChannelId: 123,
+        timestamp: '2026-03-01T10:02:00.000Z',
+        checkId: 'chk-3',
+        checkResultId: 'res-3',
+        notificationResult: null,
+      },
+    ]
+
+    const result = stripAnsi(formatAlertNotificationLogs(logs, 'terminal'))
+
+    expect(result).toContain('success')
+    expect(result).toContain('failure')
+    expect(result).toContain('in progress')
+    expect(result).toContain('Webhook response body')
+    expect(result).toContain('…')
+    expect(result).not.toContain(longMessage)
+  })
+
+  it('renders an empty logs state', () => {
+    expect(formatAlertNotificationLogs([], 'terminal')).toBe('No alert channel logs found.')
+  })
+})

--- a/packages/cli/src/formatters/alert-channels.ts
+++ b/packages/cli/src/formatters/alert-channels.ts
@@ -1,0 +1,305 @@
+import chalk from 'chalk'
+import type { AlertChannel, AlertChannelSubscription } from '../rest/alert-channels.js'
+import type { AlertNotification } from '../rest/alert-notifications.js'
+import {
+  type OutputFormat,
+  type DetailField,
+  type ColumnDef,
+  renderDetailFields,
+  renderTable,
+  formatDate,
+  truncateError,
+  truncateToWidth,
+} from './render.js'
+
+export interface AlertChannelPaginationInfo {
+  page: number
+  limit: number
+  total: number
+}
+
+function boolLabel (value: boolean | undefined, format: OutputFormat): string {
+  if (value === undefined) return format === 'terminal' ? chalk.dim('-') : '-'
+  if (format === 'md') return value ? 'yes' : 'no'
+  return value ? chalk.green('yes') : chalk.dim('no')
+}
+
+function normalizeType (type: string | undefined): string {
+  if (!type) return '-'
+  return type.toLowerCase().replace(/_/g, ' ')
+}
+
+function redacted (format: OutputFormat): string {
+  return format === 'terminal' ? chalk.dim('redacted') : 'redacted'
+}
+
+export function titleFromConfig (channel: AlertChannel): string {
+  const config = channel.config ?? {}
+  return channel.name
+    ?? config.name
+    ?? config.channel
+    ?? config.address
+    ?? config.serviceName
+    ?? config.account
+    ?? `${normalizeType(channel.type)} alert channel`
+}
+
+function targetFromConfig (channel: AlertChannel, format: OutputFormat): string {
+  const config = channel.config ?? {}
+  const secret = redacted(format)
+
+  switch (channel.type) {
+    case 'EMAIL':
+      return String(config.address ?? '-')
+    case 'SLACK':
+      return config.channel ? String(config.channel) : `Slack webhook (${secret})`
+    case 'SLACK_APP':
+      return Array.isArray(config.slackChannels) ? config.slackChannels.join(', ') : '-'
+    case 'WEBHOOK':
+      return config.name ? String(config.name) : `Webhook URL (${secret})`
+    case 'PAGERDUTY':
+      return String(config.serviceName ?? config.account ?? `Service key (${secret})`)
+    case 'OPSGENIE':
+      return [
+        config.name,
+        config.region,
+        config.priority,
+      ].filter(Boolean).join(' / ') || `API key (${secret})`
+    case 'SMS':
+    case 'CALL':
+      return String(config.name ?? config.number ?? config.phoneNumber ?? '-')
+    default:
+      return String(config.name ?? '-')
+  }
+}
+
+function enabledEvents (channel: AlertChannel, format: OutputFormat): string {
+  const events: string[] = []
+  if (channel.sendFailure) events.push('failure')
+  if (channel.sendRecovery) events.push('recovery')
+  if (channel.sendDegraded) events.push('degraded')
+  if (events.length === 0) return format === 'terminal' ? chalk.dim('-') : '-'
+  return events.join(', ')
+}
+
+function sslExpiryLabel (channel: AlertChannel, format: OutputFormat): string {
+  if (!channel.sslExpiry) return boolLabel(false, format)
+  const threshold = channel.sslExpiryThreshold ?? 30
+  return `yes (${threshold} days)`
+}
+
+function subscriptionCount (channel: AlertChannel): string {
+  return String(channel.subscriptions?.length ?? 0)
+}
+
+function buildAlertChannelColumns (format: OutputFormat): ColumnDef<AlertChannel>[] {
+  if (format === 'md') {
+    return [
+      { header: 'Type', value: c => normalizeType(c.type) },
+      { header: 'Name', value: titleFromConfig },
+      { header: 'Subscriptions', value: subscriptionCount },
+      { header: 'Created', value: (c, fmt) => formatDate(c.created_at ?? c.createdAt, fmt) },
+      { header: 'ID', value: c => String(c.id) },
+    ]
+  }
+
+  const termWidth = process.stdout.columns || 120
+  const nameWidth = Math.min(34, Math.floor(termWidth * 0.28))
+  const targetWidth = Math.min(28, Math.floor(termWidth * 0.22))
+
+  return [
+    { header: 'Type', width: 14, value: c => normalizeType(c.type) },
+    { header: 'Name', width: nameWidth, value: c => truncateToWidth(titleFromConfig(c), nameWidth - 2) },
+    { header: 'Target', width: targetWidth, value: (c, fmt) => truncateToWidth(targetFromConfig(c, fmt), targetWidth - 2) },
+    { header: 'Subs', width: 8, align: 'right', value: subscriptionCount },
+    { header: 'Created', width: 24, value: (c, fmt) => formatDate(c.created_at ?? c.createdAt, fmt) },
+    { header: 'ID', value: c => chalk.dim(String(c.id)) },
+  ]
+}
+
+export function formatAlertChannels (channels: AlertChannel[], format: OutputFormat): string {
+  return renderTable(buildAlertChannelColumns(format), channels, format)
+}
+
+export function formatAlertChannelPaginationInfo (pagination: AlertChannelPaginationInfo): string {
+  const { page, limit, total } = pagination
+  const totalPages = Math.max(1, Math.ceil(total / limit))
+  const start = total === 0 ? 0 : (page - 1) * limit + 1
+  const end = Math.min(page * limit, total)
+  return chalk.dim(`Showing ${start}-${end} of ${total} alert channels (page ${page}/${totalPages})`)
+}
+
+export function formatAlertChannelNavigationHints (pagination: AlertChannelPaginationInfo): string {
+  const { page, limit, total } = pagination
+  const totalPages = Math.ceil(total / limit)
+  const lines: string[] = []
+
+  if (page < totalPages) {
+    lines.push(`  ${chalk.dim('Next page:')}    checkly alert-channels list --page ${page + 1}`)
+  }
+  if (page > 1) {
+    lines.push(`  ${chalk.dim('Prev page:')}    checkly alert-channels list --page ${page - 1}`)
+  }
+  lines.push(`  ${chalk.dim('View channel:')} checkly alert-channels get <id>`)
+  lines.push(`  ${chalk.dim('View logs:')}    checkly alert-channels logs <id> --status failed`)
+
+  return lines.join('\n')
+}
+
+const alertChannelDetailFields: DetailField<AlertChannel>[] = [
+  { label: 'Type', value: c => normalizeType(c.type) },
+  { label: 'Target', value: targetFromConfig },
+  { label: 'Enabled events', value: enabledEvents },
+  { label: 'SSL expiry', value: sslExpiryLabel },
+  { label: 'Auto-subscribe', value: (c, fmt) => boolLabel(c.autoSubscribe, fmt) },
+  { label: 'Subscriptions', value: subscriptionCount },
+  { label: 'Created', value: (c, fmt) => formatDate(c.created_at ?? c.createdAt, fmt) },
+  { label: 'Updated', value: (c, fmt) => formatDate(c.updated_at ?? c.updatedAt, fmt) },
+  { label: 'ID', value: c => String(c.id) },
+]
+
+function subscriptionType (subscription: AlertChannelSubscription): string {
+  if (subscription.checkId || subscription.check) return 'check'
+  if (subscription.groupId || subscription.group) return 'group'
+  return 'subscription'
+}
+
+function subscriptionName (subscription: AlertChannelSubscription, format: OutputFormat): string {
+  const name = subscription.checkName ?? subscription.groupName ?? subscription.check?.name ?? subscription.group?.name
+  if (name) return name
+  return format === 'terminal' ? chalk.dim('-') : '-'
+}
+
+function subscriptionId (subscription: AlertChannelSubscription): string {
+  return String(
+    subscription.checkId
+    ?? subscription.check?.id
+    ?? subscription.groupId
+    ?? subscription.group?.id
+    ?? subscription.id
+    ?? '-',
+  )
+}
+
+function hasSubscriptionNames (subscriptions: AlertChannelSubscription[]): boolean {
+  return subscriptions.some(subscription => Boolean(
+    subscription.checkName
+    ?? subscription.groupName
+    ?? subscription.check?.name
+    ?? subscription.group?.name,
+  ))
+}
+
+function buildSubscriptionColumns (
+  format: OutputFormat,
+  subscriptions: AlertChannelSubscription[],
+): ColumnDef<AlertChannelSubscription>[] {
+  const includeName = hasSubscriptionNames(subscriptions)
+
+  if (format === 'md') {
+    const columns: ColumnDef<AlertChannelSubscription>[] = [
+      { header: 'Type', value: subscriptionType },
+      { header: 'ID', value: subscriptionId },
+    ]
+    if (includeName) {
+      columns.splice(1, 0, { header: 'Name', value: (s, fmt) => subscriptionName(s, fmt) })
+    }
+    return columns
+  }
+
+  const columns: ColumnDef<AlertChannelSubscription>[] = [
+    { header: 'Type', width: 14, value: subscriptionType },
+    { header: 'ID', value: s => chalk.dim(subscriptionId(s)) },
+  ]
+  if (includeName) {
+    columns.splice(1, 0, {
+      header: 'Name',
+      width: 32,
+      value: (s, fmt) => truncateToWidth(subscriptionName(s, fmt), 30),
+    })
+  }
+  return columns
+}
+
+export function formatAlertChannelSubscriptions (channel: AlertChannel, format: OutputFormat): string {
+  const subscriptions = channel.subscriptions ?? []
+  if (subscriptions.length === 0) return 'No subscriptions configured.'
+  return renderTable(buildSubscriptionColumns(format, subscriptions), subscriptions, format)
+}
+
+export function formatAlertChannelDetail (channel: AlertChannel, format: OutputFormat): string {
+  const lines: string[] = []
+  lines.push(renderDetailFields(titleFromConfig(channel), alertChannelDetailFields, channel, format))
+
+  lines.push('')
+  if (format === 'md') {
+    lines.push('## Subscriptions')
+    lines.push('')
+  } else {
+    lines.push(chalk.bold('SUBSCRIPTIONS'))
+  }
+  lines.push(formatAlertChannelSubscriptions(channel, format))
+
+  return lines.join('\n')
+}
+
+function formatNotificationStatus (status: string, format: OutputFormat): string {
+  const label = status.toLowerCase().replace(/_/g, ' ')
+  if (format === 'md') return label
+  switch (status) {
+    case 'SUCCESS':
+      return chalk.green(label)
+    case 'FAILURE':
+    case 'RATE_LIMITED':
+      return chalk.red(label)
+    case 'IN_PROGRESS':
+      return chalk.yellow(label)
+    default:
+      return chalk.dim(label)
+  }
+}
+
+function notificationCheckLabel (log: AlertNotification): string {
+  return String(
+    log.check?.name
+    ?? log.checkName
+    ?? log.alertConfig?.checkName
+    ?? log.checkId
+    ?? '-',
+  )
+}
+
+function notificationResultLabel (log: AlertNotification): string {
+  return log.checkResultId ?? '-'
+}
+
+function notificationMessage (log: AlertNotification): string {
+  return log.notificationResult ?? '-'
+}
+
+function buildAlertNotificationColumns (format: OutputFormat): ColumnDef<AlertNotification>[] {
+  if (format === 'md') {
+    return [
+      { header: 'Time', value: l => formatDate(l.timestamp, format) },
+      { header: 'Status', value: l => formatNotificationStatus(l.status, format) },
+      { header: 'Type', value: l => normalizeType(l.type) },
+      { header: 'Check', value: notificationCheckLabel },
+      { header: 'Result', value: notificationResultLabel },
+      { header: 'Message', value: l => truncateError(notificationMessage(l), 120) },
+    ]
+  }
+
+  return [
+    { header: 'Time', width: 22, value: l => formatDate(l.timestamp, format) },
+    { header: 'Status', width: 14, value: l => formatNotificationStatus(l.status, format) },
+    { header: 'Type', width: 12, value: l => normalizeType(l.type) },
+    { header: 'Check', width: 28, value: l => truncateToWidth(notificationCheckLabel(l), 26) },
+    { header: 'Result', width: 22, value: l => chalk.dim(truncateToWidth(notificationResultLabel(l), 20)) },
+    { header: 'Message', value: l => truncateError(notificationMessage(l), 80) },
+  ]
+}
+
+export function formatAlertNotificationLogs (logs: AlertNotification[], format: OutputFormat): string {
+  if (logs.length === 0) return 'No alert channel logs found.'
+  return renderTable(buildAlertNotificationColumns(format), logs, format)
+}

--- a/packages/cli/src/helpers/number.ts
+++ b/packages/cli/src/helpers/number.ts
@@ -1,0 +1,21 @@
+export function parsePositiveInteger (value: string | number, label: string): number {
+  const parsed = typeof value === 'number' ? value : Number(value)
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${label} must be a positive integer.`)
+  }
+  return parsed
+}
+
+export function parseNonNegativeInteger (value: number, label: string): number {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${label} must be a non-negative integer.`)
+  }
+  return value
+}
+
+export function validateIntegerRange (value: number, label: string, min: number, max: number): number {
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new Error(`${label} must be an integer between ${min} and ${max}.`)
+  }
+  return value
+}

--- a/packages/cli/src/rest/alert-channels.ts
+++ b/packages/cli/src/rest/alert-channels.ts
@@ -1,0 +1,84 @@
+import type { AxiosInstance } from 'axios'
+import { parseTotalFromContentRange } from '../helpers/content-range.js'
+
+export type AlertChannelType =
+  | 'CALL'
+  | 'EMAIL'
+  | 'OPSGENIE'
+  | 'PAGERDUTY'
+  | 'SLACK'
+  | 'SLACK_APP'
+  | 'SMS'
+  | 'WEBHOOK'
+
+export interface AlertChannelSubscription {
+  id?: string | number
+  checkId?: string | null
+  checkName?: string
+  groupId?: number | null
+  groupName?: string
+  activated?: boolean
+  check?: {
+    id?: string
+    name?: string
+  }
+  group?: {
+    id?: number
+    name?: string
+  }
+}
+
+export interface AlertChannel {
+  id: number
+  type: AlertChannelType | string
+  name?: string
+  config?: Record<string, any>
+  subscriptions?: AlertChannelSubscription[]
+  sendRecovery?: boolean
+  sendFailure?: boolean
+  sendDegraded?: boolean
+  sslExpiry?: boolean
+  sslExpiryThreshold?: number
+  autoSubscribe?: boolean
+  created_at?: string
+  updated_at?: string | null
+  createdAt?: string
+  updatedAt?: string | null
+}
+
+export interface AlertChannelListParams {
+  limit?: number
+  page?: number
+}
+
+export interface PaginatedAlertChannels {
+  alertChannels: AlertChannel[]
+  total: number
+  page: number
+  limit: number
+}
+
+class AlertChannels {
+  api: AxiosInstance
+  constructor (api: AxiosInstance) {
+    this.api = api
+  }
+
+  async getAllPaginated (params: AlertChannelListParams = {}): Promise<PaginatedAlertChannels> {
+    const response = await this.api.get<AlertChannel[]>('/v1/alert-channels', { params })
+    const total = parseTotalFromContentRange(response.headers['content-range']) ?? response.data.length
+    return {
+      alertChannels: response.data,
+      total,
+      page: params.page ?? 1,
+      limit: params.limit ?? 10,
+    }
+  }
+
+  async get (id: number): Promise<AlertChannel> {
+    const response = await this.api.get<AlertChannel>(`/v1/alert-channels/${id}`)
+    return response.data
+  }
+}
+
+export default AlertChannels

--- a/packages/cli/src/rest/alert-notifications.ts
+++ b/packages/cli/src/rest/alert-notifications.ts
@@ -1,0 +1,57 @@
+import type { AxiosInstance } from 'axios'
+import { parseTotalFromContentRange } from '../helpers/content-range.js'
+
+export interface AlertNotification {
+  id: string
+  type: string
+  status: 'IN_PROGRESS' | 'SUCCESS' | 'FAILURE' | 'RATE_LIMITED' | string
+  alertConfig?: Record<string, any>
+  notificationResult?: string | null
+  timestamp?: string | null
+  checkType?: string
+  checkId?: string
+  checkName?: string
+  check?: {
+    id?: string
+    name?: string
+  }
+  checkAlertId?: string
+  alertChannelId: number
+  checkResultId?: string
+}
+
+export interface AlertNotificationListParams {
+  limit?: number
+  page?: number
+  from?: number
+  to?: number
+  alertChannelId?: number
+  hasFailures?: boolean
+}
+
+export interface PaginatedAlertNotifications {
+  data: AlertNotification[]
+  total: number
+  page: number
+  limit: number
+}
+
+class AlertNotifications {
+  api: AxiosInstance
+  constructor (api: AxiosInstance) {
+    this.api = api
+  }
+
+  async getAll (params: AlertNotificationListParams = {}): Promise<PaginatedAlertNotifications> {
+    const response = await this.api.get<AlertNotification[]>('/v1/alert-notifications', { params })
+    const total = parseTotalFromContentRange(response.headers['content-range']) ?? response.data.length
+    return {
+      data: response.data,
+      total,
+      page: params.page ?? 1,
+      limit: params.limit ?? 10,
+    }
+  }
+}
+
+export default AlertNotifications

--- a/packages/cli/src/rest/api.ts
+++ b/packages/cli/src/rest/api.ts
@@ -25,6 +25,8 @@ import Analytics from './analytics.js'
 import BatchAnalytics from './batch-analytics.js'
 import Entitlements from './entitlements.js'
 import AccountMembers from './account-members.js'
+import AlertChannels from './alert-channels.js'
+import AlertNotifications from './alert-notifications.js'
 import Rca from './rca.js'
 import Cancel from './cancel.js'
 import { handleErrorResponse, UnauthorizedError } from './errors.js'
@@ -131,5 +133,7 @@ export const analytics = new Analytics(api)
 export const batchAnalytics = new BatchAnalytics(api)
 export const entitlements = new Entitlements(api)
 export const accountMembers = new AccountMembers(api)
+export const alertChannels = new AlertChannels(api)
+export const alertNotifications = new AlertNotifications(api)
 export const rca = new Rca(api)
 export const cancel = new Cancel(api)


### PR DESCRIPTION
## Summary
- Add `alert-channels list`, `alert-channels get`, and `alert-channels logs` to the CLI
- Wire the commands to the public alert-channels and alert-notifications API clients
- Add formatters and focused tests for list, detail, logs, and command metadata
- Register the new `alert-channels` topic in the CLI package metadata

## Testing
- `npx tsc -p packages/cli/tsconfig.json --skipLibCheck`
- `npm run lint`
- Focused Vitest coverage for the new alert-channel commands, formatters, and command metadata