### PR TITLE
fix(cli): handle Bun object-form workspaces in workspace discovery

### DIFF
--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/bun-workspace-object-form-in-root-package/apps/main/package.json
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/bun-workspace-object-form-in-root-package/apps/main/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "main",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "sibling": "*"
+  }
+}

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/bun-workspace-object-form-in-root-package/apps/main/tests/foo.spec.js
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/bun-workspace-object-form-in-root-package/apps/main/tests/foo.spec.js
@@ -1,0 +1,1 @@
+require('sibling')

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/bun-workspace-object-form-in-root-package/apps/sibling/index.js
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/bun-workspace-object-form-in-root-package/apps/sibling/index.js
@@ -1,0 +1,1 @@
+console.log('Hello from sibling')

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/bun-workspace-object-form-in-root-package/apps/sibling/package.json
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/bun-workspace-object-form-in-root-package/apps/sibling/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "sibling",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/bun-workspace-object-form-in-root-package/package.json
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/bun-workspace-object-form-in-root-package/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "bun-workspace-object-form-in-root-package",
+  "version": "1.0.0",
+  "private": true,
+  "license": "ISC",
+  "workspaces": {
+    "packages": [
+      "apps/*"
+    ],
+    "catalogs": {
+      "checkly": "7.11.0"
+    }
+  }
+}

--- a/packages/cli/src/services/check-parser/__tests__/check-parser.spec.ts
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser.spec.ts
@@ -5,7 +5,7 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 
 import { Parser } from '../parser.js'
 import { FixtureSandbox } from '../../../testing/fixture-sandbox.js'
-import { NpmDetector, PNpmDetector } from '../package-files/package-manager.js'
+import { BunDetector, NpmDetector, PNpmDetector } from '../package-files/package-manager.js'
 import { FAUX_PACKAGE_DESCRIPTION } from '../faux-package.js'
 import { Workspace } from '../package-files/workspace.js'
 
@@ -125,6 +125,44 @@ describe('dependency-parser - parser()', () => {
             // Only check paths first, makes missing files easier to see.
             expect(got.map(({ filePath }) => filePath)).toEqual(want.map(({ filePath }) => filePath))
             expect(got).toEqual(want)
+          })
+        })
+      })
+
+      describe('bun workspaces', () => {
+        // Regression test for #1324: Bun (and Yarn classic) allow the root
+        // package.json `workspaces` field to be an object
+        // (`{ packages: [...], catalogs: {...} }`) rather than a plain array of
+        // glob patterns. Workspace discovery used to assume an array and crashed
+        // with `TypeError: patterns.map is not a function`.
+        describe('bun-workspace-object-form-in-root-package', () => {
+          const toAbsolutePath = (...filepath: string[]) => fixt.abspath(
+            'bun-workspace-object-form-in-root-package',
+            ...filepath,
+          )
+
+          const packageManager = new BunDetector()
+
+          let workspace: Workspace | undefined
+          beforeAll(async () => {
+            workspace = await packageManager.lookupWorkspace(toAbsolutePath('.'))
+            expect(workspace).toBeDefined()
+          })
+
+          it('should discover workspace members from object-form workspaces', () => {
+            expect(workspace?.memberByName('sibling')).toBeDefined()
+          })
+
+          it('should resolve dependencies on sibling workspace packages', async () => {
+            const parser = new Parser({
+              checkUnsupportedModules: false,
+              restricted: false,
+              workspace,
+            })
+            const { dependencies } = await parser.parse(toAbsolutePath('apps/main/tests/foo.spec.js'))
+            const filePaths = dependencies.map(({ filePath }) => filePath)
+            expect(filePaths).toContain(toAbsolutePath('apps/sibling/index.js'))
+            expect(filePaths).toContain(toAbsolutePath('apps/sibling/package.json'))
           })
         })
       })

--- a/packages/cli/src/services/check-parser/package-files/__tests__/package-json-file.spec.ts
+++ b/packages/cli/src/services/check-parser/package-files/__tests__/package-json-file.spec.ts
@@ -80,6 +80,56 @@ describe('package.json file', () => {
     })
   })
 
