### PR TITLE
feat(cli): add test sessions list command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# Agent Guidelines
+
+This repo has a lot of historical CLI surface area. Consistency still matters:
+when existing commands disagree, do not copy the first nearby example blindly.
+Identify the closest current precedent, make the choice explicit in the PR, and
+add tests that lock in the intended shape.
+
+## CLI Command Conventions
+
+- New commands live under `packages/cli/src/commands/` and should follow the
+  existing `AuthCommand` / oclif metadata pattern: `hidden`, `readOnly`,
+  `destructive`, and `idempotent` must be intentional.
+- Prefer the newest command with the same interaction model as the precedent.
+  For cursor-paginated list commands, use `status-pages list` as the canonical
+  current example.
+- Do not invent compact table encodings that require users to know column order
+  or hidden semantics. Prefer explicit columns and readable labels, even if the
+  table is wider.
+- If a command depends on a backend/API PR that is not merged yet, call that out
+  in the PR body with a direct link and state whether the CLI PR is blocked from
+  merge or release.
+
+## List Command JSON Output
+
+List commands should expose JSON in a stable CLI envelope instead of leaking
+whatever shape the backing endpoint happens to return.
+
+- Offset-paginated lists should use:
+  `{ data, pagination: { page, limit, total, totalPages } }`
+- Cursor-paginated lists should use:
+  `{ data, pagination: { nextId, length } }`
+- `data` should contain the list entries, not the full API response object.
+- Returning the raw API body is appropriate for `get`/detail commands where the
+  command is intentionally exposing one resource payload.
+
+If an older command does not follow this yet, do not spread the inconsistency to
+new commands. Either follow the canonical shape above or explain the deviation
+in the PR.
+
+## Review Checklist for CLI Additions
+
+- Compare flag names, default limits, pagination behavior, JSON shape, and table
+  layout against the closest current command before implementing.
+- Add tests for REST parameter mapping, JSON output shape, empty/error paths,
+  and any generated follow-up commands shown to users.
+- Run focused lint, focused Vitest, `prepare:dist`, `prepack`, and a help-output
+  smoke test for the new command when feasible.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,9 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+Also read `AGENTS.md` for shared agent conventions that apply across coding
+assistants, especially CLI command shape and output consistency rules.
+
 ## Build and Development
 
 This is a **pnpm monorepo** with two packages: `packages/cli` (the main `checkly` CLI) and `packages/create-cli` (the `create-checkly` scaffolding tool). Both are ESM-only TypeScript.

--- a/packages/cli/src/commands/__tests__/command-metadata.spec.ts
+++ b/packages/cli/src/commands/__tests__/command-metadata.spec.ts
@@ -37,6 +37,7 @@ import SkillsInstall from '../skills/install.js'
 import AccountPlan from '../account/plan.js'
 import AccountMembers from '../account/members.js'
 import Api from '../api.js'
