### PR TITLE
fix(cli): remove extra blank line before 'Running N checks' output

### DIFF
--- a/packages/cli/src/reporters/ci.ts
+++ b/packages/cli/src/reporters/ci.ts
@@ -8,7 +8,7 @@ import { TestResultsShortLinks } from '../rest/test-sessions.js'
 export default class CiReporter extends AbstractListReporter {
   onBegin (checks: Array<{ check: any, sequenceId: SequenceId }>, testSessionId?: string) {
     super.onBegin(checks, testSessionId)
-    printLn(`Running ${this.numChecks} checks in ${this._runLocationString()}:`, 2, 1)
+    printLn(`Running ${this.numChecks} checks in ${this._runLocationString()}:`, 2)
     this._printSummary({ skipCheckCount: true })
   }
 

--- a/packages/cli/src/reporters/dot.ts
+++ b/packages/cli/src/reporters/dot.ts
@@ -6,7 +6,7 @@ import { print, printLn } from './util.js'
 export default class DotReporter extends AbstractListReporter {
   onBegin (checks: Array<{ check: any, sequenceId: SequenceId }>, testSessionId?: string) {
     super.onBegin(checks, testSessionId)
-    printLn(`Running ${this.numChecks} checks in ${this._runLocationString()}.`, 2, 1)
+    printLn(`Running ${this.numChecks} checks in ${this._runLocationString()}.`, 2)
   }
 
   onEnd () {

--- a/packages/cli/src/reporters/github.ts
+++ b/packages/cli/src/reporters/github.ts
@@ -95,7 +95,7 @@ export class GithubMdBuilder {
 export default class GithubReporter extends AbstractListReporter {
   onBegin (checks: Array<{ check: any, sequenceId: SequenceId }>, testSessionId?: string) {
     super.onBegin(checks, testSessionId)
-    printLn(`Running ${this.numChecks} checks in ${this._runLocationString()}.`, 2, 1)
+    printLn(`Running ${this.numChecks} checks in ${this._runLocationString()}.`, 2)
   }
 
   onEnd () {

--- a/packages/cli/src/reporters/json.ts
+++ b/packages/cli/src/reporters/json.ts
@@ -72,7 +72,7 @@ export class JsonBuilder {
 export default class JsonReporter extends AbstractListReporter {
   onBegin (checks: Array<{ check: any, checkRunId: CheckRunId, sequenceId: SequenceId }>, testSessionId?: string) {
     super.onBegin(checks, testSessionId)
-    printLn(`Running ${this.numChecks} checks in ${this._runLocationString()}.`, 2, 1)
+    printLn(`Running ${this.numChecks} checks in ${this._runLocationString()}.`, 2)
   }
 
   onEnd () {

--- a/packages/cli/src/reporters/list.ts
+++ b/packages/cli/src/reporters/list.ts
@@ -9,7 +9,7 @@ import { TestResultsShortLinks } from '../rest/test-sessions.js'
 export default class ListReporter extends AbstractListReporter {
   onBegin (checks: Array<{ check: any, sequenceId: SequenceId }>, testSessionId?: string) {
     super.onBegin(checks, testSessionId)
-    printLn(`Running ${this.numChecks} checks in ${this._runLocationString()}.`, 2, 1)
+    printLn(`Running ${this.numChecks} checks in ${this._runLocationString()}.`, 2)
     this._printSummary()
   }
 


### PR DESCRIPTION
## Summary

- Remove redundant `beforeLnCount=1` from all reporter `onBegin` methods that was producing a double blank line between the last progress step ("Uploading Playwright tests... ✅") and the "Running N checks in region." line
- `actionSuccess()` already emits a trailing blank line after each progress step, so the reporters' leading blank line was duplicative

Affects `test`, `pw-test`, and `trigger` commands across all reporter types (list, dot, ci, github, json).

## Test plan

- [x] Unit tests pass (957 passed)
- [x] Run `checkly test` and verify one blank line between progress steps and "Running..." output

🤖 Generated with [Claude Code](https://claude.com/claude-code)