### PR TITLE
ci: seed pnpm cache on main so PR branches get cache hits

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - main
       - next/*
+  # Also run on pushes to main so the pnpm store cache is populated on the
+  # default branch. GitHub only lets branches inherit caches created on the
+  # default branch, so without this every PR branch starts with a cold cache
+  # and re-downloads all dependencies from scratch.
+  push:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -53,6 +60,9 @@ jobs:
           path: packages/cli/dist/ai-context/*
           retention-days: 1
   test-e2e-checkly:
+    # Only on PRs — these hit the live Checkly API. The push-to-main run exists
+    # solely to seed the dependency cache, which lint + test already cover.
+    if: github.event_name == 'pull_request'
     strategy:
       fail-fast: false
       matrix:
@@ -78,6 +88,8 @@ jobs:
           CHECKLY_EMPTY_ACCOUNT_ID: ${{ secrets.E2E_EMPTY_CHECKLY_ACCOUNT_ID }}
           CHECKLY_EMPTY_API_KEY: ${{ secrets.E2E_EMPTY_CHECKLY_API_KEY }}
   test-e2e-create-checkly:
+    # Only on PRs — see test-e2e-checkly above.
+    if: github.event_name == 'pull_request'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Problem

The `test` workflow only triggered on `pull_request`, so the default branch (`main`) never ran an install job and never populated a pnpm store cache. GitHub only lets branches inherit caches created on the **default branch**, so every PR branch started cold and re-downloaded all dependencies from scratch.

Confirmed in CI logs for a recent PR — every job reported a miss and a full download:

```
pnpm cache is not found
Progress: resolved 631, reused 0, downloaded 631, added 631, done
```

The caching mechanics were already configured correctly in every job (`pnpm/action-setup@v5` → `actions/setup-node@v4` with `cache: "pnpm"`); the issue was purely that there was no default-branch cache to inherit.

## Change

- Add a `push: branches: [main]` trigger so `lint` + `test` run on `main` and seed the per-OS pnpm store cache. `test` runs on both `ubuntu-latest` and `windows-latest-x64`, so both the Linux-x64 and Windows-x64 caches that PR jobs (including the Windows e2e jobs) restore get warmed.
- Gate the two `e2e` jobs to `if: github.event_name == 'pull_request'`. They hit the live Checkly API and consume secrets/quota, so they shouldn't run on every push to `main` — the cache is already seeded by `lint` + `test`.

After one `main` run lands, PRs that don't change `pnpm-lock.yaml` get a cache hit on their first run. (PRs that change the lockfile still cold-start, since the cache key is the lockfile hash — unavoidable.)

## Notes

If the `e2e - *` jobs are configured as required status checks on `main`, this is still safe: a skipped required check counts as passing on `push` events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)