+import TestSessionsList from '../test-sessions/list.js'
 import TestSessionsGet from '../test-sessions/get.js'
 
 const commands: Array<[string, typeof BaseCommand]> = [
@@ -48,6 +49,7 @@ const commands: Array<[string, typeof BaseCommand]> = [
   ['checks stats', ChecksStats],
   ['status-pages list', StatusPagesList],
   ['status-pages get', StatusPagesGet],
+  ['test-sessions list', TestSessionsList],
   ['test-sessions get', TestSessionsGet],
   ['incidents list', IncidentsList],
   ['incidents create', IncidentsCreate],

--- a/packages/cli/src/commands/__tests__/test-sessions-list.spec.ts
+++ b/packages/cli/src/commands/__tests__/test-sessions-list.spec.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TestSessionsListResponse } from '../../rest/test-sessions.js'
+
+vi.mock('../../rest/api.js', () => ({
+  testSessions: { list: vi.fn() },
+}))
+
+import * as api from '../../rest/api.js'
+import TestSessionsList from '../test-sessions/list.js'
+
+const listResponse: TestSessionsListResponse = {
+  length: 1,
+  nextId: 'cursor-2',
+  entries: [
+    {
+      id: '8166fa86-c9b4-4162-8541-d380c6c212d8',
+      accountId: 'account-id',
+      projectId: 'project-id',
+      name: 'Production smoke test',
+      provider: 'API',
+      running: [],
+      passed: [],
+      failed: ['seq-1'],
+      cancelled: [],
+      status: 'FAILED',
+      region: 'eu-west-1',
+      privateLocationId: null,
+      invoker: { name: 'Invoker User' },
+      repoUrl: null,
+      commitId: null,
+      commitOwner: 'Herve',
+      commitMessage: null,
+      branchName: 'main',
+      environment: 'production',
+      startedAt: '2026-05-20T08:00:00.000Z',
+      stoppedAt: '2026-05-20T08:02:03.456Z',
+      created_at: '2026-05-20T08:00:00.000Z',
+      updated_at: '2026-05-20T08:02:03.456Z',
+    },
+  ],
+}
+
+function createCommandContext (parsed: unknown) {
+  const logged: string[] = []
+  return {
+    parse: vi.fn().mockResolvedValue(parsed),
+    error: vi.fn((message: string) => {
+      throw new Error(message)
+    }),
+    log: vi.fn((msg?: string) => {
+      if (msg) logged.push(msg)
+    }),
+    style: {
+      outputFormat: undefined,
+      longError: vi.fn(),
+    },
+    logged,
+  }
+}
+
+describe('test-sessions list command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.exitCode = undefined
+    vi.mocked(api.testSessions.list).mockResolvedValue({ data: listResponse } as any)
+  })
+
+  it('maps list flags to public API query params and renders table output', async () => {
+    const ctx = createCommandContext({
+      flags: {
+        'limit': 10,
+        'cursor': 'cursor-1',
+        'from': '2026-05-20T00:00:00Z',
+        'to': '2026-05-21T00:00:00Z',
+        'status': ['failed'],
+        'branch': ['main'],
+        'user': ['Herve'],
+        'no-users': true,
+        'provider': ['api'],
+        'search': 'smoke',
+        'error-group': 'error-group-id',
+        'output': 'table',
+      },
+    })
+
+    await TestSessionsList.prototype.run.call(ctx as any)
+
+    expect(api.testSessions.list).toHaveBeenCalledWith({
+      from: 1_779_235_200,
+      to: 1_779_321_600,
+      limit: 10,
+      statuses: ['FAILED'],
+      branches: ['main'],
+      users: ['Herve'],
+      providers: ['API'],
+      noUsers: true,
+      nextId: 'cursor-1',
+      textSearch: 'smoke',
+      errorGroupId: 'error-group-id',
+    })
+    expect(ctx.logged[0]).toContain('Production smok')
+    expect(ctx.logged[0]).toContain('FAILED')
+    expect(ctx.logged[0]).toContain('1')
+    expect(ctx.logged[0]).toContain('checkly test-sessions list --limit 10')
+    expect(ctx.logged[0]).toContain('--cursor cursor-2')
+    expect(ctx.logged[0]).toContain('checkly test-sessions get 8166fa86-c9b4-4162-8541-d380c6c212d8')
+  })
+
+  it('returns cursor pagination envelope for json output', async () => {
+    const ctx = createCommandContext({
+      flags: {
+        limit: 20,
+        output: 'json',
+      },
+    })
+
+    await TestSessionsList.prototype.run.call(ctx as any)
+
+    expect(JSON.parse(ctx.logged[0])).toEqual({
+      data: listResponse.entries,
+      pagination: {
+        nextId: listResponse.nextId,
+        length: listResponse.length,
+      },
+    })
+  })
+
+  it('renders markdown output', async () => {
+    const ctx = createCommandContext({
+      flags: {
+        limit: 20,
+        output: 'md',
+      },
+    })
+
+    await TestSessionsList.prototype.run.call(ctx as any)
+
+    expect(ctx.logged[0]).toContain('| Status | Started | Name | Provider | Branch | User | Running | Passed | Failed | Cancelled | ID |')
+    expect(ctx.logged[0]).toContain('| failed |')
+  })
+
+  it('rejects invalid time filters', async () => {
+    const ctx = createCommandContext({
+      flags: {
+        limit: 20,
+        from: 'not-a-date',
+        output: 'table',
+      },
+    })
+
+    await expect(TestSessionsList.prototype.run.call(ctx as any))
+      .rejects
+      .toThrow('Invalid --from "not-a-date". Use an ISO date or Unix timestamp in seconds.')
+    expect(api.testSessions.list).not.toHaveBeenCalled()
+  })
+
+  it('reports API failures without throwing', async () => {
+    const ctx = createCommandContext({
+      flags: {
+        limit: 20,
+        output: 'table',
+      },
+    })
+    vi.mocked(api.testSessions.list).mockRejectedValue(new Error('boom'))
+
+    await TestSessionsList.prototype.run.call(ctx as any)
+
+    expect(ctx.style.longError).toHaveBeenCalledWith('Failed to list test sessions.', expect.any(Error))
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('shell-quotes filters when rendering the next page command', async () => {
+    const ctx = createCommandContext({
+      flags: {
+        limit: 20,
+        branch: ['feature with space'],
+        search: 'smoke $(echo unsafe)',
+        output: 'table',
+      },
+    })
+
+    await TestSessionsList.prototype.run.call(ctx as any)
+
+    expect(ctx.logged[0]).toContain(`--branch 'feature with space'`)
+    expect(ctx.logged[0]).toContain(`--search 'smoke $(echo unsafe)'`)
+  })
+})

