### PR TITLE
Add adaptive table formatter

### DIFF
--- a/packages/cli/src/formatters/README.md
+++ b/packages/cli/src/formatters/README.md
@@ -1,0 +1,16 @@
+# CLI Formatters
+
+Prefer shared formatter helpers over command-local terminal layout math.
+
+For list-style terminal output, use `renderAdaptiveTable` when columns need to fit changing terminal widths or changing response content. Command formatters should describe column intent with `minWidth`, `maxWidth`, `width`, and `align`; the renderer should handle measuring, truncating, and padding.
+
+Avoid new formatter code that:
+
+- Reads `process.stdout.columns` directly.
+- Computes `fixedWidth`, `available`, or percentage-based column widths in command formatters.
+- Calls `truncateToWidth(value, columnWidth - 2)` from every cell renderer.
+- Duplicates padding or alignment logic with `padEnd` for table columns.
+
+Use exact `width` only for genuinely stable columns, such as short status labels, frequencies, or fixed-width identifiers. Use flexible widths for user-controlled text such as names, URLs, descriptions, tags, and service names.
+
+Markdown output should usually stay untruncated. The adaptive renderer delegates markdown output to `renderTable`, so terminal-specific layout constraints do not leak into `--output md`.

--- a/packages/cli/src/formatters/__tests__/__snapshots__/checks.spec.ts.snap
+++ b/packages/cli/src/formatters/__tests__/__snapshots__/checks.spec.ts.snap
@@ -68,11 +68,11 @@ Muted Check            API         passing   10m   production, api"
 `;
 
 exports[`formatChecks > renders terminal table with showId > checks-table-terminal-with-id 1`] = `
-"NAME                   TYPE        STATUS    FREQ  TAGS                           ID
-My API Check           API         passing   10m   production, api                check-1
-Failing Browser Check  BROWSER     failing   10m   production, browser            check-2
-Inactive Check         API         inactive  10m   -                              check-3
-Muted Check            API         passing   10m   production, api                check-4"
+"NAME                   TYPE        STATUS    FREQ  TAGS                 ID
+My API Check           API         passing   10m   production, api      check-1
+Failing Browser Check  BROWSER     failing   10m   production, browser  check-2
+Inactive Check         API         inactive  10m   -                    check-3
+Muted Check            API         passing   10m   production, api      check-4"
 `;
 
 exports[`formatErrorGroups > renders markdown error groups > error-groups-md 1`] = `

--- a/packages/cli/src/formatters/__tests__/checks.spec.ts
+++ b/packages/cli/src/formatters/__tests__/checks.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { stripAnsi } from '../render.js'
+import { stripAnsi, visWidth } from '../render.js'
 import {
   formatSummaryBar,
   formatTypeBreakdown,
@@ -250,6 +250,31 @@ describe('formatChecks', () => {
     const result = formatChecks(checks, 'md')
     expect(result).toContain('| Name |')
     expect(result).toContain('| --- |')
+  })
+
+  it('adapts long terminal rows to narrow terminals', () => {
+    const columnsDescriptor = Object.getOwnPropertyDescriptor(process.stdout, 'columns')
+    Object.defineProperty(process.stdout, 'columns', { value: 60, configurable: true })
+
+    try {
+      const result = stripAnsi(formatChecks([{
+        ...passingCheck,
+        name: 'Extremely long production API check name',
+        description: 'This description is intentionally too long for a narrow terminal',
+        tags: ['production', 'critical', 'checkout', 'api'],
+      }], 'terminal'))
+
+      expect(result).toContain('…')
+      for (const line of result.split('\n')) {
+        expect(visWidth(line)).toBeLessThanOrEqual(60)
+      }
+    } finally {
+      if (columnsDescriptor) {
+        Object.defineProperty(process.stdout, 'columns', columnsDescriptor)
+      } else {
+        delete (process.stdout as NodeJS.WriteStream & { columns?: number }).columns
+      }
+    }
   })
 })
 

--- a/packages/cli/src/formatters/__tests__/render.spec.ts
+++ b/packages/cli/src/formatters/__tests__/render.spec.ts
@@ -15,6 +15,7 @@ import {
   escapeMdCell,
   renderDetailFields,
   renderTable,
+  renderAdaptiveTable,
   type DetailField,
   type ColumnDef,
 } from '../render.js'
