### PR TITLE
docs: add CLAUDE.md and custom commands for adding constructs

### DIFF
--- a/.claude/commands/new-alert-channel.md
+++ b/.claude/commands/new-alert-channel.md
@@ -1,0 +1,65 @@
+# Add a New Alert Channel Construct
+
+**Input:** $ARGUMENTS
+
+Interpret the arguments as a description of the new alert channel: its name, what service it integrates with, and its configuration properties. If arguments are missing or unclear, ask before proceeding.
+
+There are two alert channel families:
+
+- **Webhook-based** (e.g., Telegram, Incident.io, MS Teams) — extends `WebhookAlertChannel`, routes through `webhook-alert-channel-codegen.ts`. Use **TelegramAlertChannel** as reference.
+- **Standalone** (e.g., Slack, Opsgenie, PagerDuty) — extends `AlertChannel` directly, routes through `alert-channel-codegen.ts`. Use **SlackAlertChannel** as reference.
+
+Determine which family applies based on the integration. If unsure, ask.
+
+All paths below are relative to `packages/cli/`.
+
+## Phase 1: Core Construct File (new file)
+
+- [ ] `src/constructs/{name}-alert-channel.ts`
+  - **Webhook-based**: Class extending `WebhookAlertChannel`. Define `{Name}AlertChannelProps` extending `AlertChannelProps`. In the constructor, call `super(logicalId, props)` (add `// @ts-ignore` above the call — the props type mismatch with `WebhookAlertChannelProps` is expected), then set `this.webhookType = 'WEBHOOK_{UPPER_NAME}'`, `this.method`, `this.url`, and `this.template`. Implement `describe()` and `synthesize()` (synthesize returns `type: 'WEBHOOK'` with a `config` object containing `name`, `webhookType`, `url`, `template`, `method`, `headers`, `queryParameters`, `webhookSecret`).
+  - **Standalone**: Class extending `AlertChannel`. Define `{Name}AlertChannelProps` extending `AlertChannelProps`. In the constructor, call `super(logicalId, props)` and `Session.registerConstruct(this)`. Implement `describe()` and `synthesize()` (synthesize returns a unique `type` string and a `config` object with channel-specific properties).
+
+## Phase 2: Code Generation File (new file)
+
+- [ ] `src/constructs/{name}-alert-channel-codegen.ts`
+  - Class `{Name}AlertChannelCodegen` extending `Codegen<{Name}AlertChannelResource>`.
+  - Define `{Name}AlertChannelResource` interface extending the appropriate parent (`WebhookAlertChannelResource` or `AlertChannelResource`).
+  - Implement `describe()`, `prepare()`, and `gencode()`. For **webhook-based** channels, also implement `validateSafety()` to reject unexpected values for method, headers, queryParameters, and webhookSecret (standalone channels do not need this).
+  - `prepare()`: resolve file path via `context.filePath()`, register with `context.registerAlertChannel()`.
+  - `gencode()`: look up alert channel, add imports, emit `new {Name}AlertChannel(...)` expression using `file.section(decl(...))` pattern. Call `buildAlertChannelProps()` from `./alert-channel-codegen.js`.
+
+## Phase 3: Registry (modify existing files)
+
+- [ ] `src/constructs/index.ts` — Add export: `export * from './{name}-alert-channel.js'`
+
+- [ ] **Webhook-based** — `src/constructs/webhook-alert-channel-codegen.ts`:
+  1. Add `'WEBHOOK_{UPPER_NAME}'` to `WebhookType` union
+  2. Import `{Name}AlertChannelCodegen`
+  3. Add property and initialize in constructor
+  4. Add entry to `codegensByWebhookType` map
+
+- [ ] **Standalone** — `src/constructs/alert-channel-codegen.ts`:
+  1. Add `'{UPPER_NAME}'` to `AlertChannelType` union
+  2. Import `{Name}AlertChannelCodegen`
+  3. Add property and initialize in constructor
+  4. Add entry to `codegensByType` map
+
+## Phase 4: Tests (new file)
+
+- [ ] `src/constructs/__tests__/{name}-alert-channel.spec.ts` — Unit tests covering: construct instantiation, `synthesize()` output structure, property mapping, and `describe()`. Follow existing alert channel tests as template.
+
+## Phase 5: Build and Verify
+
+- [ ] `pnpm --filter checkly run prepare` — Rebuild.
+- [ ] `pnpm --filter checkly test` — Run unit tests.
+- [ ] `pnpm lint:fix` — Fix formatting (run from repo root).
+
+## Naming Conventions
+
+| Concept | Pattern | Example (Telegram) |
+|---------|---------|-------------------|
+| File name | `{name}-alert-channel.ts` | `telegram-alert-channel.ts` |
+| Class name | `{Name}AlertChannel` | `TelegramAlertChannel` |
+| Props interface | `{Name}AlertChannelProps` | `TelegramAlertChannelProps` |
+| Webhook type | `WEBHOOK_{UPPER_NAME}` | `WEBHOOK_TELEGRAM` |
+| Codegen class | `{Name}AlertChannelCodegen` | `TelegramAlertChannelCodegen` |