--- a/packages/cli/src/commands/test-sessions/list.ts
+++ b/packages/cli/src/commands/test-sessions/list.ts
@@ -1,0 +1,219 @@
+import { Flags } from '@oclif/core'
+import { AuthCommand } from '../authCommand.js'
+import { outputFlag } from '../../helpers/flags.js'
+import * as api from '../../rest/api.js'
+import type { ListTestSessionsParams, TestSessionProvider, TestSessionStatus } from '../../rest/test-sessions.js'
+import type { OutputFormat } from '../../formatters/render.js'
+import {
+  formatTestSessionsList,
+  formatTestSessionsListNavigationHints,
+  formatTestSessionsListPaginationInfo,
+} from '../../formatters/test-sessions.js'
+
+const statusOptions = ['running', 'failed', 'passed', 'cancelled'] as const
+const providerOptions = ['github', 'vercel', 'api', 'trigger', 'pw_reporter'] as const
+
+function quoteArg (value: string): string {
+  if (/^[A-Za-z0-9._/@:+=,-]+$/.test(value)) return value
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+function parseUnixTimestamp (value: string | undefined, label: string): number | undefined {
+  if (!value) return undefined
+
+  const trimmed = value.trim()
+  if (/^\d+$/.test(trimmed)) {
+    return Number(trimmed)
+  }
+
+  const timestamp = Date.parse(trimmed)
+  if (Number.isNaN(timestamp)) {
+    throw new Error(`Invalid --${label} "${value}". Use an ISO date or Unix timestamp in seconds.`)
+  }
+
+  return Math.floor(timestamp / 1000)
+}
+
+function normalizeStatus (value: string): TestSessionStatus | undefined {
+  const normalized = value.trim().toUpperCase()
+  return ['RUNNING', 'FAILED', 'PASSED', 'CANCELLED'].includes(normalized)
+    ? normalized as TestSessionStatus
+    : undefined
+}
+
+function normalizeProvider (value: string): TestSessionProvider | undefined {
+  const normalized = value.trim().replace(/-/g, '_').toUpperCase()
+  return ['GITHUB', 'VERCEL', 'API', 'TRIGGER', 'PW_REPORTER'].includes(normalized)
+    ? normalized as TestSessionProvider
+    : undefined
+}
+
+function buildListCommand (flags: Record<string, any>): string {
+  const parts = ['checkly test-sessions list', '--limit', String(flags.limit)]
+
+  const appendMany = (flag: string, values: string[] | undefined) => {
+    for (const value of values ?? []) {
+      parts.push(flag, quoteArg(value))
+    }
+  }
+
+  if (flags.from) parts.push('--from', quoteArg(flags.from))
+  if (flags.to) parts.push('--to', quoteArg(flags.to))
+  appendMany('--status', flags.status)
+  appendMany('--branch', flags.branch)
+  appendMany('--user', flags.user)
+  appendMany('--provider', flags.provider)
+  if (flags['no-users']) parts.push('--no-users')
+  if (flags.search) parts.push('--search', quoteArg(flags.search))
+  if (flags['error-group']) parts.push('--error-group', quoteArg(flags['error-group']))
+
+  return parts.join(' ')
+}
+
+export default class TestSessionsList extends AuthCommand {
+  static hidden = false
+  static readOnly = true
+  static idempotent = true
+  static description = 'List recorded test sessions.'
+
+  static flags = {
+    'limit': Flags.integer({
+      char: 'l',
+      description: 'Number of test sessions to return (1-100).',
+      default: 20,
+    }),
+    'cursor': Flags.string({
+      description: 'Cursor for next page (from previous output).',
+    }),
+    'from': Flags.string({
+      description: 'Only include test sessions created at or after this ISO date or Unix timestamp.',
+    }),
+    'to': Flags.string({
+      description: 'Only include test sessions created before this ISO date or Unix timestamp.',
+    }),
+    'status': Flags.string({
+      description: `Filter by test session status: ${statusOptions.join(', ')}. Can be specified multiple times.`,
+      multiple: true,
+      delimiter: ',',
+    }),
+    'branch': Flags.string({
+      description: 'Filter by Git branch name. Can be specified multiple times.',
+      multiple: true,
+      delimiter: ',',
+    }),
+    'user': Flags.string({
+      description: 'Filter by commit owner or invoking user ID. Can be specified multiple times.',
+      multiple: true,
+      delimiter: ',',
+    }),
+    'no-users': Flags.boolean({
+      description: 'Include sessions with no commit owner and no invoking user.',
+      default: false,
+    }),
+    'provider': Flags.string({
+      description: `Filter by test session provider: ${providerOptions.join(', ')}. Can be specified multiple times.`,
+      multiple: true,
+      delimiter: ',',
+    }),
+    'search': Flags.string({
+      char: 's',
+      description: 'Search test session text fields (3-200 characters).',
+    }),
+    'error-group': Flags.string({
+      description: 'Filter by test-session error group ID.',
+    }),
+    'output': outputFlag({ default: 'table' }),
+  }
+
+  async run (): Promise<void> {
+    const { flags } = await this.parse(TestSessionsList)
+    this.style.outputFormat = flags.output
+
+    if (flags.limit < 1 || flags.limit > 100) {
+      this.error('--limit must be an integer between 1 and 100.')
+    }
+
+    if (flags.search && (flags.search.length < 3 || flags.search.length > 200)) {
+      this.error('--search must be between 3 and 200 characters.')
+    }
+
+    const statuses = flags.status?.map(normalizeStatus)
+    if (flags.status && statuses?.some(status => !status)) {
+      this.error(`Invalid --status value. Valid values: ${statusOptions.join(', ')}.`)
+    }
+
+    const providers = flags.provider?.map(normalizeProvider)
+    if (flags.provider && providers?.some(provider => !provider)) {
+      this.error(`Invalid --provider value. Valid values: ${providerOptions.join(', ')}.`)
+    }
+
+    let from: number | undefined
+    let to: number | undefined
+
+    try {
+      from = parseUnixTimestamp(flags.from, 'from')
+      to = parseUnixTimestamp(flags.to, 'to')
+    } catch (err: any) {
+      this.error(err.message)
+    }
+
+    const params: ListTestSessionsParams = {
+      from,
+      to,
+      limit: flags.limit,
+      statuses: statuses?.filter(Boolean) as TestSessionStatus[] | undefined,
+      branches: flags.branch,
+      users: flags.user,
+      providers: providers?.filter(Boolean) as TestSessionProvider[] | undefined,
+      noUsers: flags['no-users'] || undefined,
+      nextId: flags.cursor,
+      textSearch: flags.search,
+      errorGroupId: flags['error-group'],
+    }
+
+    try {
+      const { data } = await api.testSessions.list(params)
+
+      if (flags.output === 'json') {
+        this.log(JSON.stringify({
+          data: data.entries,
+          pagination: {
+            nextId: data.nextId,
+            length: data.length,
+          },
+        }, null, 2))
+        return
+      }
+
+      if (data.length === 0) {
+        this.log('No test sessions found.')
+        return
+      }
+
+      const fmt: OutputFormat = flags.output === 'md' ? 'md' : 'terminal'
+      const lines = [
+        formatTestSessionsList(data.entries, fmt),
+      ]
+
+      if (fmt === 'terminal') {
+        lines.push('')
+        lines.push(formatTestSessionsListPaginationInfo(data.length, data.nextId))
+
+        const navHints = formatTestSessionsListNavigationHints(
+          data.nextId,
+          buildListCommand(flags),
+          data.entries[0]?.id,
+        )
+        if (navHints) {
+          lines.push('')
+          lines.push(navHints)
+        }
+      }
+
+      this.log(lines.join('\n'))
+    } catch (err: any) {
+      this.style.longError('Failed to list test sessions.', err)
+      process.exitCode = 1
+    }
+  }
+}

--- a/packages/cli/src/formatters/test-sessions.ts
+++ b/packages/cli/src/formatters/test-sessions.ts
@@ -1,6 +1,12 @@
 import chalk from 'chalk'
 import type { TestSessionErrorGroup } from '../rest/test-session-error-groups.js'
-import type { TestSessionDetail, TestSessionMetadata, TestSessionResult, TestSessionStatus } from '../rest/test-sessions.js'
+import type {
+  TestSessionDetail,
+  TestSessionListEntry,
+  TestSessionMetadata,
+  TestSessionResult,
+  TestSessionStatus,
+} from '../rest/test-sessions.js'
 import {
   type ColumnDef,
   type DetailField,
@@ -46,6 +52,11 @@ function formatStatus (status: TestSessionStatus, format: OutputFormat): string 
   }
 }
 
