### PR TITLE
feat(cli): add test sessions get command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /tmp
 /yarn.lock
 node_modules
+*.tgz
 !packages/cli/src/services/__tests__/fixtures/playwright-json/**
 .vscode
 .checkly

--- a/packages/cli/e2e/__tests__/help.spec.ts
+++ b/packages/cli/e2e/__tests__/help.spec.ts
@@ -71,6 +71,7 @@ describe('help', () => {
   status-pages     List and manage status pages in your Checkly account.
   switch           Switch user account.
   sync-playwright  Copy Playwright config into the Checkly config file.
+  test-sessions    Inspect recorded test sessions.
   whoami           See your currently logged in account and user.`)
   })
 })

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -88,6 +88,9 @@
       },
       "status-pages": {
         "description": "List and manage status pages in your Checkly account."
+      },
+      "test-sessions": {
+        "description": "Inspect recorded test sessions."
       }
     },
     "helpClass": "./dist/help/help-extension.js"

--- a/packages/cli/src/commands/__tests__/command-metadata.spec.ts
+++ b/packages/cli/src/commands/__tests__/command-metadata.spec.ts
@@ -37,6 +37,7 @@ import SkillsInstall from '../skills/install.js'
 import AccountPlan from '../account/plan.js'
 import AccountMembers from '../account/members.js'
 import Api from '../api.js'
+import TestSessionsGet from '../test-sessions/get.js'
 
 const commands: Array<[string, typeof BaseCommand]> = [
   ['api', Api],
@@ -47,6 +48,7 @@ const commands: Array<[string, typeof BaseCommand]> = [
   ['checks stats', ChecksStats],
   ['status-pages list', StatusPagesList],
   ['status-pages get', StatusPagesGet],
+  ['test-sessions get', TestSessionsGet],
   ['incidents list', IncidentsList],
   ['incidents create', IncidentsCreate],
   ['incidents update', IncidentsUpdate],

--- a/packages/cli/src/commands/__tests__/test-sessions-get.spec.ts
+++ b/packages/cli/src/commands/__tests__/test-sessions-get.spec.ts
@@ -170,6 +170,30 @@ describe('test-sessions get command', () => {
     expect(process.exitCode).toBe(1)
   })
 
+  it('deduplicates error group IDs when suggesting the list limit', async () => {
+    vi.mocked(api.testSessions.get).mockResolvedValue({
+      data: {
+        ...testSession,
+        errorGroupIds: ['eg-1', 'eg-2', 'eg-3', 'eg-1'],
+        results: [{
+          ...testSession.results[0],
+          errorGroupIds: ['eg-1', 'eg-2', 'eg-3'],
+        }],
+      },
+    } as any)
+    const ctx = createCommandContext({
+      args: { id: testSession.testSessionId },
+      flags: { 'output': 'detail', 'error-group': 'other-eg' },
+    })
+
+    await TestSessionsGet.prototype.run.call(ctx as any)
+
+    expect(ctx.style.longError).toHaveBeenCalledWith(
+      'Test session error group not found in this session.',
+      expect.stringContaining('--error-groups-limit 5'),
+    )
+  })
+
   it('returns raw API response for json output', async () => {
     const ctx = createCommandContext({
       args: { id: testSession.testSessionId },

--- a/packages/cli/src/commands/__tests__/test-sessions-get.spec.ts
+++ b/packages/cli/src/commands/__tests__/test-sessions-get.spec.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TestSessionErrorGroup } from '../../rest/test-session-error-groups.js'
+import type { TestSessionDetail } from '../../rest/test-sessions.js'
+
+vi.mock('../../rest/api.js', () => ({
+  testSessions: { get: vi.fn() },
+  testSessionErrorGroups: { get: vi.fn() },
+}))
+
+import * as api from '../../rest/api.js'
+import TestSessionsGet from '../test-sessions/get.js'
+
+const testSession: TestSessionDetail = {
+  testSessionId: '8166fa86-c9b4-4162-8541-d380c6c212d8',
+  testSessionLink: 'https://app.checklyhq.com/accounts/account-id/test-sessions/8166fa86-c9b4-4162-8541-d380c6c212d8',
+  name: 'Production smoke test',
+  status: 'FAILED',
+  startedAt: '2026-05-20T08:00:00.000Z',
+  stoppedAt: '2026-05-20T08:02:03.456Z',
+  timeElapsed: 123456,
+  metadata: { environment: 'production' },
+  errorGroupIds: ['session-eg-1'],
+  results: [
+    {
+      testSessionResultId: '42406a0f-5864-4a26-9884-7c5d1be15bc2',
+      testSessionResultLink: 'https://app.checklyhq.com/accounts/account-id/test-sessions/session-id/results/result-id',
+      checkId: null,
+      checkType: 'API',
+      name: 'API smoke',
+      runLocation: 'eu-west-1',
+      resultType: 'FINAL',
+      status: 'FAILED',
+      hasErrors: false,
+      hasFailures: true,
+      isDegraded: false,
+      aborted: false,
+      errorGroupIds: ['result-eg-1'],
+    },
+  ],
+}
+
+const testSessionErrorGroup: TestSessionErrorGroup = {
+  id: 'result-eg-1',
+  projectId: 'project-1',
+  environments: ['production'],
+  errorHash: 'hash-1',
+  rawErrorMessage: 'Error: boom',
+  cleanedErrorMessage: 'Error: boom',
+  firstSeen: '2026-05-20T08:00:00.000Z',
+  lastSeen: '2026-05-20T08:02:03.456Z',
+  archivedUntilNextEvent: false,
+}
+
+function createCommandContext (parsed: unknown) {
+  const logged: string[] = []
+  return {
+    parse: vi.fn().mockResolvedValue(parsed),
+    log: vi.fn((msg?: string) => {
+      if (msg) logged.push(msg)
+    }),
+    style: {
+      outputFormat: undefined,
+      longError: vi.fn(),
+    },
+    logged,
+  }
+}
+
+describe('test-sessions get command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.exitCode = undefined
+    vi.mocked(api.testSessions.get).mockResolvedValue({ data: testSession } as any)
+    vi.mocked(api.testSessionErrorGroups.get).mockResolvedValue({ data: testSessionErrorGroup } as any)
+  })
+
+  it('fetches and renders test session detail output', async () => {
+    const ctx = createCommandContext({
+      args: { id: testSession.testSessionId },
+      flags: { output: 'detail' },
+    })
+
+    await TestSessionsGet.prototype.run.call(ctx as any)
+
+    expect(api.testSessions.get).toHaveBeenCalledWith(testSession.testSessionId)
+    expect(ctx.logged[0]).toContain('Production smoke test')
+    expect(ctx.logged[0]).toContain('API smoke')
+    expect(ctx.logged[0]).toContain('ERROR GROUP IDS')
+    expect(ctx.logged[0]).toContain('session-eg-1')
+    expect(ctx.logged[0]).toContain('checkly rca run --test-session-error-group <error-group-id> --watch')
+    expect(ctx.logged[0]).toContain(testSession.testSessionLink)
+  })
+
+  it('fetches and renders one test session error group detail', async () => {
+    const ctx = createCommandContext({
+      args: { id: testSession.testSessionId },
+      flags: { 'output': 'detail', 'error-group': 'result-eg-1', 'full-error': false },
+    })
+
+    await TestSessionsGet.prototype.run.call(ctx as any)
+
+    expect(api.testSessions.get).toHaveBeenCalledWith(testSession.testSessionId)
+    expect(api.testSessionErrorGroups.get).toHaveBeenCalledWith('result-eg-1')
+    expect(ctx.logged[0]).toContain('Test session error group')
+    expect(ctx.logged[0]).toContain('Error: boom')
+  })
+
+  it('limits long test session error group detail output by default', async () => {
+    vi.mocked(api.testSessionErrorGroups.get).mockResolvedValue({
+      data: {
+        ...testSessionErrorGroup,
+        rawErrorMessage: Array.from({ length: 81 }, (_, i) => `line ${i + 1}`).join('\n'),
+      },
+    } as any)
+    const ctx = createCommandContext({
+      args: { id: testSession.testSessionId },
+      flags: { 'output': 'detail', 'error-group': 'result-eg-1', 'full-error': false },
+    })
+
+    await TestSessionsGet.prototype.run.call(ctx as any)
+
+    expect(ctx.logged[0]).toContain('line 80')
+    expect(ctx.logged[0]).not.toContain('line 81')
+    expect(ctx.logged[0]).toContain('Showing first 80 of 81 lines. Use --full-error to print the complete raw error.')
+  })
+
+  it('renders full test session error group detail output when requested', async () => {
+    vi.mocked(api.testSessionErrorGroups.get).mockResolvedValue({
+      data: {
+        ...testSessionErrorGroup,
+        rawErrorMessage: Array.from({ length: 81 }, (_, i) => `line ${i + 1}`).join('\n'),
+      },
+    } as any)
+    const ctx = createCommandContext({
+      args: { id: testSession.testSessionId },
+      flags: { 'output': 'detail', 'error-group': 'result-eg-1', 'full-error': true },
+    })
+
+    await TestSessionsGet.prototype.run.call(ctx as any)
+
+    expect(ctx.logged[0]).toContain('line 80')
+    expect(ctx.logged[0]).toContain('line 81')
+    expect(ctx.logged[0]).not.toContain('Use --full-error')
+  })
+
+  it('returns raw test session error group response for json drilldown output', async () => {
+    const ctx = createCommandContext({
+      args: { id: testSession.testSessionId },
+      flags: { 'output': 'json', 'error-group': 'result-eg-1' },
+    })
+
+    await TestSessionsGet.prototype.run.call(ctx as any)
+
+    expect(JSON.parse(ctx.logged[0])).toEqual(testSessionErrorGroup)
+  })
+
+  it('rejects error group IDs that are not in the test session', async () => {
+    const ctx = createCommandContext({
+      args: { id: testSession.testSessionId },
+      flags: { 'output': 'detail', 'error-group': 'other-eg' },
+    })
+
+    await TestSessionsGet.prototype.run.call(ctx as any)
+
+    expect(api.testSessionErrorGroups.get).not.toHaveBeenCalled()
+    expect(ctx.style.longError).toHaveBeenCalledWith(
+      'Test session error group not found in this session.',
+      expect.stringContaining('--error-groups-limit 5'),
+    )
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('returns raw API response for json output', async () => {
+    const ctx = createCommandContext({
+      args: { id: testSession.testSessionId },
+      flags: { output: 'json' },
+    })
+
+    await TestSessionsGet.prototype.run.call(ctx as any)
+
+    expect(JSON.parse(ctx.logged[0])).toEqual(testSession)
+  })
+
+  it('renders markdown output', async () => {
+    const ctx = createCommandContext({
+      args: { id: testSession.testSessionId },
+      flags: { output: 'md' },
+    })
+
+    await TestSessionsGet.prototype.run.call(ctx as any)
+
+    expect(ctx.logged[0]).toContain('# Production smoke test')
+    expect(ctx.logged[0]).toContain('## Results')
+    expect(ctx.logged[0]).toContain('## Hints')
+  })
+
+  it('reports API failures without throwing', async () => {
+    const ctx = createCommandContext({
+      args: { id: testSession.testSessionId },
+      flags: { output: 'detail' },
+    })
+    vi.mocked(api.testSessions.get).mockRejectedValue(new Error('boom'))
+
+    await TestSessionsGet.prototype.run.call(ctx as any)
+
+    expect(ctx.style.longError).toHaveBeenCalledWith('Failed to get test session details.', expect.any(Error))
+    expect(process.exitCode).toBe(1)
+  })
+})

--- a/packages/cli/src/commands/test-sessions/get.ts
+++ b/packages/cli/src/commands/test-sessions/get.ts
@@ -44,10 +44,10 @@ export default class TestSessionsGet extends AuthCommand {
       const { data: testSession } = await api.testSessions.get(args.id)
 
       if (flags['error-group']) {
-        const errorGroupIds = [
+        const errorGroupIds = [...new Set([
           ...(testSession.errorGroupIds ?? []),
           ...(testSession.results ?? []).flatMap(result => result.errorGroupIds ?? []),
-        ]
+        ])]
 
         if (!errorGroupIds.includes(flags['error-group'])) {
           const listCommand = `checkly test-sessions get ${args.id} `

--- a/packages/cli/src/commands/test-sessions/get.ts
+++ b/packages/cli/src/commands/test-sessions/get.ts
@@ -1,0 +1,91 @@
+import { Args, Flags } from '@oclif/core'
+import { AuthCommand } from '../authCommand.js'
+import { outputFlag } from '../../helpers/flags.js'
+import * as api from '../../rest/api.js'
+import {
+  formatTestSessionDetail,
+  formatTestSessionErrorGroupDetail,
+} from '../../formatters/test-sessions.js'
+import { type OutputFormat } from '../../formatters/render.js'
+
+export default class TestSessionsGet extends AuthCommand {
+  static hidden = false
+  static readOnly = true
+  static idempotent = true
+  static description = 'Get details of a recorded test session, including result error groups for RCA.'
+
+  static args = {
+    id: Args.string({
+      description: 'The ID of the test session to retrieve.',
+      required: true,
+    }),
+  }
+
+  static flags = {
+    'error-group': Flags.string({
+      description: 'Show details for a test session error group ID from this session.',
+    }),
+    'error-groups-limit': Flags.integer({
+      description: 'Number of error group IDs to show in the session summary.',
+      default: 5,
+    }),
+    'full-error': Flags.boolean({
+      description: 'Print the complete raw error when showing a test session error group.',
+      default: false,
+    }),
+    'output': outputFlag({ default: 'detail' }),
+  }
+
+  async run (): Promise<void> {
+    const { args, flags } = await this.parse(TestSessionsGet)
+    this.style.outputFormat = flags.output
+
+    try {
+      const { data: testSession } = await api.testSessions.get(args.id)
+
+      if (flags['error-group']) {
+        const errorGroupIds = [
+          ...(testSession.errorGroupIds ?? []),
+          ...(testSession.results ?? []).flatMap(result => result.errorGroupIds ?? []),
+        ]
+
+        if (!errorGroupIds.includes(flags['error-group'])) {
+          const listCommand = `checkly test-sessions get ${args.id} `
+            + `--error-groups-limit ${Math.max(5, errorGroupIds.length)}`
+          this.style.longError(
+            'Test session error group not found in this session.',
+            `Run \`${listCommand}\` to list the available error group IDs.`,
+          )
+          process.exitCode = 1
+          return
+        }
+
+        const { data: errorGroup } = await api.testSessionErrorGroups.get(flags['error-group'])
+
+        if (flags.output === 'json') {
+          this.log(JSON.stringify(errorGroup, null, 2))
+          return
+        }
+
+        const fmt: OutputFormat = flags.output === 'md' ? 'md' : 'terminal'
+        this.log(formatTestSessionErrorGroupDetail(errorGroup, fmt, {
+          fullError: flags['full-error'],
+        }))
+        return
+      }
+
+      if (flags.output === 'json') {
+        this.log(JSON.stringify(testSession, null, 2))
+        return
+      }
+
+      const fmt: OutputFormat = flags.output === 'md' ? 'md' : 'terminal'
+      this.log(formatTestSessionDetail(testSession, fmt, {
+        errorGroupsLimit: flags['error-groups-limit'],
+      }))
+    } catch (err: any) {
+      this.style.longError('Failed to get test session details.', err)
+      process.exitCode = 1
+    }
+  }
+}

--- a/packages/cli/src/commands/test-sessions/get.ts
+++ b/packages/cli/src/commands/test-sessions/get.ts
@@ -5,6 +5,7 @@ import * as api from '../../rest/api.js'
 import {
   formatTestSessionDetail,
   formatTestSessionErrorGroupDetail,
+  uniqueErrorGroupIds,
 } from '../../formatters/test-sessions.js'
 import { type OutputFormat } from '../../formatters/render.js'
 
@@ -44,10 +45,7 @@ export default class TestSessionsGet extends AuthCommand {
       const { data: testSession } = await api.testSessions.get(args.id)
 
       if (flags['error-group']) {
-        const errorGroupIds = [...new Set([
-          ...(testSession.errorGroupIds ?? []),
-          ...(testSession.results ?? []).flatMap(result => result.errorGroupIds ?? []),
-        ])]
+        const errorGroupIds = uniqueErrorGroupIds(testSession)
 
         if (!errorGroupIds.includes(flags['error-group'])) {
           const listCommand = `checkly test-sessions get ${args.id} `

--- a/packages/cli/src/formatters/__tests__/test-sessions.spec.ts
+++ b/packages/cli/src/formatters/__tests__/test-sessions.spec.ts
@@ -1,0 +1,231 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { stripAnsi } from '../render.js'
+import { formatTestSessionDetail, formatTestSessionErrorGroupDetail } from '../test-sessions.js'
+import type { TestSessionErrorGroup } from '../../rest/test-session-error-groups.js'
+import type { TestSessionDetail } from '../../rest/test-sessions.js'
+
+const testSession: TestSessionDetail = {
+  testSessionId: '8166fa86-c9b4-4162-8541-d380c6c212d8',
+  testSessionLink: 'https://app.checklyhq.com/accounts/account-id/test-sessions/8166fa86-c9b4-4162-8541-d380c6c212d8',
+  name: 'Production smoke test',
+  status: 'FAILED',
+  startedAt: '2026-05-20T08:00:00.000Z',
+  stoppedAt: '2026-05-20T08:02:03.456Z',
+  timeElapsed: 123456,
+  metadata: {
+    environment: 'production',
+    repoUrl: 'https://github.com/checkly/checkly-cli',
+    branchName: 'main',
+    commitId: 'abc123',
+  },
+  errorGroupIds: ['session-eg-1'],
+  results: [
+    {
+      testSessionResultId: '42406a0f-5864-4a26-9884-7c5d1be15bc2',
+      testSessionResultLink: 'https://app.checklyhq.com/accounts/account-id/test-sessions/session-id/results/result-id',
+      checkId: 'a4cd4ad9-4815-4a9e-92d2-0a7c562ee69a',
+      checkType: 'BROWSER',
+      name: 'Homepage',
+      runLocation: 'us-east-1',
+      resultType: 'FINAL',
+      status: 'FAILED',
+      hasErrors: false,
+      hasFailures: true,
+      isDegraded: false,
+      aborted: false,
+      errorGroupIds: ['result-eg-1'],
+    },
+  ],
+}
+
+const testSessionErrorGroup: TestSessionErrorGroup = {
+  id: 'result-eg-1',
+  projectId: 'project-1',
+  environments: ['production'],
+  errorHash: 'hash-1',
+  rawErrorMessage: 'Error: boom with raw context',
+  cleanedErrorMessage: 'Error: boom',
+  firstSeen: '2026-05-20T08:00:00.000Z',
+  lastSeen: '2026-05-20T08:02:03.456Z',
+  archivedUntilNextEvent: false,
+}
+
+describe('formatTestSessionDetail', () => {
+  const originalColumns = process.stdout.columns
+
+  beforeEach(() => {
+    vi.setSystemTime(new Date('2026-05-20T08:05:00.000Z'))
+    Object.defineProperty(process.stdout, 'columns', { configurable: true, value: 120 })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process.stdout, 'columns', { configurable: true, value: originalColumns })
+  })
+
+  it('renders terminal session summary, results, and hints', () => {
+    const result = stripAnsi(formatTestSessionDetail(testSession, 'terminal'))
+
+    expect(result).toContain('Production smoke test')
+    expect(result).toContain('Status:')
+    expect(result).toContain('failed')
+    expect(result).toContain('Started:')
+    expect(result).toContain('2026-05-20 08:00:00 UTC')
+    expect(result).toContain('Time elapsed:')
+    expect(result).toContain('2m 3s')
+    expect(result).toContain('environment: production')
+    expect(result).not.toContain('Session link:')
+    expect(result).toContain('Error groups:')
+    expect(result).toContain('2 groups')
+    expect(result).toContain('RESULTS')
+    expect(result).toContain('NAME')
+    expect(result).toContain('RESULT ID')
+    expect(result).toContain('42406a0f-5864-4a26-9884-7c5d1be15bc2')
+    expect(result).toContain('Homepage')
+    expect(result).toContain('BROWSER')
+    expect(result).toContain('FINAL')
+    expect(result).toContain('us-east-1')
+    expect(result).toContain('ERROR GROUP IDS')
+    expect(result).toContain('session-eg-1')
+    expect(result).toContain('result-eg-1')
+    expect(result).toContain('checkly test-sessions get 8166fa86-c9b4-4162-8541-d380c6c212d8 --error-group <error-group-id>')
+    expect(result).toContain('checkly rca run --test-session-error-group <error-group-id> --watch')
+    expect(result).not.toContain('checkly rca run --test-session-error-group session-eg-1 --watch')
+    expect(result).toContain('Open session:')
+  })
+
+  it('keeps long terminal result rows readable by putting IDs at the end', () => {
+    Object.defineProperty(process.stdout, 'columns', { configurable: true, value: 180 })
+
+    const result = stripAnsi(formatTestSessionDetail({
+      ...testSession,
+      results: [
+        {
+          ...testSession.results[0],
+          name: 'Smoke Lab Playwright Suite',
+          checkType: 'PLAYWRIGHT',
+          errorGroupIds: ['b397fd08-871e-4d45-b307-529778de260c'],
+        },
+        {
+          ...testSession.results[0],
+          testSessionResultId: '019e45e0-2177-4640-9b04-2d4f6f9ad55f',
+          checkId: null,
+          name: 'Smoke Lab Go Runner URL Failure',
+          checkType: 'URL',
+          errorGroupIds: ['f201a4f5-0cad-4a3c-ab70-e52149b294b1', '094ca569-f746-4d81-a38d-1d5fdd37f42a'],
+        },
+      ],
+    }, 'terminal'))
+
+    const header = result.split('\n').find(line => line.includes('RESULT ID'))!
+    const firstRow = result.split('\n').find(line => line.includes('Smoke Lab Playwright'))!
+    const secondRow = result.split('\n').find(line => line.includes('Smoke Lab Go Runner'))!
+
+    expect(header.indexOf('RESULT ID')).toBeGreaterThan(header.indexOf('ERROR GROUPS'))
+    expect(header.indexOf('CHECK ID')).toBeGreaterThan(header.indexOf('RESULT ID'))
+    expect(firstRow.indexOf('42406a0f-5864-4a26-9884-7c5d1be15bc2')).toBeGreaterThan(firstRow.indexOf('1 group'))
+    expect(secondRow).toContain('2 groups')
+    expect(secondRow).toContain('019e45e0-2177-4640-9b04-2d4f6f9ad55f')
+    expect(secondRow).not.toContain('f201a4f5-0cad-4a3c-ab70-e52149b294b1')
+  })
+
+  it('limits terminal error group IDs and shows how to expand them', () => {
+    const result = stripAnsi(formatTestSessionDetail({
+      ...testSession,
+      errorGroupIds: ['session-eg-1', 'session-eg-2'],
+      results: [
+        {
+          ...testSession.results[0],
+          errorGroupIds: ['result-eg-1', 'result-eg-2'],
+        },
+      ],
+    }, 'terminal', { errorGroupsLimit: 2 }))
+
+    expect(result).toContain('ERROR GROUP IDS')
+    expect(result).toContain('session-eg-1')
+    expect(result).toContain('session-eg-2')
+    expect(result).not.toContain('result-eg-1')
+    expect(result).toContain('Showing 2 of 4 error group IDs')
+    expect(result).toContain('--error-groups-limit 4')
+  })
+
+  it('renders markdown session summary, results table, and RCA hints', () => {
+    const result = formatTestSessionDetail(testSession, 'md')
+
+    expect(result).toContain('# Production smoke test')
+    expect(result).toContain('| Field | Value |')
+    expect(result).toContain('| Error groups | 2 groups |')
+    expect(result).toContain('## Results')
+    expect(result).toContain('| Result ID | Check ID | Name | Check Type | Status | Result Type | Run Location | Error Groups |')
+    expect(result).toContain('| 42406a0f-5864-4a26-9884-7c5d1be15bc2 | a4cd4ad9-4815-4a9e-92d2-0a7c562ee69a | Homepage | BROWSER | failed | FINAL | us-east-1 | result-eg-1 |')
+    expect(result).toContain('## Error Group IDs')
+    expect(result).toContain('| session | session-eg-1 |')
+    expect(result).toContain('| Homepage | result-eg-1 |')
+    expect(result).toContain('## Hints')
+    expect(result).toContain('- Inspect group: `checkly test-sessions get 8166fa86-c9b4-4162-8541-d380c6c212d8 --error-group <error-group-id>`')
+    expect(result).toContain('- Run RCA: `checkly rca run --test-session-error-group <error-group-id> --watch`')
+    expect(result).toContain('- Open session: https://app.checklyhq.com/accounts/account-id/test-sessions/8166fa86-c9b4-4162-8541-d380c6c212d8')
+  })
+
+  it('omits metadata and RCA hints when absent but keeps the session link hint', () => {
+    const result = stripAnsi(formatTestSessionDetail({
+      ...testSession,
+      metadata: undefined,
+      errorGroupIds: [],
+      results: [{ ...testSession.results[0], errorGroupIds: [] }],
+    }, 'terminal'))
+
+    expect(result).not.toContain('Metadata:')
+    expect(result).not.toContain('Run RCA:')
+    expect(result).not.toContain('ERROR GROUP IDS')
+    expect(result).toContain('Open session:')
+  })
+
+  it('renders hydrated test session error group detail', () => {
+    const result = stripAnsi(formatTestSessionErrorGroupDetail(testSessionErrorGroup, 'terminal'))
+
+    expect(result).toContain('Test session error group')
+    expect(result).toContain('Error:')
+    expect(result).toContain('Error: boom with raw context')
+    expect(result).not.toContain('Raw error:')
+    expect(result).not.toContain('Error: boom\n')
+    expect(result).toContain('First seen:')
+    expect(result).toContain('2026-05-20 08:00:00 UTC')
+    expect(result).toContain('ID:')
+    expect(result).toContain('result-eg-1')
+  })
+
+  it('limits long hydrated test session error group details by line count', () => {
+    const result = stripAnsi(formatTestSessionErrorGroupDetail({
+      ...testSessionErrorGroup,
+      rawErrorMessage: ['line 1', 'line 2', 'line 3'].join('\n'),
+    }, 'terminal', { errorLines: 2 }))
+
+    expect(result).toContain('line 1')
+    expect(result).toContain('line 2')
+    expect(result).not.toContain('line 3')
+    expect(result).toContain('Showing first 2 of 3 lines. Use --full-error to print the complete raw error.')
+  })
+
+  it('renders full hydrated test session error group details when requested', () => {
+    const result = stripAnsi(formatTestSessionErrorGroupDetail({
+      ...testSessionErrorGroup,
+      rawErrorMessage: ['line 1', 'line 2', 'line 3'].join('\n'),
+    }, 'terminal', { errorLines: 2, fullError: true }))
+
+    expect(result).toContain('line 1')
+    expect(result).toContain('line 2')
+    expect(result).toContain('line 3')
+    expect(result).not.toContain('Use --full-error')
+  })
+
+  it('handles absent results from the API contract', () => {
+    const result = stripAnsi(formatTestSessionDetail({
+      ...testSession,
+      results: undefined,
+    }, 'terminal'))
+
+    expect(result).toContain('Production smoke test')
+    expect(result).not.toContain('RESULTS')
+    expect(result).toContain('Open session:')
+  })
+})

--- a/packages/cli/src/formatters/__tests__/test-sessions.spec.ts
+++ b/packages/cli/src/formatters/__tests__/test-sessions.spec.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { stripAnsi } from '../render.js'
 import { formatTestSessionDetail, formatTestSessionErrorGroupDetail } from '../test-sessions.js'
 import type { TestSessionErrorGroup } from '../../rest/test-session-error-groups.js'
-import type { TestSessionDetail } from '../../rest/test-sessions.js'
+import type { TestSessionDetail, TestSessionStatus } from '../../rest/test-sessions.js'
 
 const testSession: TestSessionDetail = {
   testSessionId: '8166fa86-c9b4-4162-8541-d380c6c212d8',
@@ -91,6 +91,21 @@ describe('formatTestSessionDetail', () => {
     expect(result).toContain('checkly rca run --test-session-error-group <error-group-id> --watch')
     expect(result).not.toContain('checkly rca run --test-session-error-group session-eg-1 --watch')
     expect(result).toContain('Open session:')
+  })
+
+  it.each<TestSessionStatus>([
+    'FAILED',
+    'CANCELLED',
+    'RUNNING',
+    'PASSED',
+  ])('renders the supported %s status', status => {
+    const result = stripAnsi(formatTestSessionDetail({
+      ...testSession,
+      status,
+      results: [{ ...testSession.results[0], status }],
+    }, 'terminal'))
+
+    expect(result).toMatch(new RegExp(`Status:\\s+${status.toLowerCase()}`))
   })
 
   it('keeps long terminal result rows readable by putting IDs at the end', () => {

--- a/packages/cli/src/formatters/test-sessions.ts
+++ b/packages/cli/src/formatters/test-sessions.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 import type { TestSessionErrorGroup } from '../rest/test-session-error-groups.js'
-import type { TestSessionDetail, TestSessionMetadata, TestSessionResult } from '../rest/test-sessions.js'
+import type { TestSessionDetail, TestSessionMetadata, TestSessionResult, TestSessionStatus } from '../rest/test-sessions.js'
 import {
   type ColumnDef,
   type DetailField,
@@ -30,13 +30,19 @@ interface ErrorGroupReference {
   sources: string[]
 }
 
-function formatStatus (status: string, format: OutputFormat): string {
+function formatStatus (status: TestSessionStatus, format: OutputFormat): string {
   const normalized = status.toLowerCase()
   if (format === 'md') return normalized
-  if (['failed', 'failing', 'error', 'errored', 'timed_out', 'aborted'].includes(normalized)) return chalk.red(normalized)
-  if (['running', 'pending'].includes(normalized)) return chalk.yellow(normalized)
-  if (['passed', 'passing', 'success', 'succeeded'].includes(normalized)) return chalk.green(normalized)
-  return normalized
+
+  switch (status) {
+    case 'FAILED':
+    case 'CANCELLED':
+      return chalk.red(normalized)
+    case 'RUNNING':
+      return chalk.yellow(normalized)
+    case 'PASSED':
+      return chalk.green(normalized)
+  }
 }
 
 function formatList (values: string[] | undefined, format: OutputFormat): string {

--- a/packages/cli/src/formatters/test-sessions.ts
+++ b/packages/cli/src/formatters/test-sessions.ts
@@ -36,8 +36,9 @@ function formatStatus (status: TestSessionStatus, format: OutputFormat): string 
 
   switch (status) {
     case 'FAILED':
-    case 'CANCELLED':
       return chalk.red(normalized)
+    case 'CANCELLED':
+      return chalk.dim(normalized)
     case 'RUNNING':
       return chalk.yellow(normalized)
     case 'PASSED':
@@ -159,7 +160,7 @@ function buildResultColumns (results: TestSessionResult[], format: OutputFormat)
   return columns
 }
 
-function uniqueErrorGroupIds (session: TestSessionDetail): string[] {
+export function uniqueErrorGroupIds (session: TestSessionDetail): string[] {
   return [
     ...(session.errorGroupIds ?? []),
     ...(session.results ?? []).flatMap(result => result.errorGroupIds ?? []),

--- a/packages/cli/src/formatters/test-sessions.ts
+++ b/packages/cli/src/formatters/test-sessions.ts
@@ -1,0 +1,333 @@
+import chalk from 'chalk'
+import type { TestSessionErrorGroup } from '../rest/test-session-error-groups.js'
+import type { TestSessionDetail, TestSessionMetadata, TestSessionResult } from '../rest/test-sessions.js'
+import {
+  type ColumnDef,
+  type DetailField,
+  type OutputFormat,
+  formatCheckType,
+  formatDate,
+  renderDetailFields,
+  renderTable,
+  truncateToWidth,
+  visWidth,
+} from './render.js'
+
+const DEFAULT_ERROR_GROUPS_LIMIT = 5
+const DEFAULT_ERROR_DETAIL_LINES = 80
+
+export interface TestSessionFormatOptions {
+  errorGroupsLimit?: number
+}
+
+export interface TestSessionErrorGroupFormatOptions {
+  fullError?: boolean
+  errorLines?: number
+}
+
+interface ErrorGroupReference {
+  id: string
+  sources: string[]
+}
+
+function formatStatus (status: string, format: OutputFormat): string {
+  const normalized = status.toLowerCase()
+  if (format === 'md') return normalized
+  if (['failed', 'failing', 'error', 'errored', 'timed_out', 'aborted'].includes(normalized)) return chalk.red(normalized)
+  if (['running', 'pending'].includes(normalized)) return chalk.yellow(normalized)
+  if (['passed', 'passing', 'success', 'succeeded'].includes(normalized)) return chalk.green(normalized)
+  return normalized
+}
+
+function formatList (values: string[] | undefined, format: OutputFormat): string {
+  if (!values || values.length === 0) return format === 'terminal' ? chalk.dim('-') : '-'
+  return values.join(', ')
+}
+
+function formatErrorGroupCount (values: string[] | undefined, format: OutputFormat): string {
+  if (format === 'md') return formatList(values, format)
+  const count = values?.length ?? 0
+  if (count === 0) return chalk.dim('-')
+  return `${count} ${count === 1 ? 'group' : 'groups'}`
+}
+
+function formatErrorGroupSummary (session: TestSessionDetail, format: OutputFormat): string {
+  const count = uniqueErrorGroupIds(session).length
+  if (count === 0) return format === 'terminal' ? chalk.dim('-') : '-'
+  return `${count} ${count === 1 ? 'group' : 'groups'}`
+}
+
+function formatDuration (ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)}ms`
+
+  const totalSeconds = Math.round(ms / 1000)
+  const seconds = totalSeconds % 60
+  const totalMinutes = Math.floor(totalSeconds / 60)
+  if (totalMinutes === 0) return `${seconds}s`
+
+  const minutes = totalMinutes % 60
+  const hours = Math.floor(totalMinutes / 60)
+  if (hours === 0) return seconds === 0 ? `${minutes}m` : `${minutes}m ${seconds}s`
+
+  if (minutes === 0 && seconds === 0) return `${hours}h`
+  if (minutes === 0) return `${hours}h ${seconds}s`
+  return seconds === 0 ? `${hours}h ${minutes}m` : `${hours}h ${minutes}m ${seconds}s`
+}
+
+function formatMetadata (metadata: TestSessionMetadata | undefined, format: OutputFormat): string | null {
+  if (!metadata) return null
+
+  const entries = Object.entries(metadata).filter(([, value]) => value != null && value !== '')
+  if (entries.length === 0) return null
+
+  const labels: Record<string, string> = {
+    environment: 'environment',
+    repoUrl: 'repo',
+    commitId: 'commit',
+    commitOwner: 'author',
+    commitMessage: 'message',
+    branchName: 'branch',
+  }
+
+  const formatted = entries.map(([key, value]) => `${labels[key] ?? key}: ${value}`)
+  return format === 'md' ? formatted.join(', ') : formatted.join('\n')
+}
+
+const testSessionDetailFields: DetailField<TestSessionDetail>[] = [
+  { label: 'Status', value: (session, fmt) => formatStatus(session.status, fmt) },
+  { label: 'Started', value: (session, fmt) => formatDate(session.startedAt, fmt) },
+  { label: 'Stopped', value: (session, fmt) => formatDate(session.stoppedAt, fmt) },
+  { label: 'Time elapsed', value: session => formatDuration(session.timeElapsed) },
+  { label: 'Metadata', value: (session, fmt) => formatMetadata(session.metadata, fmt) },
+  { label: 'Session link', value: (session, fmt) => fmt === 'md' ? session.testSessionLink : null },
+  { label: 'Error groups', value: (session, fmt) => formatErrorGroupSummary(session, fmt) },
+  { label: 'ID', value: session => session.testSessionId },
+]
+
+function buildResultColumns (results: TestSessionResult[], format: OutputFormat): ColumnDef<TestSessionResult>[] {
+  if (format === 'md') {
+    return [
+      { header: 'Result ID', value: result => result.testSessionResultId },
+      { header: 'Check ID', value: result => result.checkId ?? '-' },
+      { header: 'Name', value: result => result.name || '-' },
+      { header: 'Check Type', value: result => formatCheckType(result.checkType) },
+      { header: 'Status', value: (result, fmt) => formatStatus(result.status, fmt) },
+      { header: 'Result Type', value: result => result.resultType ?? '-' },
+      { header: 'Run Location', value: result => result.runLocation ?? '-' },
+      { header: 'Error Groups', value: (result, fmt) => formatList(result.errorGroupIds, fmt) },
+    ]
+  }
+
+  const termWidth = process.stdout.columns || 120
+  const showCheckId = termWidth >= 160 && results.some(result => result.checkId)
+  const typeWidth = 14
+  const statusWidth = 10
+  const resultTypeWidth = 10
+  const locationWidth = 14
+  const errorGroupWidth = 14
+  const resultIdWidth = showCheckId ? 38 : 0
+  const checkIdWidth = showCheckId ? 38 : 0
+  const fixedWidth = typeWidth + statusWidth + resultTypeWidth + locationWidth
+    + errorGroupWidth + resultIdWidth + checkIdWidth
+  const longestName = Math.max(4, ...results.map(result => visWidth(result.name || '-')))
+  const nameWidth = Math.max(16, Math.min(longestName + 2, termWidth - fixedWidth, 42))
+
+  const columns: ColumnDef<TestSessionResult>[] = [
+    { header: 'Name', width: nameWidth, value: result => truncateToWidth(result.name || '-', nameWidth - 2) },
+    { header: 'Type', width: typeWidth, value: result => truncateToWidth(formatCheckType(result.checkType), typeWidth - 2) },
+    { header: 'Status', width: statusWidth, value: (result, fmt) => formatStatus(result.status, fmt) },
+    { header: 'Result', width: resultTypeWidth, value: result => result.resultType ? truncateToWidth(result.resultType, resultTypeWidth - 2) : chalk.dim('-') },
+    { header: 'Location', width: locationWidth, value: result => result.runLocation ? truncateToWidth(result.runLocation, locationWidth - 2) : chalk.dim('-') },
+    { header: 'Error Groups', width: errorGroupWidth, value: (result, fmt) => formatErrorGroupCount(result.errorGroupIds, fmt) },
+  ]
+
+  if (showCheckId) {
+    columns.push(
+      { header: 'Result ID', width: resultIdWidth, value: result => chalk.dim(result.testSessionResultId) },
+      { header: 'Check ID', value: result => result.checkId ? chalk.dim(result.checkId) : chalk.dim('-') },
+    )
+  } else {
+    columns.push({ header: 'Result ID', value: result => chalk.dim(result.testSessionResultId) })
+  }
+
+  return columns
+}
+
+function uniqueErrorGroupIds (session: TestSessionDetail): string[] {
+  return [
+    ...(session.errorGroupIds ?? []),
+    ...(session.results ?? []).flatMap(result => result.errorGroupIds ?? []),
+  ].filter((id, index, ids) => ids.indexOf(id) === index)
+}
+
+function errorGroupReferences (session: TestSessionDetail): ErrorGroupReference[] {
+  const refs = new Map<string, Set<string>>()
+  const add = (id: string, source: string) => {
+    const sources = refs.get(id) ?? new Set<string>()
+    sources.add(source)
+    refs.set(id, sources)
+  }
+
+  for (const id of session.errorGroupIds ?? []) {
+    add(id, 'session')
+  }
+
+  for (const result of session.results ?? []) {
+    const source = result.name || result.testSessionResultId
+    for (const id of result.errorGroupIds ?? []) {
+      add(id, source)
+    }
+  }
+
+  return [...refs.entries()].map(([id, sources]) => ({ id, sources: [...sources] }))
+}
+
+function buildErrorGroupReferenceColumns (format: OutputFormat): ColumnDef<ErrorGroupReference>[] {
+  if (format === 'md') {
+    return [
+      { header: 'Source', value: ref => ref.sources.join(', ') },
+      { header: 'Error Group ID', value: ref => ref.id },
+    ]
+  }
+
+  const termWidth = process.stdout.columns || 120
+  const idWidth = 38
+  const sourceWidth = Math.max(16, Math.min(50, termWidth - idWidth))
+
+  return [
+    {
+      header: 'Source',
+      width: sourceWidth,
+      value: ref => truncateToWidth(ref.sources.join(', '), sourceWidth - 2),
+    },
+    { header: 'Error Group ID', value: ref => chalk.dim(ref.id) },
+  ]
+}
+
+export function formatTestSessionErrorGroupIds (
+  session: TestSessionDetail,
+  format: OutputFormat,
+  options: TestSessionFormatOptions = {},
+): string {
+  const refs = errorGroupReferences(session)
+  if (refs.length === 0) return ''
+
+  const limit = Math.max(0, options.errorGroupsLimit ?? DEFAULT_ERROR_GROUPS_LIMIT)
+  if (limit === 0) return ''
+
+  const visible = refs.slice(0, limit)
+  const hiddenCount = refs.length - visible.length
+  const lines: string[] = [
+    format === 'md' ? '## Error Group IDs' : chalk.bold('ERROR GROUP IDS'),
+    '',
+    renderTable(buildErrorGroupReferenceColumns(format), visible, format),
+  ]
+
+  if (hiddenCount > 0) {
+    const showMoreCommand = `checkly test-sessions get ${session.testSessionId} --error-groups-limit ${refs.length}`
+    lines.push('')
+    lines.push(format === 'md'
+      ? `*Showing ${visible.length} of ${refs.length} error group IDs. Show all: \`${showMoreCommand}\`*`
+      : `${chalk.dim(`Showing ${visible.length} of ${refs.length} error group IDs. Show all:`)}  ${showMoreCommand}`)
+  }
+
+  return lines.join('\n')
+}
+
+export function formatTestSessionHints (session: TestSessionDetail, format: OutputFormat): string {
+  const lines: string[] = []
+  const errorGroupIds = uniqueErrorGroupIds(session)
+
+  if (errorGroupIds.length > 0) {
+    const inspectCommand = `checkly test-sessions get ${session.testSessionId} --error-group <error-group-id>`
+    const rcaCommand = 'checkly rca run --test-session-error-group <error-group-id> --watch'
+    lines.push(format === 'md'
+      ? `- Inspect group: \`${inspectCommand}\``
+      : `  ${chalk.dim('Inspect group:')}  ${inspectCommand}`)
+    lines.push(format === 'md'
+      ? `- Run RCA: \`${rcaCommand}\``
+      : `  ${chalk.dim('Run RCA:')}       ${rcaCommand}`)
+  }
+
+  if (session.testSessionLink) {
+    lines.push(format === 'md'
+      ? `- Open session: ${session.testSessionLink}`
+      : `  ${chalk.dim('Open session:')}  ${session.testSessionLink}`)
+  }
+
+  return lines.join('\n')
+}
+
+function formatRawErrorMessage (
+  rawErrorMessage: string | null,
+  format: OutputFormat,
+  options: TestSessionErrorGroupFormatOptions,
+): string | null {
+  if (!rawErrorMessage) return null
+  if (options.fullError) return rawErrorMessage
+
+  const maxLines = Math.max(1, options.errorLines ?? DEFAULT_ERROR_DETAIL_LINES)
+  const lines = rawErrorMessage.split('\n')
+  if (lines.length <= maxLines) return rawErrorMessage
+
+  const note = `Showing first ${maxLines} of ${lines.length} lines. Use --full-error to print the complete raw error.`
+  const formattedNote = format === 'md' ? `_${note}_` : chalk.dim(note)
+  return [...lines.slice(0, maxLines), '', formattedNote].join('\n')
+}
+
+function testSessionErrorGroupDetailFields (
+  options: TestSessionErrorGroupFormatOptions,
+): DetailField<TestSessionErrorGroup>[] {
+  return [
+    { label: 'Error', value: (group, fmt) => formatRawErrorMessage(group.rawErrorMessage, fmt, options) },
+    { label: 'First seen', value: (group, fmt) => formatDate(group.firstSeen, fmt) },
+    { label: 'Last seen', value: (group, fmt) => formatDate(group.lastSeen, fmt) },
+    { label: 'Archived', value: group => group.archivedUntilNextEvent ? 'yes' : 'no' },
+    { label: 'Project ID', value: group => group.projectId },
+    { label: 'Environments', value: (group, fmt) => formatList(group.environments, fmt) },
+    { label: 'Error hash', value: group => group.errorHash },
+    { label: 'ID', value: group => group.id },
+  ]
+}
+
+export function formatTestSessionErrorGroupDetail (
+  group: TestSessionErrorGroup,
+  format: OutputFormat,
+  options: TestSessionErrorGroupFormatOptions = {},
+): string {
+  return renderDetailFields('Test session error group', testSessionErrorGroupDetailFields(options), group, format)
+}
+
+export function formatTestSessionDetail (
+  session: TestSessionDetail,
+  format: OutputFormat,
+  options: TestSessionFormatOptions = {},
+): string {
+  const lines: string[] = [
+    renderDetailFields(session.name, testSessionDetailFields, session, format),
+  ]
+
+  const results = session.results ?? []
+  if (results.length > 0) {
+    lines.push('')
+    lines.push(format === 'md' ? '## Results' : chalk.bold('RESULTS'))
+    lines.push('')
+    lines.push(renderTable(buildResultColumns(results, format), results, format))
+  }
+
+  const errorGroupIds = formatTestSessionErrorGroupIds(session, format, options)
+  if (errorGroupIds) {
+    lines.push('')
+    lines.push(errorGroupIds)
+  }
+
+  const hints = formatTestSessionHints(session, format)
+  if (hints) {
+    lines.push('')
+    lines.push(format === 'md' ? '## Hints' : chalk.bold('HINTS'))
+    lines.push('')
+    lines.push(hints)
+  }
+
+  return lines.join('\n')
+}

--- a/packages/cli/src/rest/__tests__/test-sessions.spec.ts
+++ b/packages/cli/src/rest/__tests__/test-sessions.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it, vi } from 'vitest'
+import TestSessions from '../test-sessions.js'
+
+describe('TestSessions REST client', () => {
+  it('gets a public test session by ID', async () => {
+    const api = {
+      get: vi.fn().mockResolvedValue({ data: { testSessionId: 'session-id', results: [] } }),
+    }
+    const testSessions = new TestSessions(api as any)
+
+    await testSessions.get('session-id')
+
+    expect(api.get).toHaveBeenCalledWith('/v1/test-sessions/session-id')
+  })
+})

--- a/packages/cli/src/rest/test-sessions.ts
+++ b/packages/cli/src/rest/test-sessions.ts
@@ -54,6 +54,8 @@ export type TestSessionMetadata = {
   branchName?: string
 }
 
+export type TestSessionStatus = 'RUNNING' | 'FAILED' | 'PASSED' | 'CANCELLED'
+
 export type TestSessionResult = {
   testSessionResultId: string
   testSessionResultLink: string
@@ -62,7 +64,7 @@ export type TestSessionResult = {
   name?: string
   runLocation?: string
   resultType?: string
-  status: string
+  status: TestSessionStatus
   hasErrors: boolean
   hasFailures: boolean
   isDegraded: boolean
@@ -74,7 +76,7 @@ export type TestSessionDetail = {
   testSessionId: string
   testSessionLink: string
   name: string
-  status: string
+  status: TestSessionStatus
   startedAt: string
   stoppedAt: string | null
   timeElapsed: number

--- a/packages/cli/src/rest/test-sessions.ts
+++ b/packages/cli/src/rest/test-sessions.ts
@@ -45,6 +45,44 @@ export type TriggerTestSessionResponse = {
   sequenceIds: Record<string, SequenceId>
 }
 
+export type TestSessionMetadata = {
+  environment?: string
+  repoUrl?: string
+  commitId?: string
+  commitOwner?: string
+  commitMessage?: string
+  branchName?: string
+}
+
+export type TestSessionResult = {
+  testSessionResultId: string
+  testSessionResultLink: string
+  checkId?: string | null
+  checkType: string
+  name?: string
+  runLocation?: string
+  resultType?: string
+  status: string
+  hasErrors: boolean
+  hasFailures: boolean
+  isDegraded: boolean
+  aborted: boolean
+  errorGroupIds?: string[]
+}
+
+export type TestSessionDetail = {
+  testSessionId: string
+  testSessionLink: string
+  name: string
+  status: string
+  startedAt: string
+  stoppedAt: string | null
+  timeElapsed: number
+  metadata?: TestSessionMetadata
+  errorGroupIds?: string[]
+  results?: TestSessionResult[]
+}
+
 export class NoMatchingChecksError extends Error {
   constructor (options?: ErrorOptions) {
     super(`No matching checks found.`, options)
@@ -85,6 +123,10 @@ class TestSessions {
 
       throw err
     }
+  }
+
+  get (id: string) {
+    return this.api.get<TestSessionDetail>(`/v1/test-sessions/${id}`)
   }
 
   getShortLink (id: string) {


### PR DESCRIPTION
## Summary

- Add `checkly test-sessions get <test-session-id>` as a read-only detail command.
- Add public REST client support for `GET /v1/test-sessions/{testSessionId}`.
- Render detail and Markdown session summaries, result tables, session links, and RCA hints from session/result `errorGroupIds`.
- Keep terminal result rows readable by putting human fields first and long IDs at the right edge.
- Add a capped `ERROR GROUP IDS` section with `--error-groups-limit`, plus singular hydrated drilldown via `--error-group <id>`.
- Keep default JSON output as the raw session API response.

Linear: https://linear.app/checklyhq/issue/AI-342/cli-add-checkly-test-sessions-get

## Validation

- `pnpm --filter checkly exec vitest --run src/commands/__tests__/test-sessions-get.spec.ts src/formatters/__tests__/test-sessions.spec.ts src/rest/__tests__/test-sessions.spec.ts src/commands/__tests__/command-metadata.spec.ts`
- `pnpm exec eslint packages/cli/src/commands/test-sessions/get.ts packages/cli/src/formatters/test-sessions.ts packages/cli/src/rest/test-sessions.ts packages/cli/src/commands/__tests__/test-sessions-get.spec.ts packages/cli/src/formatters/__tests__/test-sessions.spec.ts packages/cli/src/rest/__tests__/test-sessions.spec.ts packages/cli/src/commands/__tests__/command-metadata.spec.ts`
- `pnpm --filter checkly run prepare:dist`
- `pnpm --filter checkly run prepack`
- `packages/cli/bin/run test-sessions get --help`