### PR TITLE
docs(ai-context): fix AssertionBuilder methods, clarify PlaywrightCheck path/pwProjects, document Dashboard customCSS

### DIFF
--- a/packages/cli/src/ai-context/references/configure-api-checks.md
+++ b/packages/cli/src/ai-context/references/configure-api-checks.md
@@ -16,13 +16,18 @@
 
 `AssertionBuilder` provides methods to assert on API responses. Available methods:
 
-- `AssertionBuilder.statusCode()` — Assert on HTTP status code. Example: `.equals(200)`, `.isGreaterThan(199)`
-- `AssertionBuilder.jsonBody(path)` — Assert on JSON body using JSONPath. Example: `AssertionBuilder.jsonBody('$.id').isNotNull()`
-- `AssertionBuilder.textBody()` — Assert on raw text body. Example: `.contains('OK')`
-- `AssertionBuilder.headers(name)` — Assert on response headers. Example: `AssertionBuilder.headers('content-type').contains('application/json')`
-- `AssertionBuilder.responseTime()` — Assert on response time in ms. Example: `.isLessThan(2000)`
+- `AssertionBuilder.statusCode()` — Numeric. Assert on HTTP status code. Example: `.equals(200)`, `.greaterThan(199)`
+- `AssertionBuilder.jsonBody(path)` — General. Assert on JSON body using JSONPath. Example: `AssertionBuilder.jsonBody('$.id').isNotNull()`
+- `AssertionBuilder.textBody()` — General. Assert on raw text body. Example: `.contains('OK')`
+- `AssertionBuilder.headers(name)` — General. Assert on response headers. Example: `AssertionBuilder.headers('content-type').contains('application/json')`
+- `AssertionBuilder.responseTime()` — Numeric. Assert on response time in ms. Example: `.lessThan(2000)`
 
-Each method returns a chainable builder with comparison methods: `.equals()`, `.notEquals()`, `.contains()`, `.notContains()`, `.isGreaterThan()`, `.isLessThan()`, `.isEmpty()`, `.isNotEmpty()`, `.isNull()`, `.isNotNull()`
+Two builder types are returned, with different comparators. Use only methods from the matching set — calling a missing method (e.g. `.isNotEmpty()`, `.isGreaterThan()`) compiles but fails at runtime:
+
+- **Numeric** (`statusCode`, `responseTime`): `.equals()`, `.notEquals()`, `.greaterThan()`, `.lessThan()`
+- **General** (`jsonBody`, `textBody`, `headers`): `.equals()`, `.notEquals()`, `.contains()`, `.notContains()`, `.greaterThan()`, `.lessThan()`, `.isEmpty()`, `.notEmpty()`, `.isNull()`, `.isNotNull()`, `.hasKey()`, `.notHasKey()`, `.hasValue()`, `.notHasValue()`
+
+Note the names: `notEmpty` (not `isNotEmpty`), `greaterThan` / `lessThan` (not `isGreaterThan` / `isLessThan`).
 
 ## Authentication Setup Scripts for API Checks
 

--- a/packages/cli/src/ai-context/references/configure-playwright-checks.md
+++ b/packages/cli/src/ai-context/references/configure-playwright-checks.md
@@ -1,7 +1,8 @@
 # Playwright Check Suites
 
 - Import the `PlaywrightCheck` construct from `checkly/constructs`.
-- use `pwProjects` if you're tasked to reuse a Playwright project.
+- `playwrightConfigPath` is resolved **relative to the `.check.ts` file that declares the construct**, not the project root. If your check lives in `monitoring/suites.check.ts` and your config in `playwright.config.ts` at the repo root, use `'../playwright.config.ts'`.
+- use `pwProjects` if you're tasked to reuse a Playwright project. Values must match the `name` field of each project in your `playwright.config.ts` (e.g. `'Cart & Checkout'`), **not** the directory slug. Mismatched names deploy silently and resolve to zero tests.
 - use `pwTags` if you're tasked to reuse a Playwright tag.
 
 <!-- EXAMPLE: PLAYWRIGHT_CHECK -->

--- a/packages/cli/src/ai-context/references/configure-supporting-constructs.md
+++ b/packages/cli/src/ai-context/references/configure-supporting-constructs.md
@@ -19,6 +19,7 @@
 
 - Import the `Dashboard` construct from `checkly/constructs`.
 - Dashboards are used to display the results of your checks on screens external to Checkly.
+- To apply custom styling, set `customCSS` to an entrypoint object so Checkly bundles and hosts the file: `customCSS: { entrypoint: './dashboard.css' }`. Passing a raw string read with `fs.readFileSync` is rejected at deploy time.
 
 <!-- EXAMPLE: DASHBOARD -->
 


### PR DESCRIPTION
## Summary

Four corrections to `packages/cli/src/ai-context/references/*` captured during a live agent-driven setup run against the Astroshop blueprint ([checkly-solutions/checkly-astroshop-ai](https://github.com/checkly-solutions/checkly-astroshop-ai)). Each item below caused the first agent-generated deploy to fail or silently no-op; all four are construct-API truths, not pedagogy — they belong in the skill, not just the public docs, because agents read this file as ground truth when generating `.check.ts` code.

## Changes

### `configure-api-checks.md` — fix `AssertionBuilder` method names + split builder types
The chainable-method list claimed `.isNotEmpty()`, `.isGreaterThan()`, `.isLessThan()` exist. They don't — the real names on `GeneralAssertionBuilder` / `NumericAssertionBuilder` are `notEmpty`, `greaterThan`, `lessThan`. Agents that take the doc at face value generate code that type-checks but fails at runtime.

Additional improvements while editing this section:
- Split Numeric (`statusCode`, `responseTime`) and General (`jsonBody`, `textBody`, `headers`) builders, since they expose different comparators — calling `.contains()` on `statusCode()` doesn't work either.
- Surface the previously-undocumented General-only methods: `hasKey`, `notHasKey`, `hasValue`, `notHasValue`.

### `configure-playwright-checks.md` — two PlaywrightCheck gotchas
- `playwrightConfigPath` resolves **relative to the `.check.ts` file that declares the construct**, not the project root. A check in `monitoring/suites.check.ts` needs `'../playwright.config.ts'`; the current example uses `'./playwright.config.ts'` without saying what it's relative to.
- `pwProjects` matches the Playwright project `name` field (e.g. `'Cart & Checkout'`), **not** the directory slug. Mismatches deploy silently with zero tests resolved — a particularly painful failure mode because nothing in the CLI output flags it.

### `configure-supporting-constructs.md` — document `Dashboard.customCSS`
The Dashboard section bullet-list and example don't mention `customCSS` at all. The natural agent-generated approach (read the file via `fs.readFileSync` and pass the string) compiles but is rejected at deploy time because the construct expects `Content | Entrypoint`. Added a one-liner pointing at the entrypoint shape.

## Test plan

- [ ] Run `npx checkly skills configure api-checks` / `playwright-checks` / `supporting-constructs` and confirm the corrected text renders cleanly.
- [ ] Spot-check the AssertionBuilder method list against `packages/cli/src/constructs/internal/assertion.ts` (verified during PR prep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)