### PR TITLE
docs(ai-context): sharpen Playwright Check Suite guidance

### DIFF
--- a/packages/cli/src/ai-context/references/configure-playwright-checks.md
+++ b/packages/cli/src/ai-context/references/configure-playwright-checks.md
@@ -4,5 +4,26 @@
 - `playwrightConfigPath` is resolved **relative to the `.check.ts` file that declares the construct**, not the project root. If your check lives in `monitoring/suites.check.ts` and your config in `playwright.config.ts` at the repo root, use `'../playwright.config.ts'`.
 - use `pwProjects` if you're tasked to reuse a Playwright project. Values must match the `name` field of each project in your `playwright.config.ts` (e.g. `'Cart & Checkout'`), **not** the directory slug. Mismatched names deploy silently and resolve to zero tests.
 - use `pwTags` if you're tasked to reuse a Playwright tag.
+- Use `installCommand` only when the default package-manager install command is not enough.
+- The Checkly runtime is **Linux, non-root, no C/C++ compiler**. Browsers (Chromium, Firefox, WebKit) are **pre-installed**, never install them.
+- If `scripts.postinstall` (or `prepare`, `install`) references bundled files that won't exist at runtime (`bash scripts/...`, `.husky/...`), downloads browsers (`playwright install`, `puppeteer install`), sets up git hooks, or compiles native code (`node-gyp`): use `--ignore-scripts` and rebuild deps separately.
+
+- For custom dependencies, rely on the user's `package.json` and lock file. Do not add dependencies to the check code manually.
+- For private packages or custom registries, include the registry config file, usually `.npmrc`, with the Playwright check `include` property. The `.npmrc` should reference a Checkly environment variable, for example `${NPM_TOKEN}`, and that token must be set in Checkly before deploy or trigger.
+- In Checkly CLI v8.0.0 and later, Playwright Check Suite `include` patterns resolve relative to the directory of the Playwright config file, not the project root. Example: if `playwrightConfigPath` is `./e2e/playwright.config.ts` and `.npmrc` is at the repo root, use `include: ["../.npmrc"]`.
+
+- Omit `engine` unless the user explicitly asks to override the JavaScript engine or version. If needed, import `Engine` from `checkly/constructs` and set `engine: Engine.node('24')` or `engine: Engine.bun('1.3')`. When no engine is configured or detected, Checkly defaults to Node.js 22.
+- Node.js engine majors map to pinned patch versions: `22` -> `22.14.0`, `24` -> `24.13.1`, and `26` -> `26.2.0`.
+
+```typescript
+import { PlaywrightCheck } from "checkly/constructs"
+
+new PlaywrightCheck("checkout-suite", {
+  name: "Checkout suite",
+  playwrightConfigPath: "./e2e/playwright.config.ts",
+  // Include root .npmrc for private package or registry auth.
+  include: ["../.npmrc"],
+})
+```
 
 <!-- EXAMPLE: PLAYWRIGHT_CHECK -->

--- a/packages/cli/src/ai-context/references/configure-playwright-checks.md
+++ b/packages/cli/src/ai-context/references/configure-playwright-checks.md
@@ -1,19 +1,38 @@
 # Playwright Check Suites
 
 - Import the `PlaywrightCheck` construct from `checkly/constructs`.
-- `playwrightConfigPath` is resolved **relative to the `.check.ts` file that declares the construct**, not the project root. If your check lives in `monitoring/suites.check.ts` and your config in `playwright.config.ts` at the repo root, use `'../playwright.config.ts'`.
-- use `pwProjects` if you're tasked to reuse a Playwright project. Values must match the `name` field of each project in your `playwright.config.ts` (e.g. `'Cart & Checkout'`), **not** the directory slug. Mismatched names deploy silently and resolve to zero tests.
-- use `pwTags` if you're tasked to reuse a Playwright tag.
+- Use Playwright Check Suites to run an existing Playwright project. Do not rewrite tests as Browser or Multistep Checks unless the user asks.
+- Set `playwrightConfigPath` relative to the `.check.ts` file that declares the construct, not the project root. If the check is in `monitoring/suites.check.ts` and the config is at the repo root, use `"../playwright.config.ts"`.
+- Use `pwProjects` only when the user wants specific Playwright projects. Values must match the Playwright project `name`, such as `"Cart & Checkout"`, not a folder or slug. Wrong names can deploy but run zero tests.
+- Use `pwTags` only when the user wants tag-based selection.
+
+## Dependencies
+
+- Use the user's `package.json` and lock file for dependencies. Do not add dependency declarations to check code.
+- For private packages or custom registries, include the registry config file, usually `.npmrc`, with `include`.
+- The `.npmrc` should reference a Checkly environment variable such as `${NPM_TOKEN}`. Tell the user that the token must exist in Checkly before `deploy` or `trigger`.
 - Use `installCommand` only when the default package-manager install command is not enough.
