### PR TITLE
docs: document slackChannels property

### DIFF
--- a/packages/cli/src/constructs/slack-app-alert-channel.ts
+++ b/packages/cli/src/constructs/slack-app-alert-channel.ts
@@ -2,6 +2,12 @@ import { AlertChannel, AlertChannelProps } from './alert-channel.js'
 import { Session } from './project.js'
 
 export interface SlackAppAlertChannelProps extends AlertChannelProps {
+  /**
+   * List of Slack #channels or @handles to notify.
+   * Private channels require the Checkly app to be invited first.
+   * @example
+   * ['#alerts', '#ops', '@alice']
+   */
   slackChannels: string[]
 }
 


### PR DESCRIPTION
## Summary
- Add JSDoc to `SlackAppAlertChannelProps.slackChannels` describing that it accepts `#channels` and `@handles`, with a note that private channels require the Checkly app to be invited first

## Test plan
- [x] Verify JSDoc renders correctly in IDE hover tooltips

🤖 Generated with [Claude Code](https://claude.com/claude-code)