@@ -418,6 +419,42 @@ describe('renderTable', () => {
     const lines = result.split('\n')
     // Last column value should not have trailing spaces
     expect(lines[1].trimEnd()).toBe(lines[1])
+  })
+})
+
+describe('renderAdaptiveTable', () => {
+  interface Row { name: string, type: string, note: string }
+
+  const columns: ColumnDef<Row>[] = [
+    { header: 'Name', minWidth: 8, maxWidth: 20, value: r => r.name },
+    { header: 'Type', width: 8, value: r => r.type },
+    { header: 'Note', minWidth: 8, value: r => r.note },
+  ]
+
+  const rows: Row[] = [
+    {
+      name: 'Long production check name',
+      type: 'API',
+      note: 'Monitors a very important endpoint with a verbose description',
+    },
+  ]
+
+  it('keeps terminal rows within the requested width', () => {
+    const result = stripAnsi(renderAdaptiveTable(columns, rows, 'terminal', { terminalWidth: 40 }))
+    for (const line of result.split('\n')) {
+      expect(visWidth(line)).toBeLessThanOrEqual(40)
+    }
+  })
+
+  it('truncates flexible columns instead of requiring callers to do it', () => {
+    const result = stripAnsi(renderAdaptiveTable(columns, rows, 'terminal', { terminalWidth: 40 }))
+    expect(result).toContain('…')
+  })
+
+  it('does not truncate markdown output', () => {
+    const result = renderAdaptiveTable(columns, rows, 'md', { terminalWidth: 40 })
+    expect(result).toContain('Long production check name')
+    expect(result).toContain('Monitors a very important endpoint with a verbose description')
   })
 })
 