-- The Checkly runtime is **Linux, non-root, no C/C++ compiler**. Browsers (Chromium, Firefox, WebKit) are **pre-installed**, never install them.
-- If `scripts.postinstall` (or `prepare`, `install`) references bundled files that won't exist at runtime (`bash scripts/...`, `.husky/...`), downloads browsers (`playwright install`, `puppeteer install`), sets up git hooks, or compiles native code (`node-gyp`): use `--ignore-scripts` and rebuild deps separately.
+- In Checkly CLI v8.0.0 and later, `include` patterns resolve relative to the Playwright config directory, not the project root. If `playwrightConfigPath` points to a subdirectory, adjust `include` globs. Example: `playwrightConfigPath: "./e2e/playwright.config.ts"` with root `.npmrc` needs `include: ["../.npmrc"]`.
 
-- For custom dependencies, rely on the user's `package.json` and lock file. Do not add dependencies to the check code manually.
-- For private packages or custom registries, include the registry config file, usually `.npmrc`, with the Playwright check `include` property. The `.npmrc` should reference a Checkly environment variable, for example `${NPM_TOKEN}`, and that token must be set in Checkly before deploy or trigger.
-- In Checkly CLI v8.0.0 and later, Playwright Check Suite `include` patterns resolve relative to the directory of the Playwright config file, not the project root. Example: if `playwrightConfigPath` is `./e2e/playwright.config.ts` and `.npmrc` is at the repo root, use `include: ["../.npmrc"]`.
+## Install troubleshooting
 
-- Omit `engine` unless the user explicitly asks to override the JavaScript engine or version. If needed, import `Engine` from `checkly/constructs` and set `engine: Engine.node('24')` or `engine: Engine.bun('1.3')`. When no engine is configured or detected, Checkly defaults to Node.js 22.
-- Node.js engine majors map to pinned patch versions: `22` -> `22.14.0`, `24` -> `24.13.1`, and `26` -> `26.2.0`.
+- The execution environment is Linux and non-root, and it does not include a C/C++ compiler. Browsers are pre-installed, so never add `playwright install`, `npx playwright install`, Puppeteer browser downloads, or similar browser installation commands.
+- If `scripts.postinstall`, `scripts.prepare`, or `scripts.install` references missing files, downloads browsers, sets up git hooks, or compiles native code, set `installCommand` to skip project lifecycle scripts and rebuild dependency scripts:
+  - npm: `npm install --ignore-scripts && npm rebuild`
+  - pnpm: `pnpm install --ignore-scripts && pnpm rebuild`
+- Flag likely dependency problems before suggesting a deploy:
+  - `puppeteer` is usually unnecessary because browsers are pre-installed.
+  - Native dependencies that require a compiler, such as `sharp` or `better-sqlite3`, may fail.
+  - `fsevents` must be optional; a locked non-optional `fsevents` dependency can fail on Linux.
+  - `workspace:*` dependencies must be included in the uploaded bundle.
+  - Private registries must have auth configured through Checkly environment variables.
+
+## Runtime model
+
+- Do not use `runtimeId` for Playwright Check Suites. Browser and Multistep Checks use `runtimeId`; Playwright Check Suites use project dependencies plus `engine`.
+- Omit `engine` unless the user explicitly asks to override the JavaScript engine or version.
+- If an engine override is needed, import `Engine` from `checkly/constructs` and use `Engine.node("24")` or `Engine.bun("1.3")`.
+- If no engine is configured or detected, Checkly defaults to Node.js 22. Node.js engine majors map to pinned patch versions: `22` -> `22.14.0`, `24` -> `24.13.1`, and `26` -> `26.2.0`.
 
 ```typescript
 import { PlaywrightCheck } from "checkly/constructs"

--- a/packages/cli/src/ai-context/references/configure.md
+++ b/packages/cli/src/ai-context/references/configure.md
@@ -6,6 +6,8 @@
 - Use the [Checkly construct reference documentation](https://www.checklyhq.com/docs/constructs/overview/).
 - Import and / or require any constructs you need in your code, such as `ApiCheck`, `BrowserCheck`, or `PlaywrightCheck` from the `checkly/constructs` package.
 - Always ground generated code and CLI commands against the official documentation and examples in this file.
+- Use `runtimeId` for Browser Checks and MultiStep Checks. Runtimes are managed Checkly execution environments with fixed Checkly-provided dependencies such as Playwright, browser binaries, and runtime libraries.
+- Use `engine` only for Playwright Check Suites. `engine` selects the JavaScript engine version that runs the user's own Playwright project.
 
 ## Using the Checkly CLI
 
@@ -19,7 +21,7 @@
 - `*.check.ts|js` - TS / JS files that define the checks.
 - `*.spec.ts|js` - TS / JS files that contain Playwright code for Browser and MultiStep checks.
 - `src/__checks__` - Default directory where all your checks are stored. Use this directory if it already exists, otherwise create a new directory for your checks.
-- `package.json` - Standard NPM project manifest.
+- `package.json` - Standard npm project manifest.
 
 Here is an example directory tree of what that would look like:
 


### PR DESCRIPTION
- clarify whenPlaywright Check Suites vs Browser or MultiStep checks
- document custom dependency handling with package files, .npmrc, and Checkly env vars
- note v8 include patterns resolve from the Playwright config directory
- add install troubleshooting for browser downloads, lifecycle scripts, and native deps
- keep engine overrides opt-in and document Node engine versions

## Affected Components
* [X] CLI
