### PR TITLE
fix(ci): use working-directory instead of --filter for version command

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -37,7 +37,8 @@ jobs:
       - run: rm -f packages/cli/README.md && cp README.md packages/cli
       - run: echo "PR_VERSION=0.0.0-pr.${{github.event.pull_request.number}}.$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter checkly version ${{ env.PR_VERSION }} --no-git-tag-version
+      - run: pnpm version ${{ env.PR_VERSION }} --no-git-tag-version
+        working-directory: packages/cli
       # Publish to npm with the additional tag if CANARY_TAG is set
       - run: |
           pnpm --filter checkly publish --tag experimental --no-git-checks

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -44,7 +44,7 @@ jobs:
           pnpm --filter checkly publish --tag experimental --no-git-checks
           if [[ -n "$CANARY_TAG" ]]; then
             echo "Publishing with additional tag: $CANARY_TAG"
-            npm dist-tag add checkly@$PR_VERSION $CANARY_TAG
+            pnpm dist-tag add checkly@$PR_VERSION $CANARY_TAG
           fi
         env:
           CANARY_TAG: ${{ env.CANARY_TAG }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,12 +50,14 @@ jobs:
         run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: Set version and publish prerelease for 'cli' package
         run: |
-          pnpm --filter checkly version ${{ github.event.release.tag_name }}-prerelease-${{ env.SHORT_SHA }} --no-git-tag-version
-          pnpm --filter checkly publish --provenance --tag prerelease --no-git-checks
+          pnpm version ${{ github.event.release.tag_name }}-prerelease-${{ env.SHORT_SHA }} --no-git-tag-version
+          pnpm publish --provenance --tag prerelease --no-git-checks
+        working-directory: packages/cli
       - name: Set version and publish prerelease for 'create-cli' package
         run: |
-          pnpm --filter create-checkly version ${{ github.event.release.tag_name }}-prerelease-${{ env.SHORT_SHA }} --no-git-tag-version
-          pnpm --filter create-checkly publish --provenance --tag prerelease --no-git-checks
+          pnpm version ${{ github.event.release.tag_name }}-prerelease-${{ env.SHORT_SHA }} --no-git-tag-version
+          pnpm publish --provenance --tag prerelease --no-git-checks
+        working-directory: packages/create-cli
       - name: Save LLM rules as an artifact
         uses: actions/upload-artifact@v4
         with:
@@ -112,12 +114,14 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Set version and publish 'cli' package
         run: |
-          pnpm --filter checkly version ${{ github.event.release.tag_name }} --no-git-tag-version
-          pnpm --filter checkly publish --provenance --no-git-checks
+          pnpm version ${{ github.event.release.tag_name }} --no-git-tag-version
+          pnpm publish --provenance --no-git-checks
+        working-directory: packages/cli
       - name: Set version and publish 'create-cli' package
         run: |
-          pnpm --filter create-checkly version ${{ github.event.release.tag_name }} --no-git-tag-version
-          pnpm --filter create-checkly publish --provenance --no-git-checks
+          pnpm version ${{ github.event.release.tag_name }} --no-git-tag-version
+          pnpm publish --provenance --no-git-checks
+        working-directory: packages/create-cli
       - name: Save LLM rules as an artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary

- `pnpm --filter <pkg> version` treats `version` as a workspace script name, not the built-in `pnpm version` command, causing `ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT`
- Use `working-directory` to run `pnpm version` and `pnpm publish` directly from the package directory
- Fixes `release.yml` (4 occurrences) and `release-canary.yml` (1 occurrence)

## Test plan

- [ ] Trigger a canary build by adding the `build` label to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)