--- a/.claude/commands/new-monitor.md
+++ b/.claude/commands/new-monitor.md
@@ -1,0 +1,88 @@
+# Add a New Monitor Construct
+
+**Input:** $ARGUMENTS
+
+Interpret the arguments as a description of the new monitor: its name, what it monitors, its custom properties, and its assertion sources. If arguments are missing or unclear, ask before proceeding.
+
+Use an existing monitor as your reference implementation. For monitors with assertions and requests (the common case), use **IcmpMonitor** or **DnsMonitor**. For simpler constructs without assertions, use **HeartbeatMonitor**.
+
+All paths below are relative to `packages/cli/` unless noted otherwise.
+
+## Phase 1: Core Construct Files (new files)
+
+Create these three files (skip assertion + request if the construct has no assertions):
+
+- [ ] `src/constructs/{name}-monitor.ts` — Class extending `Monitor` (from `./monitor.js`). Define `{Name}MonitorProps` extending `MonitorProps`. Implement `constructor`, `describe()`, `validate()`, `synthesize()`. The constructor must call `Session.registerConstruct(this)`, `this.addSubscriptions()`, and `this.addPrivateLocationCheckAssignments()`. `synthesize()` must include `checkType: '{UPPER_NAME}'` and spread `super.synthesize()`.
+
+- [ ] `src/constructs/{name}-assertion.ts` — Define `{Name}AssertionSource` union type, `{Name}Assertion` type alias using `CoreAssertion`, and `{Name}AssertionBuilder` class with static methods per assertion source. Use `NumericAssertionBuilder` for numeric sources (e.g., latency) and `GeneralAssertionBuilder` for text/JSON sources. Import builders from `./internal/assertion.js`.
+
+- [ ] `src/constructs/{name}-request.ts` — Define `{Name}Request` interface with request configuration properties. Include an `assertions?: Array<{Name}Assertion>` field if assertions are supported.
+
+## Phase 2: Code Generation Files (new files)
+
+- [ ] `src/constructs/{name}-monitor-codegen.ts` — Class `{Name}MonitorCodegen` extending `Codegen<{Name}MonitorResource>`. Define `{Name}MonitorResource` extending `MonitorResource` with `checkType: '{UPPER_NAME}'`. Implement `describe()` and `gencode()`. Follow the exact pattern in `IcmpMonitorCodegen.gencode()`: resolve output path via `context.filePath()`, get file handle via `this.program.generatedConstructFile()`, add imports with `file.namedImport()`, emit the `new {Name}Monitor(...)` expression via `file.section()`, and call `buildMonitorProps()` from `./monitor-codegen.js`.
+
+- [ ] `src/constructs/{name}-assertion-codegen.ts` — Export `valueFor{Name}Assertion()` function. Switch on `assertion.source`, delegate to `valueForNumericAssertion` or `valueForGeneralAssertion` from `./internal/assertion-codegen.js`.
+
+- [ ] `src/constructs/{name}-request-codegen.ts` — Export `valueFor{Name}Request()` function. Build an object value with request fields, calling `valueFor{Name}Assertion()` for each assertion.
+
+## Phase 3: Central Registry (modify existing files)
+
+- [ ] `src/constructs/index.ts` — Add three export lines:
+  ```
+  export * from './{name}-monitor.js'
+  export * from './{name}-assertion.js'
+  export * from './{name}-request.js'
+  ```
+
+- [ ] `src/constructs/check-codegen.ts` — (1) Import `{Name}MonitorCodegen` and `{Name}MonitorResource`. (2) Add property `{name}MonitorCodegen: {Name}MonitorCodegen` to `CheckCodegen`. (3) Initialize in constructor. (4) Add `case '{UPPER_NAME}':` in both the `describe()` and `gencode()` switch statements.
+
+- [ ] `src/constants.ts` — Add `{UPPER_NAME}: '{UPPER_NAME}'` to the `CheckTypes` object.
+
+## Phase 4: Reporter and Formatter Integration (modify existing files)
+
+- [ ] `src/reporters/util.ts` — Add `if (checkResult.checkType === '{UPPER_NAME}')` block in `formatCheckResult()`. Define `format{Name}Request()` and `format{Name}Response()` functions, and add subsections for request errors, connection errors, and assertions as appropriate. Follow the ICMP or DNS block as a template.
+
+- [ ] `src/formatters/batch-stats.ts` — Add detection logic for the new check type in `buildColumns()` and add metric-specific columns if the construct has unique metrics (not standard response time).
+
+- [ ] `src/rest/analytics.ts` — Add entry to `checkTypeToPath` map and `defaultMetrics` map.
+
+## Phase 5: AI Context (new file + modify existing)
+
+- [ ] `src/ai-context/references/configure-{name}-monitors.md` — New markdown reference. Follow the pattern of `configure-icmp-monitors.md`.
+
+- [ ] `src/ai-context/context.ts` — Add entry to `REFERENCES` array and add an `{UPPER_NAME}_MONITOR` entry to `EXAMPLE_CONFIGS`.
+
+## Phase 6: Tests (new files + modify existing)
+
+- [ ] `src/constructs/__tests__/{name}-monitor.spec.ts` — Unit tests covering: default synthesis, group assignment, request properties, validation, assertion builder methods. Follow `icmp-monitor.spec.ts` as template.
+
+- [ ] `e2e/__tests__/fixtures/deploy-project/{name}.check.ts` — Minimal construct instantiation with `activated: false`.
+
+- [ ] `e2e/__tests__/deploy.spec.ts` — Add the new construct's logical ID to expected `Create:` output in deploy test assertions.
+
+## Phase 7: Examples (new files, paths relative to repo root)
+
+- [ ] `examples/advanced-project/src/__checks__/uptime/{name}.check.ts` — TypeScript example with group, assertions, and doc link comments.
+
+- [ ] `examples/advanced-project-js/src/__checks__/uptime/{name}.check.js` — JavaScript equivalent.
+
+## Phase 8: Build and Verify
+
+- [ ] `pnpm --filter checkly run prepare` — Rebuild (compiles TS + regenerates AI context).
+- [ ] `pnpm --filter checkly test` — Run unit tests.
+- [ ] `pnpm run sync:skills` — Sync AI context to published skills (from repo root).
+- [ ] `pnpm lint:fix` — Fix formatting (run from repo root).
+
+## Naming Conventions
+
+| Concept | Pattern | Example (ICMP) |
+|---------|---------|----------------|
+| File names | `{name}-monitor.ts` | `icmp-monitor.ts` |
+| Class name | `{Name}Monitor` | `IcmpMonitor` |
+| Props interface | `{Name}MonitorProps` | `IcmpMonitorProps` |
+| Check type constant | `{UPPER_NAME}` | `ICMP` |
+| Assertion builder | `{Name}AssertionBuilder` | `IcmpAssertionBuilder` |
+| Request interface | `{Name}Request` | `IcmpRequest` |
+| Codegen class | `{Name}MonitorCodegen` | `IcmpMonitorCodegen` |
+| AI context reference | `configure-{name}-monitors.md` | `configure-icmp-monitors.md` |