+function formatOptionalStatus (status: TestSessionStatus | undefined, format: OutputFormat): string {
+  if (!status) return format === 'terminal' ? chalk.dim('-') : '-'
+  return formatStatus(status, format)
+}
+
 function formatList (values: string[] | undefined, format: OutputFormat): string {
   if (!values || values.length === 0) return format === 'terminal' ? chalk.dim('-') : '-'
   return values.join(', ')
@@ -79,6 +90,111 @@ function formatDuration (ms: number): string {
   if (minutes === 0 && seconds === 0) return `${hours}h`
   if (minutes === 0) return `${hours}h ${seconds}s`
   return seconds === 0 ? `${hours}h ${minutes}m` : `${hours}h ${minutes}m ${seconds}s`
+}
+
+function formatNullableString (value: string | null | undefined, format: OutputFormat): string {
+  if (!value) return format === 'terminal' ? chalk.dim('-') : '-'
+  return value
+}
+
+function formatResultBucketCount (values: string[] | null | undefined, format: OutputFormat): string {
+  const count = values?.length ?? 0
+  if (count === 0) return format === 'terminal' ? chalk.dim('-') : '-'
+  return String(count)
+}
+
+function formatInvoker (session: TestSessionListEntry, format: OutputFormat): string {
+  return formatNullableString(session.commitOwner ?? session.invoker?.name, format)
+}
+
+function buildTestSessionListColumns (
+  sessions: TestSessionListEntry[],
+  format: OutputFormat,
+): ColumnDef<TestSessionListEntry>[] {
+  if (format === 'md') {
+    return [
+      { header: 'Status', value: (session, fmt) => formatOptionalStatus(session.status, fmt) },
+      { header: 'Started', value: (session, fmt) => formatDate(session.startedAt, fmt) },
+      { header: 'Name', value: session => session.name },
+      { header: 'Provider', value: session => session.provider },
+      { header: 'Branch', value: (session, fmt) => formatNullableString(session.branchName, fmt) },
+      { header: 'User', value: (session, fmt) => formatInvoker(session, fmt) },
+      { header: 'Running', value: (session, fmt) => formatResultBucketCount(session.running, fmt) },
+      { header: 'Passed', value: (session, fmt) => formatResultBucketCount(session.passed, fmt) },
+      { header: 'Failed', value: (session, fmt) => formatResultBucketCount(session.failed, fmt) },
+      { header: 'Cancelled', value: (session, fmt) => formatResultBucketCount(session.cancelled, fmt) },
+      { header: 'ID', value: session => session.id },
+    ]
+  }
+
+  const termWidth = process.stdout.columns || 120
+  const statusWidth = 11
+  const startedWidth = 25
+  const providerWidth = 13
+  const branchWidth = 18
+  const userWidth = 18
+  const resultBucketWidth = 10
+  const idWidth = 38
+  const fixedWidth = statusWidth + startedWidth + providerWidth + branchWidth + userWidth
+    + (resultBucketWidth * 4) + idWidth
+  const longestName = Math.max(4, ...sessions.map(session => visWidth(session.name)))
+  const nameWidth = Math.max(18, Math.min(longestName + 2, termWidth - fixedWidth, 42))
+
+  return [
+    { header: 'Status', width: statusWidth, value: (session, fmt) => formatOptionalStatus(session.status, fmt) },
+    {
+      header: 'Started',
+      width: startedWidth,
+      value: (session, fmt) => truncateToWidth(formatDate(session.startedAt, fmt), startedWidth - 2),
+    },
+    { header: 'Name', width: nameWidth, value: session => truncateToWidth(session.name, nameWidth - 2) },
+    { header: 'Provider', width: providerWidth, value: session => truncateToWidth(session.provider, providerWidth - 2) },
+    {
+      header: 'Branch',
+      width: branchWidth,
+      value: (session, fmt) => truncateToWidth(formatNullableString(session.branchName, fmt), branchWidth - 2),
+    },
+    {
+      header: 'User',
+      width: userWidth,
+      value: (session, fmt) => truncateToWidth(formatInvoker(session, fmt), userWidth - 2),
+    },
+    { header: 'Running', width: resultBucketWidth, value: (session, fmt) => formatResultBucketCount(session.running, fmt) },
+    { header: 'Passed', width: resultBucketWidth, value: (session, fmt) => formatResultBucketCount(session.passed, fmt) },
+    { header: 'Failed', width: resultBucketWidth, value: (session, fmt) => formatResultBucketCount(session.failed, fmt) },
+    { header: 'Cancelled', width: resultBucketWidth, value: (session, fmt) => formatResultBucketCount(session.cancelled, fmt) },
+    { header: 'ID', value: session => chalk.dim(session.id) },
+  ]
+}
+
+export function formatTestSessionsList (
+  sessions: TestSessionListEntry[],
+  format: OutputFormat,
+): string {
+  return renderTable(buildTestSessionListColumns(sessions, format), sessions, format)
+}
+
+export function formatTestSessionsListPaginationInfo (count: number, nextId: string | null | undefined): string {
+  const base = `${count} test session${count !== 1 ? 's' : ''}`
+  if (nextId) {
+    return chalk.dim(`Showing ${base} (more available)`)
+  }
+  return chalk.dim(`Showing ${base}`)
+}
+
+export function formatTestSessionsListNavigationHints (
+  nextId: string | null | undefined,
+  listCommand: string,
+  firstSessionId?: string,
+): string {
+  const lines: string[] = []
+  if (nextId) {
+    lines.push(`  ${chalk.dim('Next page:')}       ${listCommand} --cursor ${nextId}`)
+  }
+  if (firstSessionId) {
+    lines.push(`  ${chalk.dim('Inspect session:')} ${`checkly test-sessions get ${firstSessionId}`}`)
+  }
+  return lines.join('\n')
 }
 
 function formatMetadata (metadata: TestSessionMetadata | undefined, format: OutputFormat): string | null {

--- a/packages/cli/src/rest/__tests__/test-sessions.spec.ts
+++ b/packages/cli/src/rest/__tests__/test-sessions.spec.ts
@@ -48,4 +48,37 @@ describe('TestSessions REST client', () => {
       params: { maxWaitSeconds: 30 },
     })
   })