--- a/packages/cli/src/formatters/checks.ts
+++ b/packages/cli/src/formatters/checks.ts
@@ -8,8 +8,6 @@ import {
   type OutputFormat,
   type DetailField,
   type ColumnDef,
-  truncateToWidth,
-  visWidth,
   formatFrequency,
   formatCheckType,
   formatMs,
@@ -18,6 +16,7 @@ import {
   truncateError,
   resolveResultStatus,
   renderDetailFields,
+  renderAdaptiveTable,
   renderTable,
 } from './render.js'
 
@@ -227,32 +226,25 @@ function buildCheckColumns (
   }
 
   const { showId = false } = options
-  const termWidth = process.stdout.columns || 120
-  const fixedWidth = 12 + 10 + 6
-  const idReserve = showId ? 38 : 0
   const hasDescriptions = checks.some(c => c.description)
-  const available = termWidth - fixedWidth - idReserve
-  const longestName = Math.max(4, ...checks.map(c => visWidth(c.name)))
-  const nameWidth = Math.min(longestName + 2, 42)
-  const flexSpace = Math.max(8, available - nameWidth)
-  const descWidth = hasDescriptions ? Math.min(30, Math.floor(flexSpace * 0.4)) : 0
-  const tagWidth = flexSpace - descWidth
 
   const columns: ColumnDef<CheckWithStatus>[] = [
     {
       header: 'Name',
-      width: nameWidth,
-      value: c => truncateToWidth(c.name, nameWidth - 2),
+      minWidth: 12,
+      maxWidth: 42,
+      value: c => c.name,
     },
   ]
 
   if (hasDescriptions) {
     columns.push({
       header: 'Description',
-      width: descWidth,
+      minWidth: 12,
+      maxWidth: 30,
       value: c => {
         if (!c.description) return chalk.dim('-')
-        return truncateToWidth(c.description, descWidth - 2)
+        return c.description
       },
     })
   }
@@ -277,14 +269,13 @@ function buildCheckColumns (
 
   columns.push({
     header: 'Tags',
-    ...(showId && { width: tagWidth }),
+    minWidth: 8,
     value: c => {
-      const tags = c.tags.length > 0 ? c.tags.join(', ') : chalk.dim('-')
-      return truncateToWidth(tags, tagWidth - 2)
+      return c.tags.length > 0 ? c.tags.join(', ') : chalk.dim('-')
     },
   })
   if (showId) {
-    columns.push({ header: 'ID', value: c => chalk.dim(c.id) })
+    columns.push({ header: 'ID', width: 38, value: c => chalk.dim(c.id) })
   }
 
   return columns
@@ -295,7 +286,7 @@ export function formatChecks (
   options: TableOptions & { pagination?: PaginationInfo } = {},
 ): string {
   const columns = buildCheckColumns(checks, format, options)
-  let result = renderTable(columns, checks, format)
+  let result = renderAdaptiveTable(columns, checks, format)
 
   if (format === 'md' && options.pagination) {
     const { page, limit, total } = options.pagination

--- a/packages/cli/src/formatters/render.ts
+++ b/packages/cli/src/formatters/render.ts
@@ -118,8 +118,15 @@ export interface DetailField<T> {
 export interface ColumnDef<T> {
   header: string
   width?: number
+  minWidth?: number
+  maxWidth?: number
+  truncate?: boolean
   align?: 'left' | 'right'
   value: (item: T, format: OutputFormat) => string
+}
+
+export interface AdaptiveTableOptions {
+  terminalWidth?: number
 }
 
 export function renderDetailFields<T> (
@@ -198,6 +205,115 @@ export function renderTable<T> (
       if (i === lastIdx && col.align !== 'right') return val
       return padColumn(val, col.width, col.align, i < lastIdx)
     }).join(''),
+  )
+
+  return [headerParts.join(''), ...dataRows].join('\n')
+}
+
+function naturalColumnWidth (header: string, values: string[], trailingGap: boolean): number {
+  const contentWidth = Math.max(visWidth(header.toUpperCase()), ...values.map(visWidth))
+  return contentWidth + (trailingGap ? RIGHT_ALIGN_GAP : 0)
+}
+
+function shrinkToFit (widths: number[], minWidths: number[], overage: number): void {
+  let remaining = overage
+
+  while (remaining > 0) {
+    const shrinkable = widths
+      .map((width, index) => ({ index, room: width - minWidths[index] }))
+      .filter(col => col.room > 0)
+
+    if (shrinkable.length === 0) break
+
+    let shrunk = 0
+    for (const col of shrinkable) {
+      const reduction = Math.min(col.room, 1)
+      widths[col.index] -= reduction
+      remaining -= reduction
+      shrunk += reduction
+      if (remaining === 0) break
+    }
+
+    if (shrunk === 0) break
+  }
+}
+
+function resolveAdaptiveWidths<T> (
+  columns: ColumnDef<T>[],
+  resolvedRows: string[][],
+  terminalWidth: number,
+): number[] {
+  const lastIdx = columns.length - 1
+  const widths: number[] = []
+  const minWidths: number[] = []
+
+  for (const [index, column] of columns.entries()) {
+    const trailingGap = index < lastIdx
+    if (column.width != null) {
+      widths[index] = column.width
+      minWidths[index] = column.width
+      continue
+    }
+
+    const values = resolvedRows.map(row => row[index])
+    const natural = naturalColumnWidth(column.header, values, trailingGap)
+    const min = column.minWidth ?? natural
+    const max = column.maxWidth ?? Number.POSITIVE_INFINITY
+    widths[index] = Math.max(min, Math.min(natural, max))
+    minWidths[index] = min
+  }
+
+  const total = () => widths.reduce((sum, width) => sum + width, 0)
+  const overage = total() - terminalWidth
+
+  if (overage > 0) {
+    shrinkToFit(widths, minWidths, overage)
+  }
+
+  return widths
+}
+
+function formatAdaptiveCell<T> (
+  value: string,
+  column: ColumnDef<T>,
+  width: number,
+  columnIndex: number,
+  lastIndex: number,
+): string {
+  const trailingGap = columnIndex < lastIndex
+  const shouldTruncate = column.truncate ?? column.width == null
+  let display = value
+
+  if (shouldTruncate) {
+    const gap = column.align === 'right' ? 0 : (trailingGap ? RIGHT_ALIGN_GAP : 0)
+    display = truncateToWidth(display, Math.max(1, width - gap))
+  }
+
+  if (columnIndex === lastIndex && column.align !== 'right') return display
+  return padColumn(display, width, column.align, trailingGap)
+}
+
+export function renderAdaptiveTable<T> (
+  columns: ColumnDef<T>[],
+  rows: T[],
+  format: OutputFormat,
+  options: AdaptiveTableOptions = {},
+): string {
+  if (format === 'md') return renderTable(columns, rows, format)
+
+  const resolvedRows = rows.map(row => columns.map(col => col.value(row, format)))
+  const terminalWidth = options.terminalWidth ?? (process.stdout.columns || 120)
+  const widths = resolveAdaptiveWidths(columns, resolvedRows, terminalWidth)
+  const lastIdx = columns.length - 1
+
+  const headerParts = columns.map((col, i) =>
+    formatAdaptiveCell(chalk.bold(col.header.toUpperCase()), col, widths[i], i, lastIdx),
+  )
+
+  const dataRows = resolvedRows.map(row =>
+    row.map((value, i) =>
+      formatAdaptiveCell(value, columns[i], widths[i], i, lastIdx),
+    ).join(''),
   )
 
   return [headerParts.join(''), ...dataRows].join('\n')


### PR DESCRIPTION
## Summary

- add `renderAdaptiveTable` so formatter columns can declare layout intent instead of computing terminal widths locally
- migrate `checks list` to the adaptive renderer as the first command example
- document formatter guidance to avoid reintroducing hard-coded table width math

## Validation

- `pnpm --filter checkly exec tsc --noEmit --pretty false`
- `pnpm --filter checkly exec eslint src/formatters/render.ts src/formatters/checks.ts src/formatters/__tests__/render.spec.ts src/formatters/__tests__/checks.spec.ts`
- `pnpm --filter checkly exec vitest --run ./src/formatters/__tests__/render.spec.ts ./src/formatters/__tests__/checks.spec.ts`

Note: formatter tests require the local `checkly-0.0.1-dev.tgz` fixture package, created with `npm pack --ignore-scripts --silent` and removed after the test run.