--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,3 @@ local
 **/checkly-github-report.md
 **/checkly-summary.md
 **/e2e/__tests__/fixtures/empty-project/e2e-test-project-*
-CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,8 @@ The core abstraction is the `Construct` base class (`src/constructs/construct.ts
 
 `Session` is a static class on `Project` that carries global context during check file loading: the current project, available runtimes, check defaults, file loaders, and the path of the currently-loading check file.
 
+To add a new construct, use `/new-monitor` or `/new-alert-channel` for step-by-step checklists.
+
 ### Check discovery and loading
 
 `project-parser.ts` orchestrates discovery: it resolves glob patterns from `checkly.config.ts` (`checkMatch`, `browserCheckMatch`, `multiStepCheckMatch`), dynamically imports each matching file, and the constructs self-register with the `Session`/`Project` during import. File loading uses a pluggable `FileLoader` system (`src/loader/`): `NativeFileLoader` (Node's native TS support), `JitiFileLoader` (jiti), or `MixedFileLoader` (tries both in sequence).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,114 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build and Development
+
+This is a **pnpm monorepo** with two packages: `packages/cli` (the main `checkly` CLI) and `packages/create-cli` (the `create-checkly` scaffolding tool). Both are ESM-only TypeScript.
+
+```bash
+# Install dependencies
+pnpm install
+
+# Build everything (clean + compile + AI context)
+pnpm --filter checkly run prepare
+pnpm --filter create-checkly run prepare
+
+# Watch mode for CLI development
+pnpm --filter checkly run watch
+```
+
+## Testing
+
+Unit tests use **Vitest**. The CLI package requires `pnpm pack` before running tests (the test script handles this) because the test sandbox installs the CLI from a tarball.
+
+```bash
+# Run all unit tests (both packages)
+pnpm test
+
+# Run a single test file (pnpm pack must have run first; `pnpm --filter checkly test` does this)
+pnpm --filter checkly exec vitest --run src/services/check-parser/__tests__/parser.spec.ts
+
+# Run tests matching a pattern
+pnpm --filter checkly exec vitest --run -t "pattern"
+
+# E2E tests (require CHECKLY_ACCOUNT_ID and CHECKLY_API_KEY)
+pnpm --filter checkly run test:e2e
+
+# E2E against local backend (localhost:3000)
+pnpm --filter checkly run test:e2e:local
+```
+
+Unit tests live alongside source in `src/**/*.spec.ts`. E2E tests are in `e2e/__tests__/**/*.spec.ts` with a 15-second timeout.
+
+**Test sandbox**: Tests that exercise CLI behavior use `FixtureSandbox` (from `src/testing/fixture-sandbox.ts`), which creates isolated temp directories with `checkly` installed from the packed tarball. Templates (`bare`, `playwright`, etc.) are pre-built in `global-setup.ts` and reused across tests.
+
+## Linting
+
+```bash
+pnpm lint        # check
+pnpm lint:fix    # auto-fix
+```
+
+Key ESLint rules enforced by `@stylistic` recommended + custom config:
+- **No semicolons** (stylistic recommended default)
+- **Space before function parens**: `function ()`, `method ()`, `async ()` — not `function()`
+- **Arrow parens as-needed**: `x => x + 1` not `(x) => x + 1`
+- No enums (use union types), no `console` outside commands/reporters
+- Max 120 char lines, `require-await`, 1TBS brace style, always-multiline trailing commas, `object-shorthand: always`
+- Operator line-breaks go before the operator (except `=`, `+=`)
+
+## Commits
+
+Conventional commits enforced by commitlint (max 100 char header). Pre-commit hook runs lint-staged on `*.{ts,js,mjs}` files.
+
+## Architecture
+
+### Constructs (the resource model)
+
+The core abstraction is the `Construct` base class (`src/constructs/construct.ts`). Every Checkly resource (check, alert channel, dashboard, etc.) extends `Construct` and implements:
+- `validate(diagnostics)` — reports configuration errors
+- `bundle(bundler)` — prepares for deployment (e.g., packaging scripts into tarballs)
+- `synthesize()` — produces the API-ready payload
+
+`Project` (`src/constructs/project.ts`) is the root construct. It holds a typed map (`ProjectData`) of all resources keyed by type and logical ID.
+
+`Session` is a static class on `Project` that carries global context during check file loading: the current project, available runtimes, check defaults, file loaders, and the path of the currently-loading check file.
+
+### Check discovery and loading
+
+`project-parser.ts` orchestrates discovery: it resolves glob patterns from `checkly.config.ts` (`checkMatch`, `browserCheckMatch`, `multiStepCheckMatch`), dynamically imports each matching file, and the constructs self-register with the `Session`/`Project` during import. File loading uses a pluggable `FileLoader` system (`src/loader/`): `NativeFileLoader` (Node's native TS support), `JitiFileLoader` (jiti), or `MixedFileLoader` (tries both in sequence).
+
+### Check bundling and parsing
+
+`src/services/check-parser/` handles dependency analysis and packaging:
+- `parser.ts` — uses Acorn/TypeScript ESTree to extract imports and resolve npm dependencies
+- `bundler.ts` — creates tar.gz archives of check code + dependencies, uploads to Checkly storage
+- `playwright-config-expander.ts` — parses Playwright configs to extract test projects and patterns
+
+### Command framework
+
+Built on **oclif**. Commands live in `src/commands/`. `BaseCommand` provides engine-check and version headers. `AuthCommand` extends it for authenticated operations. Commands declare static metadata: `coreCommand`, `readOnly`, `destructive`, `idempotent`.
+
+### Deploy flow
+
+`deploy.ts` → load config → parse project (discover + instantiate) → bundle all constructs → validate → diff against remote state → create/update/delete resources via REST API.
+
+### Test/trigger flow
+
+`test.ts` → parse + bundle → `TestRunner.scheduleChecks()` → API creates a test session → results stream back over MQTT → reporters format output (`list`, `dot`, `ci`, `github`, `json`).
+
+### REST client
+
+Axios-based, in `src/rest/`. One API class per resource type. Request interceptor adds auth headers and CLI metadata. Base URL determined by `CHECKLY_API_URL` or `CHECKLY_ENV` (production/staging/local).
+
+### AI context pipeline
+
+Source in `src/ai-context/`, built during `prepare`. Generates examples from fixtures, produces public skills in `dist/ai-context/public-skills/`. The published copy at `skills/checkly/SKILL.md` must stay in sync — CI checks this. After modifying AI context sources, run the full prepare step, then `pnpm run sync:skills` from the repo root.
+
+## Key Environment Variables
+
+- `CHECKLY_ACCOUNT_ID`, `CHECKLY_API_KEY` — authentication
+- `CHECKLY_ENV` — target environment (`production`, `staging`, `development`, `local`)
+- `CHECKLY_API_URL` — override API base URL (used when `CHECKLY_ENV=local`)
+- `CHECKLY_CLI_VERSION` — override reported CLI version (useful for testing `create-checkly`)


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` with build/test commands, linting rules, and architecture overview for Claude Code onboarding
- Add `/new-monitor` custom command — step-by-step checklist for adding a new monitor/check construct (~18 files)
- Add `/new-alert-channel` custom command — checklist for adding a new alert channel construct (webhook-based or standalone)
- Remove `CLAUDE.md` from `.gitignore`

## Test plan

- [ ] Verify `/new-monitor` loads correctly in Claude Code
- [ ] Verify `/new-alert-channel` loads correctly in Claude Code
- [ ] Confirm CLAUDE.md renders properly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)