### PR TITLE
feat(cli): watch test session completion

### DIFF
--- a/packages/cli/src/commands/__tests__/test-sessions-get.spec.ts
+++ b/packages/cli/src/commands/__tests__/test-sessions-get.spec.ts
@@ -3,7 +3,7 @@ import type { TestSessionErrorGroup } from '../../rest/test-session-error-groups
 import type { TestSessionDetail } from '../../rest/test-sessions.js'
 
 vi.mock('../../rest/api.js', () => ({
-  testSessions: { get: vi.fn() },
+  testSessions: { get: vi.fn(), waitForCompletion: vi.fn() },
   testSessionErrorGroups: { get: vi.fn() },
 }))
 
@@ -61,6 +61,9 @@ function createCommandContext (parsed: unknown) {
     style: {
       outputFormat: undefined,
       longError: vi.fn(),
+      actionStart: vi.fn(),
+      actionSuccess: vi.fn(),
+      actionFailure: vi.fn(),
     },
     logged,
   }
@@ -71,6 +74,7 @@ describe('test-sessions get command', () => {
     vi.clearAllMocks()
     process.exitCode = undefined
     vi.mocked(api.testSessions.get).mockResolvedValue({ data: testSession } as any)
+    vi.mocked(api.testSessions.waitForCompletion).mockResolvedValue(testSession as any)
     vi.mocked(api.testSessionErrorGroups.get).mockResolvedValue({ data: testSessionErrorGroup } as any)
   })
 
@@ -91,6 +95,39 @@ describe('test-sessions get command', () => {
     expect(ctx.logged[0]).toContain(testSession.testSessionLink)
   })
 
