### PR TITLE
feat(cli)!: default --record to true on test and trigger commands

### DIFF
--- a/examples/advanced-project-js/.github/workflow.yml
+++ b/examples/advanced-project-js/.github/workflow.yml
@@ -44,7 +44,7 @@ jobs:
         run: npm ci
       - name: Run checks # run the checks passing in the ENVIRONMENT_URL and recording a test session.
         id: run-checks
-        run: npx checkly -v && npx checkly test -e ENVIRONMENT_URL=${{ env.ENVIRONMENT_URL }} --reporter=github --record
+        run: npx checkly -v && npx checkly test -e ENVIRONMENT_URL=${{ env.ENVIRONMENT_URL }} --reporter=github
       - name: Create summary # export the markdown report to the job summary.
         id: create-summary
         run: cat checkly-github-report.md > $GITHUB_STEP_SUMMARY

--- a/examples/advanced-project/.github/workflow.yml
+++ b/examples/advanced-project/.github/workflow.yml
@@ -44,7 +44,7 @@ jobs:
         run: npm ci
       - name: Run checks # run the checks passing in the ENVIRONMENT_URL and recording a test session.
         id: run-checks
-        run: npx checkly -v && npx checkly test -e ENVIRONMENT_URL=${{ env.ENVIRONMENT_URL }} --reporter=github --record
+        run: npx checkly -v && npx checkly test -e ENVIRONMENT_URL=${{ env.ENVIRONMENT_URL }} --reporter=github
       - name: Create summary # export the markdown report to the job summary.
         id: create-summary
         run: cat checkly-github-report.md > $GITHUB_STEP_SUMMARY

--- a/examples/boilerplate-project-js/README.md
+++ b/examples/boilerplate-project-js/README.md
@@ -31,9 +31,7 @@ This project has the basic boilerplate files needed to get you started.
 
 - Running `npx checkly pw-test` will use the `playwright.config.js` file and run the test suite in Checkly.
 
-- Running `npx checkly test` will look for `.check.js` files and `.spec.js` in `__checks__` directories and execute them in a dry run.
-
-- Running `npx checkly test --record` will run all checks in a test session for you to preview in the UI.
+- Running `npx checkly test` will look for `.check.js` files and `.spec.js` in `__checks__` directories and execute them in a dry run. Results are recorded as a test session for you to preview in the UI. Use `--no-record` to skip recording.
 
 - Running `npx checkly deploy` will deploy your checks to Checkly, attach alert channels, and run them on a 10m schedule in the
 region `us-east-1` and `eu-west-1`