+
+  it('lists public test sessions with filters', async () => {
+    const api = {
+      get: vi.fn().mockResolvedValue({ data: { length: 0, entries: [], nextId: null } }),
+    }
+    const testSessions = new TestSessions(api as any)
+
+    await testSessions.list({
+      limit: 10,
+      statuses: ['FAILED'],
+      branches: ['main'],
+      users: ['Herve'],
+      providers: ['API'],
+      noUsers: true,
+      nextId: 'cursor',
+      textSearch: 'smoke',
+      errorGroupId: 'error-group-id',
+    })
+
+    expect(api.get).toHaveBeenCalledWith('/v1/test-sessions', {
+      params: {
+        limit: 10,
+        statuses: ['FAILED'],
+        branches: ['main'],
+        users: ['Herve'],
+        providers: ['API'],
+        noUsers: true,
+        nextId: 'cursor',
+        textSearch: 'smoke',
+        errorGroupId: 'error-group-id',
+      },
+    })
+  })
 })

--- a/packages/cli/src/rest/test-sessions.ts
+++ b/packages/cli/src/rest/test-sessions.ts
@@ -59,6 +59,8 @@ export type TestSessionMetadata = {
 
 export type TestSessionStatus = 'RUNNING' | 'FAILED' | 'PASSED' | 'CANCELLED'
 
+export type TestSessionProvider = 'GITHUB' | 'VERCEL' | 'API' | 'TRIGGER' | 'PW_REPORTER'
+
 export type TestSessionResult = {
   testSessionResultId: string
   testSessionResultLink: string
@@ -86,6 +88,57 @@ export type TestSessionDetail = {
   metadata?: TestSessionMetadata
   errorGroupIds?: string[]
   results?: TestSessionResult[]
+}
+
+type TestSessionListEntryInvoker = {
+  name: string
+  picture?: string | null
+} | null
+
+export type TestSessionListEntry = {
+  id: string
+  accountId: string
+  projectId?: string | null
+  name: string
+  provider: string
+  running?: string[] | null
+  passed?: string[] | null
+  failed?: string[] | null
+  cancelled?: string[] | null
+  status?: TestSessionStatus
+  region: string
+  privateLocationId?: string | null
+  invoker?: TestSessionListEntryInvoker
+  repoUrl?: string | null
+  commitId?: string | null
+  commitOwner?: string | null
+  commitMessage?: string | null
+  branchName?: string | null
+  environment?: string | null
+  startedAt: string
+  stoppedAt?: string | null
+  created_at: string
+  updated_at?: string | null
+}
+
+export type ListTestSessionsParams = {
+  from?: number
+  to?: number
+  limit?: number
+  statuses?: TestSessionStatus[]
+  branches?: string[]
+  users?: string[]
+  providers?: TestSessionProvider[]
+  noUsers?: boolean
+  nextId?: string
+  textSearch?: string
+  errorGroupId?: string
+}
+
+export type TestSessionsListResponse = {
+  length: number
+  entries: TestSessionListEntry[]
+  nextId?: string | null
 }
 
 export class NoMatchingChecksError extends Error {
@@ -152,6 +205,10 @@ class TestSessions {
         throw err
       }
     }
+  }
+
+  list (params: ListTestSessionsParams = {}) {
+    return this.api.get<TestSessionsListResponse>('/v1/test-sessions', { params })
   }
 
   getShortLink (id: string) {


### PR DESCRIPTION
## Merge condition

**Blocked by:** https://github.com/checkly/monorepo/pull/2043

This CLI PR **must not be merged or released** until the backend public `GET /v1/test-sessions` list endpoint from `checkly/monorepo#2043` is merged and ready for the CLI to call. The command added here depends on that public endpoint being available.

## Summary

- Add `checkly test-sessions list` backed by `GET /v1/test-sessions`.
- Support cursor pagination, ISO/Unix time filters, statuses, branches, users, providers, `--no-users`, text search, and test-session error group filtering.
- Add table, JSON, and Markdown output plus next-page and inspect-session hints.

## Validation

- `pnpm exec eslint packages/cli/src/commands/test-sessions/list.ts packages/cli/src/commands/__tests__/test-sessions-list.spec.ts packages/cli/src/formatters/test-sessions.ts packages/cli/src/rest/test-sessions.ts packages/cli/src/rest/__tests__/test-sessions.spec.ts packages/cli/src/commands/__tests__/command-metadata.spec.ts`
- Focused Vitest run with temporary config skipping the tarball global setup: `121 passed`
- `pnpm -C packages/cli run prepare:dist`
- `pnpm -C packages/cli run prepack`
- `packages/cli/bin/run test-sessions list --help`

## Notes

Full `pnpm pack` is still blocked locally by the existing `prepare:ai-context` issue where `./bin/run import plan` reports `import:plan is not a checkly command`.
