### PR TITLE
fix(ci): use pnpm pack + npm publish for OIDC trusted publishing

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -16,10 +16,9 @@ jobs:
       - uses: pnpm/action-setup@v5
         with:
           version: 10
-      # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           cache: "pnpm"
       # Extract the dynamic value from the canary label if present
@@ -37,15 +36,16 @@ jobs:
       - run: rm -f packages/cli/README.md && cp README.md packages/cli
       - run: echo "PR_VERSION=0.0.0-pr.${{github.event.pull_request.number}}.$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - run: pnpm install --frozen-lockfile
-      - run: pnpm version ${{ env.PR_VERSION }} --no-git-tag-version
-        working-directory: packages/cli
-      # Publish to npm with the additional tag if CANARY_TAG is set
-      - run: |
-          pnpm --filter checkly publish --tag experimental --no-git-checks
+      - name: Set version, pack, and publish
+        run: |
+          pnpm version ${{ env.PR_VERSION }} --no-git-tag-version
+          pnpm pack
+          npm publish checkly-*.tgz --tag experimental
           if [[ -n "$CANARY_TAG" ]]; then
             echo "Publishing with additional tag: $CANARY_TAG"
-            pnpm dist-tag add checkly@$PR_VERSION $CANARY_TAG
+            npm dist-tag add checkly@$PR_VERSION $CANARY_TAG
           fi
+        working-directory: packages/cli
         env:
           CANARY_TAG: ${{ env.CANARY_TAG }}
           PR_VERSION: ${{ env.PR_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,11 +37,9 @@ jobs:
       - uses: pnpm/action-setup@v5
         with:
           version: 10
-      # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: '24.x'
           cache: "pnpm"
       # Ensure that the README is published with the package
       - run: rm -f packages/cli/README.md && cp README.md packages/cli
@@ -51,12 +49,14 @@ jobs:
       - name: Set version and publish prerelease for 'cli' package
         run: |
           pnpm version ${{ github.event.release.tag_name }}-prerelease-${{ env.SHORT_SHA }} --no-git-tag-version
-          pnpm publish --provenance --tag prerelease --no-git-checks
+          pnpm pack
+          npm publish checkly-*.tgz --provenance --tag prerelease
         working-directory: packages/cli
       - name: Set version and publish prerelease for 'create-cli' package
         run: |
           pnpm version ${{ github.event.release.tag_name }}-prerelease-${{ env.SHORT_SHA }} --no-git-tag-version
-          pnpm publish --provenance --tag prerelease --no-git-checks
+          pnpm pack
+          npm publish create-checkly-*.tgz --provenance --tag prerelease
         working-directory: packages/create-cli
       - name: Save LLM rules as an artifact
         uses: actions/upload-artifact@v4
@@ -106,8 +106,7 @@ jobs:
           version: 10
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: '24.x'
           cache: "pnpm"
       # Ensure that the README is published with the package
       - run: rm -f packages/cli/README.md && cp README.md packages/cli
@@ -115,12 +114,14 @@ jobs:
       - name: Set version and publish 'cli' package
         run: |
           pnpm version ${{ github.event.release.tag_name }} --no-git-tag-version
-          pnpm publish --provenance --no-git-checks
+          pnpm pack
+          npm publish checkly-*.tgz --provenance
         working-directory: packages/cli
       - name: Set version and publish 'create-cli' package
         run: |
           pnpm version ${{ github.event.release.tag_name }} --no-git-tag-version
-          pnpm publish --provenance --no-git-checks
+          pnpm pack
+          npm publish create-checkly-*.tgz --provenance
         working-directory: packages/create-cli
       - name: Save LLM rules as an artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- pnpm doesn't support OIDC trusted publishing ([pnpm/pnpm#9812](https://github.com/pnpm/pnpm/issues/9812)), which broke both `pnpm version` (treated as a script name) and `pnpm publish` (no OIDC token exchange)
- Use `pnpm pack` to create the tarball, then `npm publish <tarball>` for the actual upload which handles OIDC
- Bump Node from 20.x to 24.x in release workflows for built-in npm OIDC support
- Remove `registry-url` from `setup-node` in the release workflow to avoid short-circuiting OIDC (kept in canary workflow which uses token auth)

## Test plan

- [ ] Trigger a canary build via `build` label
- [ ] Trigger a release to verify OIDC publishing works

🤖 Generated with [Claude Code](https://claude.com/claude-code)