--- a/examples/boilerplate-project/README.md
+++ b/examples/boilerplate-project/README.md
@@ -30,9 +30,7 @@ This project has the basic boilerplate files needed to get you started.
 ```
 - Running `npx checkly pw-test` will use the `playwright.config.ts` file and run the test suite in Checkly.
 
-- Running `npx checkly test` will look for `.check.ts` files and `.spec.ts` in `__checks__` directories and execute them in a dry run.
-
-- Running `npx checkly test --record` will run all checks in a test session for you to preview in the UI.
+- Running `npx checkly test` will look for `.check.ts` files and `.spec.ts` in `__checks__` directories and execute them in a dry run. Results are recorded as a test session for you to preview in the UI. Use `--no-record` to skip recording.
 
 - Running `npx checkly deploy` will deploy your checks to Checkly, attach alert channels, and run them on a 10m schedule in the
 region `us-east-1` and `eu-west-1`

--- a/packages/cli/src/ai-context/references/configure.md
+++ b/packages/cli/src/ai-context/references/configure.md
@@ -68,7 +68,7 @@ Run `npx checkly skills manage plan` for the full reference.
 
 ## Testing and Debugging
 
-- Test checks using the `npx checkly test` command. Pass environment variables with the `-e` flag, use `--record` to persist results, and use `--verbose` to see all errors.
+- Test checks using the `npx checkly test` command. Pass environment variables with the `-e` flag, results are recorded by default (use `--no-record` to skip), and use `--verbose` to see all errors.
 
 ## Deploying
 

--- a/packages/cli/src/commands/pw-test.ts
+++ b/packages/cli/src/commands/pw-test.ts
@@ -83,7 +83,7 @@ export default class PwTestCommand extends AuthCommand {
       description: commonMessages.configFile,
     }),
     'record': Flags.boolean({
-      description: 'Record test results in Checkly as a test session with full logs, traces and videos.',
+      description: '[default: true] Record test results in Checkly as a test session with full logs, traces and videos.',
       default: true,
       allowNo: true,
     }),

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -93,7 +93,7 @@ export default class Test extends AuthCommand {
       description: commonMessages.configFile,
     }),
     'record': Flags.boolean({
-      description: 'Record test results in Checkly as a test session with full logs, traces and videos.',
+      description: '[default: true] Record test results in Checkly as a test session with full logs, traces and videos.',
       default: true,
       allowNo: true,
     }),

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -94,11 +94,12 @@ export default class Test extends AuthCommand {
     }),
     'record': Flags.boolean({
       description: 'Record test results in Checkly as a test session with full logs, traces and videos.',
-      default: false,
+      default: true,
+      allowNo: true,
     }),
     'test-session-name': Flags.string({
       char: 'n',
-      description: 'A name to use when storing results in Checkly with --record.',
+      description: 'A name to use when storing results in Checkly.',
     }),
     'update-snapshots': Flags.boolean({
       char: 'u',

--- a/packages/cli/src/commands/trigger.ts
+++ b/packages/cli/src/commands/trigger.ts
@@ -83,7 +83,7 @@ export default class Trigger extends AuthCommand {
       exclusive: ['env'],
     }),
     'record': Flags.boolean({
-      description: 'Record check results in Checkly as a test session with full logs, traces and videos.',
+      description: '[default: true] Record check results in Checkly as a test session with full logs, traces and videos.',
       default: true,
       allowNo: true,
     }),

--- a/packages/cli/src/commands/trigger.ts
+++ b/packages/cli/src/commands/trigger.ts
@@ -84,11 +84,12 @@ export default class Trigger extends AuthCommand {
     }),
     'record': Flags.boolean({
       description: 'Record check results in Checkly as a test session with full logs, traces and videos.',
-      default: false,
+      default: true,
+      allowNo: true,
     }),
     'test-session-name': Flags.string({
       char: 'n',
-      description: 'A name to use when storing results in Checkly with --record.',
+      description: 'A name to use when storing results in Checkly.',
     }),
     'retries': Flags.integer({
       description: `[default: 0, max: ${MAX_RETRIES}] How many times to retry a check run.`,

--- a/packages/cli/src/help/examples.ts
+++ b/packages/cli/src/help/examples.ts
@@ -5,8 +5,8 @@ type Example = {
 
 const examples: Array<Example> = [
   {
-    description: 'Record your test session in Checkly with logs, traces and videos.',
-    command: 'npx checkly test --record',
+    description: 'Run your checks on Checkly with full logs, traces and videos.',
+    command: 'npx checkly test',
   },
   {
     description: 'Pass environment variables to your checks.',

--- a/packages/cli/src/helpers/onboarding/messages.ts
+++ b/packages/cli/src/helpers/onboarding/messages.ts
@@ -71,8 +71,8 @@ export function footer (hasPlaywright: boolean = false): string {
     `  ${chalk.bold('npx checkly login')}`,
     chalk.dim('  Log in or create a free account'),
     '',
-    `  ${chalk.bold('npx checkly test --record')}`,
-    chalk.dim('  Dry run your checks and record results'),
+    `  ${chalk.bold('npx checkly test')}`,
+    chalk.dim('  Dry run your checks'),
     '',
     `  ${chalk.bold('npx checkly deploy')}`,
     chalk.dim('  Deploy checks to Checkly'),
@@ -133,7 +133,7 @@ export function agentFooter (
     '',
     chalk.dim('  Prefer to set up manually?'),
     chalk.dim(`  ${chalk.bold('npx checkly login')}`),
-    chalk.dim(`  ${chalk.bold('npx checkly test --record')}`),
+    chalk.dim(`  ${chalk.bold('npx checkly test')}`),
     chalk.dim(`  ${chalk.bold('npx checkly deploy')}`),
   )
 
@@ -162,7 +162,7 @@ export function existingProjectFooter (
     '',
     chalk.green.bold('  You\'re all set!'),
     '',
-    `  ${chalk.bold('npx checkly test --record')}`,
+    `  ${chalk.bold('npx checkly test')}`,
     chalk.dim('  Run your checks locally'),
     '',
     `  ${chalk.bold('npx checkly deploy')}`,

--- a/packages/cli/src/messages/common-messages.ts
+++ b/packages/cli/src/messages/common-messages.ts
@@ -2,9 +2,6 @@ const commonMessages = {
   forceMode: 'Force mode. Skips the confirmation dialog.',
   configFile: 'The Checkly CLI configuration file. If not passed, uses the checkly.config.ts|js file in the current'
     + ' directory.',
-  inlineTips: {
-    useRecordFlag: 'Use `--record` to get test results in Checkly with full traces, videos and logs: `npx checkly test --record`',
-  },
 }
 
 export default commonMessages

--- a/packages/cli/src/reporters/__tests__/__snapshots__/github-md-builder.spec.ts.snap
+++ b/packages/cli/src/reporters/__tests__/__snapshots__/github-md-builder.spec.ts.snap
@@ -18,5 +18,5 @@ Ran **2** checks in **eu-west-1**.
 |:-|:-|:-|:-|:-|
 |✅ Pass|my-test.spec.ts|BROWSER|\`src/__checks__/folder/browser.check.ts\`|7s |
 |✅ Pass|Test API check|API|\`src/some-other-folder/api.check.ts\`|2s |
-> Tip: Use \`--record\` to get test results in Checkly with full traces, videos and logs: \`npx checkly test --record\`"
+"
 `;