+  it('waits for completion before rendering detail output', async () => {
+    const completed = { ...testSession, status: 'PASSED' as const }
+    vi.mocked(api.testSessions.waitForCompletion).mockResolvedValue(completed as any)
+    const ctx = createCommandContext({
+      args: { id: testSession.testSessionId },
+      flags: { output: 'detail', wait: true },
+    })
+
+    await TestSessionsGet.prototype.run.call(ctx as any)
+
+    expect(api.testSessions.get).not.toHaveBeenCalled()
+    expect(api.testSessions.waitForCompletion).toHaveBeenCalledWith(testSession.testSessionId)
+    expect(ctx.style.actionStart).toHaveBeenCalledWith('Waiting for test session to complete...')
+    expect(ctx.style.actionSuccess).toHaveBeenCalled()
+    expect(ctx.logged[0]).toContain('Production smoke test')
+    expect(ctx.logged[0]).toContain('passed')
+  })
+
+  it('waits for completion before returning raw json output', async () => {
+    const completed = { ...testSession, status: 'PASSED' as const }
+    vi.mocked(api.testSessions.waitForCompletion).mockResolvedValue(completed as any)
+    const ctx = createCommandContext({
+      args: { id: testSession.testSessionId },
+      flags: { output: 'json', wait: true },
+    })
+
+    await TestSessionsGet.prototype.run.call(ctx as any)
+
+    expect(api.testSessions.get).not.toHaveBeenCalled()
+    expect(JSON.parse(ctx.logged[0])).toEqual(completed)
+    expect(ctx.style.actionStart).not.toHaveBeenCalled()
+  })
+
   it('fetches and renders one test session error group detail', async () => {
     const ctx = createCommandContext({
       args: { id: testSession.testSessionId },
@@ -103,6 +140,25 @@ describe('test-sessions get command', () => {
     expect(api.testSessionErrorGroups.get).toHaveBeenCalledWith('result-eg-1')
     expect(ctx.logged[0]).toContain('Test session error group')
     expect(ctx.logged[0]).toContain('Error: boom')
+  })
+
+  it('waits for completion before checking a test session error group', async () => {
+    vi.mocked(api.testSessions.waitForCompletion).mockResolvedValue({
+      ...testSession,
+      errorGroupIds: [],
+      results: [{ ...testSession.results[0], errorGroupIds: ['result-eg-1'] }],
+    } as any)
+    const ctx = createCommandContext({
+      args: { id: testSession.testSessionId },
+      flags: { 'error-group': 'result-eg-1', 'full-error': false, 'output': 'detail', 'wait': true },
+    })
+
+    await TestSessionsGet.prototype.run.call(ctx as any)
+
+    expect(api.testSessions.get).not.toHaveBeenCalled()
+    expect(api.testSessions.waitForCompletion).toHaveBeenCalledWith(testSession.testSessionId)
+    expect(api.testSessionErrorGroups.get).toHaveBeenCalledWith('result-eg-1')
+    expect(ctx.logged[0]).toContain('Test session error group')
   })
 
   it('limits long test session error group detail output by default', async () => {

--- a/packages/cli/src/commands/__tests__/test-sessions-get.spec.ts
+++ b/packages/cli/src/commands/__tests__/test-sessions-get.spec.ts
@@ -3,7 +3,7 @@ import type { TestSessionErrorGroup } from '../../rest/test-session-error-groups
 import type { TestSessionDetail } from '../../rest/test-sessions.js'
 
 vi.mock('../../rest/api.js', () => ({
-  testSessions: { get: vi.fn(), waitForCompletion: vi.fn() },
+  testSessions: { get: vi.fn(), pollUntilComplete: vi.fn() },
   testSessionErrorGroups: { get: vi.fn() },
 }))
 
@@ -74,7 +74,7 @@ describe('test-sessions get command', () => {
     vi.clearAllMocks()
     process.exitCode = undefined
     vi.mocked(api.testSessions.get).mockResolvedValue({ data: testSession } as any)
-    vi.mocked(api.testSessions.waitForCompletion).mockResolvedValue(testSession as any)
+    vi.mocked(api.testSessions.pollUntilComplete).mockResolvedValue(testSession as any)
     vi.mocked(api.testSessionErrorGroups.get).mockResolvedValue({ data: testSessionErrorGroup } as any)
   })
 
@@ -95,30 +95,30 @@ describe('test-sessions get command', () => {
     expect(ctx.logged[0]).toContain(testSession.testSessionLink)
   })
 
-  it('waits for completion before rendering detail output', async () => {
+  it('watches completion before rendering detail output', async () => {
     const completed = { ...testSession, status: 'PASSED' as const }
-    vi.mocked(api.testSessions.waitForCompletion).mockResolvedValue(completed as any)
+    vi.mocked(api.testSessions.pollUntilComplete).mockResolvedValue(completed as any)
     const ctx = createCommandContext({
       args: { id: testSession.testSessionId },
-      flags: { output: 'detail', wait: true },
+      flags: { output: 'detail', watch: true },
     })
 
     await TestSessionsGet.prototype.run.call(ctx as any)
 
     expect(api.testSessions.get).not.toHaveBeenCalled()
-    expect(api.testSessions.waitForCompletion).toHaveBeenCalledWith(testSession.testSessionId)
-    expect(ctx.style.actionStart).toHaveBeenCalledWith('Waiting for test session to complete...')
+    expect(api.testSessions.pollUntilComplete).toHaveBeenCalledWith(testSession.testSessionId)
+    expect(ctx.style.actionStart).toHaveBeenCalledWith('Watching test session until completion...')
     expect(ctx.style.actionSuccess).toHaveBeenCalled()
     expect(ctx.logged[0]).toContain('Production smoke test')
     expect(ctx.logged[0]).toContain('passed')
   })
 
-  it('waits for completion before returning raw json output', async () => {
+  it('watches completion before returning raw json output', async () => {
     const completed = { ...testSession, status: 'PASSED' as const }
-    vi.mocked(api.testSessions.waitForCompletion).mockResolvedValue(completed as any)
+    vi.mocked(api.testSessions.pollUntilComplete).mockResolvedValue(completed as any)
     const ctx = createCommandContext({
       args: { id: testSession.testSessionId },
-      flags: { output: 'json', wait: true },
+      flags: { output: 'json', watch: true },
     })
 
     await TestSessionsGet.prototype.run.call(ctx as any)
@@ -142,21 +142,21 @@ describe('test-sessions get command', () => {
     expect(ctx.logged[0]).toContain('Error: boom')
   })
 
-  it('waits for completion before checking a test session error group', async () => {
-    vi.mocked(api.testSessions.waitForCompletion).mockResolvedValue({
+  it('watches completion before checking a test session error group', async () => {
+    vi.mocked(api.testSessions.pollUntilComplete).mockResolvedValue({
       ...testSession,
       errorGroupIds: [],
       results: [{ ...testSession.results[0], errorGroupIds: ['result-eg-1'] }],
     } as any)
     const ctx = createCommandContext({
       args: { id: testSession.testSessionId },
-      flags: { 'error-group': 'result-eg-1', 'full-error': false, 'output': 'detail', 'wait': true },
+      flags: { 'error-group': 'result-eg-1', 'full-error': false, 'output': 'detail', 'watch': true },
     })
 
     await TestSessionsGet.prototype.run.call(ctx as any)
 
     expect(api.testSessions.get).not.toHaveBeenCalled()
-    expect(api.testSessions.waitForCompletion).toHaveBeenCalledWith(testSession.testSessionId)
+    expect(api.testSessions.pollUntilComplete).toHaveBeenCalledWith(testSession.testSessionId)
     expect(api.testSessionErrorGroups.get).toHaveBeenCalledWith('result-eg-1')
     expect(ctx.logged[0]).toContain('Test session error group')
   })

--- a/packages/cli/src/commands/test-sessions/get.ts
+++ b/packages/cli/src/commands/test-sessions/get.ts
@@ -8,6 +8,7 @@ import {
   uniqueErrorGroupIds,
 } from '../../formatters/test-sessions.js'
 import { type OutputFormat } from '../../formatters/render.js'
+import type { TestSessionDetail } from '../../rest/test-sessions.js'
 
 export default class TestSessionsGet extends AuthCommand {
   static hidden = false
@@ -34,6 +35,11 @@ export default class TestSessionsGet extends AuthCommand {
       description: 'Print the complete raw error when showing a test session error group.',
       default: false,
     }),
+    'wait': Flags.boolean({
+      char: 'w',
+      description: 'Wait for a running test session to complete before rendering.',
+      default: false,
+    }),
     'output': outputFlag({ default: 'detail' }),
   }
 
@@ -42,7 +48,28 @@ export default class TestSessionsGet extends AuthCommand {
     this.style.outputFormat = flags.output
 
     try {
-      const { data: testSession } = await api.testSessions.get(args.id)
+      let testSession: TestSessionDetail
+
+      if (flags.wait) {
+        const showAction = flags.output === 'detail'
+        if (showAction) {
+          this.style.actionStart('Waiting for test session to complete...')
+        }
+        try {
+          testSession = await api.testSessions.waitForCompletion(args.id)
+          if (showAction) {
+            this.style.actionSuccess()
+          }
+        } catch (err) {
+          if (showAction) {
+            this.style.actionFailure()
+          }
+          throw err
+        }
+      } else {
+        const { data } = await api.testSessions.get(args.id)
+        testSession = data
+      }
 
       if (flags['error-group']) {
         const errorGroupIds = uniqueErrorGroupIds(testSession)

--- a/packages/cli/src/commands/test-sessions/get.ts
+++ b/packages/cli/src/commands/test-sessions/get.ts
@@ -35,9 +35,9 @@ export default class TestSessionsGet extends AuthCommand {
       description: 'Print the complete raw error when showing a test session error group.',
       default: false,
     }),
-    'wait': Flags.boolean({
+    'watch': Flags.boolean({
       char: 'w',
-      description: 'Wait for a running test session to complete before rendering.',
+      description: 'Watch a running test session until it completes before rendering.',
       default: false,
     }),
     'output': outputFlag({ default: 'detail' }),
@@ -50,13 +50,13 @@ export default class TestSessionsGet extends AuthCommand {
     try {
       let testSession: TestSessionDetail
 
-      if (flags.wait) {
+      if (flags.watch) {
         const showAction = flags.output === 'detail'
         if (showAction) {
-          this.style.actionStart('Waiting for test session to complete...')
+          this.style.actionStart('Watching test session until completion...')
         }
         try {
-          testSession = await api.testSessions.waitForCompletion(args.id)
+          testSession = await api.testSessions.pollUntilComplete(args.id)
           if (showAction) {
             this.style.actionSuccess()
           }

--- a/packages/cli/src/rest/__tests__/test-sessions.spec.ts
+++ b/packages/cli/src/rest/__tests__/test-sessions.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import TestSessions from '../test-sessions.js'
+import { RequestTimeoutError } from '../errors.js'
 
 describe('TestSessions REST client', () => {
   it('gets a public test session by ID', async () => {
@@ -11,5 +12,40 @@ describe('TestSessions REST client', () => {
     await testSessions.get('session-id')
 
     expect(api.get).toHaveBeenCalledWith('/v1/test-sessions/session-id')
+  })
+
+  it('gets public test session completion by ID', async () => {
+    const api = {
+      get: vi.fn().mockResolvedValue({ data: { testSessionId: 'session-id', status: 'PASSED', results: [] } }),
+    }
+    const testSessions = new TestSessions(api as any)
+
+    await testSessions.getCompletion('session-id')
+
+    expect(api.get).toHaveBeenCalledWith('/v1/test-sessions/session-id/completion', {
+      params: { maxWaitSeconds: 30 },
+    })
+  })
+
+  it('retries public test session completion timeouts until complete', async () => {
+    const completed = { testSessionId: 'session-id', status: 'PASSED', results: [] }
+    const api = {
+      get: vi.fn()
+        .mockRejectedValueOnce(new RequestTimeoutError({
+          statusCode: 408,
+          error: 'Request Timeout',
+          message: 'Test session is still in progress, but maximum per-request wait time was exceeded. Please retry.',
+        }))
+        .mockResolvedValueOnce({ data: completed }),
+    }
+    const testSessions = new TestSessions(api as any)
+
+    const result = await testSessions.waitForCompletion('session-id')
+
+    expect(result).toEqual(completed)
+    expect(api.get).toHaveBeenCalledTimes(2)
+    expect(api.get).toHaveBeenCalledWith('/v1/test-sessions/session-id/completion', {
+      params: { maxWaitSeconds: 30 },
+    })
   })
 })

--- a/packages/cli/src/rest/__tests__/test-sessions.spec.ts
+++ b/packages/cli/src/rest/__tests__/test-sessions.spec.ts
@@ -27,7 +27,7 @@ describe('TestSessions REST client', () => {
     })
   })
 
-  it('retries public test session completion timeouts until complete', async () => {
+  it('polls public test session completion timeouts until complete', async () => {
     const completed = { testSessionId: 'session-id', status: 'PASSED', results: [] }
     const api = {
       get: vi.fn()
@@ -40,7 +40,7 @@ describe('TestSessions REST client', () => {
     }
     const testSessions = new TestSessions(api as any)
 
-    const result = await testSessions.waitForCompletion('session-id')
+    const result = await testSessions.pollUntilComplete('session-id')
 
     expect(result).toEqual(completed)
     expect(api.get).toHaveBeenCalledTimes(2)

--- a/packages/cli/src/rest/test-sessions.ts
+++ b/packages/cli/src/rest/test-sessions.ts
@@ -3,7 +3,9 @@ import { GitInformation } from '../services/util.js'
 import { RetryStrategy, SharedFile } from '../constructs/index.js'
 import { compressJSONPayload } from './util.js'
 import { SequenceId } from '../services/abstract-check-runner.js'
-import { ForbiddenError } from './errors.js'
+import { ForbiddenError, RequestTimeoutError } from './errors.js'
+
+const COMPLETION_MAX_WAIT_SECONDS = 30
 
 type RunTestSessionRequest = {
   name: string
@@ -130,6 +132,26 @@ class TestSessions {
 
   get (id: string) {
     return this.api.get<TestSessionDetail>(`/v1/test-sessions/${id}`)
+  }
+
+  getCompletion (id: string, maxWaitSeconds = COMPLETION_MAX_WAIT_SECONDS) {
+    return this.api.get<TestSessionDetail>(`/v1/test-sessions/${id}/completion`, {
+      params: { maxWaitSeconds },
+    })
+  }
+
+  async waitForCompletion (id: string): Promise<TestSessionDetail> {
+    while (true) {
+      try {
+        const { data } = await this.getCompletion(id)
+        return data
+      } catch (err) {
+        if (err instanceof RequestTimeoutError) {
+          continue
+        }
+        throw err
+      }
+    }
   }
 
   getShortLink (id: string) {

--- a/packages/cli/src/rest/test-sessions.ts
+++ b/packages/cli/src/rest/test-sessions.ts
@@ -140,7 +140,7 @@ class TestSessions {
     })
   }
 
-  async waitForCompletion (id: string): Promise<TestSessionDetail> {
+  async pollUntilComplete (id: string): Promise<TestSessionDetail> {
     while (true) {
       try {
         const { data } = await this.getCompletion(id)


### PR DESCRIPTION
## Summary
- add `checkly test-sessions get <id> --watch` / `-w`
- poll `GET /v1/test-sessions/{testSessionId}/completion` until a completed session response is returned
- reuse existing test-session rendering and error-group drilldown after completion

## Validation
- `pnpm exec vitest --run ./src/commands/__tests__/test-sessions-get.spec.ts ./src/rest/__tests__/test-sessions.spec.ts ./src/formatters/__tests__/test-sessions.spec.ts ./src/commands/__tests__/command-metadata.spec.ts`
- `pnpm exec eslint src/commands/test-sessions/get.ts src/commands/__tests__/test-sessions-get.spec.ts src/rest/test-sessions.ts src/rest/__tests__/test-sessions.spec.ts src/formatters/test-sessions.ts src/formatters/__tests__/test-sessions.spec.ts src/commands/__tests__/command-metadata.spec.ts`
- `pnpm run prepare:dist`
- `pnpm run prepack`