+  describe('workspaces', () => {
+    it('returns array-form workspaces as-is', () => {
+      const testFile = PackageJsonFile.make('package.json', {
+        name: 'foo',
+        version: '1.0.0',
+        workspaces: ['apps/*', 'packages/*'],
+      })
+
+      expect(testFile.workspaces).toEqual(['apps/*', 'packages/*'])
+    })
+
+    it('returns the packages array from Bun/Yarn object-form workspaces (issue #1324)', () => {
+      const testFile = PackageJsonFile.make('package.json', {
+        name: 'foo',
+        version: '1.0.0',
+        workspaces: {
+          packages: ['packages/*'],
+          catalogs: {
+            checkly: '7.11.0',
+          },
+        },
+      })
+
+      expect(testFile.workspaces).toEqual(['packages/*'])
+    })
+
+    it('returns undefined for object-form workspaces without a packages array', () => {
+      const testFile = PackageJsonFile.make('package.json', {
+        name: 'foo',
+        version: '1.0.0',
+        workspaces: {
+          catalogs: {
+            checkly: '7.11.0',
+          },
+        },
+      })
+
+      expect(testFile.workspaces).toBeUndefined()
+    })
+
+    it('returns undefined when workspaces is absent', () => {
+      const testFile = PackageJsonFile.make('package.json', {
+        name: 'foo',
+        version: '1.0.0',
+      })
+
+      expect(testFile.workspaces).toBeUndefined()
+    })
+  })
+
   describe('resolveExportPath', () => {
     const importConditions = ['import', 'node', 'module-sync', 'default']
     const requireConditions = ['require', 'node', 'module-sync', 'default']

--- a/packages/cli/src/services/check-parser/package-files/package-json-file.ts
+++ b/packages/cli/src/services/check-parser/package-files/package-json-file.ts
@@ -44,7 +44,11 @@ type Schema = {
   dependencies?: Record<string, string>
   devDependencies?: Record<string, string>
   private?: boolean
-  workspaces?: string[]
+  // npm/pnpm/yarn use the array form, but Bun (and Yarn classic) also allow an
+  // object form (`{ packages: [...], catalogs/nohoist: ... }`). `catalogs` and
+  // `nohoist` are never read — they exist here only so the object form
+  // typechecks. The `workspaces` getter normalizes both to `string[]`.
+  workspaces?: string[] | { packages?: string[], catalogs?: Record<string, unknown>, nohoist?: string[] }
 }
 
 export interface EngineSupportResult {
@@ -194,8 +198,17 @@ export class PackageJsonFile {
     return this.jsonFile.data.engines
   }
 
-  public get workspaces () {
-    return this.jsonFile.data.workspaces
+  public get workspaces (): string[] | undefined {
+    const workspaces = this.jsonFile.data.workspaces
+    if (Array.isArray(workspaces)) {
+      return workspaces
+    }
+    // Bun/Yarn object form: `{ packages: [...], catalogs/nohoist: ... }`.
+    // Anything else (incl. a malformed value) yields no workspace patterns.
+    if (typeof workspaces === 'object' && workspaces !== null && Array.isArray(workspaces.packages)) {
+      return workspaces.packages
+    }
+    return undefined
   }
 
   supportsEngine (engine: string, version: string): EngineSupportResult {


### PR DESCRIPTION
## Problem

Fixes #1324.

When a Checkly project lives inside a Bun monorepo whose root `package.json` declares `workspaces` in **object form** rather than as an array of glob patterns:

```json
{
  "workspaces": {
    "packages": ["packages/*"],
    "catalogs": { "checkly": "7.11.0" }
  }
}
```

`checkly deploy` / `checkly debug parse-project` crash with:

```
TypeError: patterns.map is not a function
```

Workspace discovery assumed `workspaces` is always a `string[]`, but Bun (and Yarn classic) also support the object form `{ packages, catalogs/nohoist }`. The object reached `Workspace.resolvePatterns`, which calls `.map()` on it.

## Fix

Normalize at the single source of truth — the `PackageJsonFile.workspaces` getter now always returns `string[] | undefined`:

- array form → returned as-is
- object form → its `packages` array
- object without a valid `packages` array (or any malformed value) → `undefined`, so discovery is skipped instead of crashing

This keeps `Package.workspaces`, the downstream `workspaces.length === 0` skip check, and `resolvePatterns` unchanged.

## Tests

- **Unit** (`package-json-file.spec.ts`): the `workspaces` getter across array / object-with-packages / object-without-packages / absent.
- **Integration** (`check-parser.spec.ts`): a new `bun workspaces` block driven by `BunDetector` with an object-form fixture. Confirmed to throw the exact reported error without the fix and pass with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)