--- a/packages/cli/src/reporters/ci.ts
+++ b/packages/cli/src/reporters/ci.ts
@@ -4,7 +4,6 @@ import AbstractListReporter from './abstract-list.js'
 import { formatCheckTitle, formatCheckResult, CheckStatus, printLn, resultToCheckStatus } from './util.js'
 import { SequenceId } from '../services/abstract-check-runner.js'
 import { TestResultsShortLinks } from '../rest/test-sessions.js'
-import commonMessages from '../messages/common-messages.js'
 
 export default class CiReporter extends AbstractListReporter {
   onBegin (checks: Array<{ check: any, sequenceId: SequenceId }>, testSessionId?: string) {
@@ -17,9 +16,6 @@ export default class CiReporter extends AbstractListReporter {
     printLn('Finished running all checks:', 2)
     this._printSummary()
     this._printTestSessionsUrl()
-    if (!this.testSessionId) {
-      this._printTip(commonMessages.inlineTips.useRecordFlag)
-    }
   }
 
   onCheckAttemptResult (sequenceId: string, checkResult: any, links?: TestResultsShortLinks): void {

--- a/packages/cli/src/reporters/github.ts
+++ b/packages/cli/src/reporters/github.ts
@@ -4,7 +4,6 @@ import * as path from 'path'
 import AbstractListReporter, { checkFilesMap } from './abstract-list.js'
 import { SequenceId } from '../services/abstract-check-runner.js'
 import { CheckStatus, formatDuration, getTestSessionUrl, printLn, resultToCheckStatus } from './util.js'
-import commonMessages from '../messages/common-messages.js'
 
 const outputFile = './checkly-github-report.md'
 
@@ -83,15 +82,11 @@ export class GithubMdBuilder {
       }
     }
 
-    let markdown = this.header + '\n'
+    const markdown = this.header + '\n'
       + this.subHeader.join('\n') + '\n'
       + this.tableSeparator + this.tableHeaders.join('|') + this.tableSeparator + '\n'
       + this.tableSeparatorFiller.repeat(this.tableHeaders.length) + this.tableSeparator + '\n'
       + this.tableRows.sort((a, b) => a < b ? 1 : -1).join('\n') + '\n'
-
-    if (!this.testSessionId) {
-      markdown = markdown + `> Tip: ${commonMessages.inlineTips.useRecordFlag}`
-    }
 
     return markdown
   }

--- a/packages/cli/src/reporters/list.ts
+++ b/packages/cli/src/reporters/list.ts
@@ -5,7 +5,6 @@ import AbstractListReporter from './abstract-list.js'
 import { SequenceId } from '../services/abstract-check-runner.js'
 import { formatCheckTitle, formatCheckResult, CheckStatus, printLn, resultToCheckStatus } from './util.js'
 import { TestResultsShortLinks } from '../rest/test-sessions.js'
-import commonMessages from '../messages/common-messages.js'
 
 export default class ListReporter extends AbstractListReporter {
   onBegin (checks: Array<{ check: any, sequenceId: SequenceId }>, testSessionId?: string) {
@@ -30,9 +29,6 @@ export default class ListReporter extends AbstractListReporter {
     this._clearSummary()
     this._printSummary()
     this._printTestSessionsUrl()
-    if (!this.testSessionId) {
-      this._printTip(commonMessages.inlineTips.useRecordFlag)
-    }
   }
 
   onCheckAttemptResult (sequenceId: string, checkResult: any, links?: TestResultsShortLinks): void {

--- a/packages/create-cli/e2e/__tests__/bootstrap.spec.ts
+++ b/packages/create-cli/e2e/__tests__/bootstrap.spec.ts
@@ -54,7 +54,7 @@ function expectCompleteCreation ({
 
          > Enter your project directory using cd ${projectFolder}
          > Run npx checkly login to login to your Checkly account or create a free new account
-         > Run npx checkly test --record to dry run your checks
+         > Run npx checkly test to dry run your checks
          > Run npx checkly deploy to deploy your checks to the Checkly cloud
 
          Questions?

--- a/packages/create-cli/src/utils/messages.ts
+++ b/packages/create-cli/src/utils/messages.ts
@@ -53,7 +53,7 @@ export async function footer (targetDir?: string): Promise<void> {
   )
   await sleep(200)
   console.log(
-    `${prefix}> Run ${chalk.cyan('npx checkly test --record')} to dry run your checks`,
+    `${prefix}> Run ${chalk.cyan('npx checkly test')} to dry run your checks`,
   )
   await sleep(200)
   console.log(


### PR DESCRIPTION
## Summary

- **`test` and `trigger` commands**: `--record` now defaults to `true` (with `--no-record` to opt out), matching the existing `pw-test` behavior
- Removed the now-dead "Use `--record`..." tip from list, ci, and github reporters
- Updated all documentation, onboarding messages, and example projects to reflect the new default

## Test plan

- [x] Unit tests pass (914 passing)
- [x] Lint passes
- [x] Build succeeds
- [x] `npx checkly test --help` shows `--[no-]record` defaulting to true
- [x] `npx checkly trigger --help` shows the same
- [x] `npx checkly test --no-record` disables recording

🤖 Generated with [Claude Code](https://claude.com/claude-code)