### PR TITLE
feat(cli): add --user-context to rca run [AI-343]

### DIFF
--- a/packages/cli/src/commands/rca/run.ts
+++ b/packages/cli/src/commands/rca/run.ts
@@ -11,7 +11,7 @@ export default class RcaRun extends AuthCommand {
   static readOnly = false
   static idempotent = false
   static description = 'Trigger a root cause analysis for a check or test session error group.'
-  static usage = 'rca run [-e <value> | -te <value>] [-w] [-o detail|json|md]'
+  static usage = 'rca run [-e <value> | -te <value>] [--user-context <text>] [-w] [-o detail|json|md]'
 
   static flags = {
     'error-group': Flags.string({
@@ -23,6 +23,9 @@ export default class RcaRun extends AuthCommand {
     'test-session-error-group': Flags.string({
       description: 'The test session error group ID to analyze.',
       helpLabel: '-te, --test-session-error-group',
+    }),
+    'user-context': Flags.string({
+      description: 'Extra context to pass into the root cause analysis.',
     }),
     'watch': Flags.boolean({
       char: 'w',
@@ -56,7 +59,7 @@ export default class RcaRun extends AuthCommand {
         // Fetch the error group to get the checkId for navigation hints
         const { data: errorGroup } = await api.errorGroups.get(source.id)
 
-        const response = await api.rca.trigger(source.id)
+        const response = await api.rca.trigger(source.id, flags['user-context'])
         rcaId = response.data.id
         pendingInfo = {
           rcaId,
@@ -69,7 +72,7 @@ export default class RcaRun extends AuthCommand {
       } else {
         await api.testSessionErrorGroups.get(source.id)
 
-        const response = await api.rca.triggerTestSessionErrorGroup(source.id)
+        const response = await api.rca.triggerTestSessionErrorGroup(source.id, flags['user-context'])
         rcaId = response.data.id
         pendingInfo = {
           rcaId,

--- a/packages/cli/src/rest/__tests__/rca.spec.ts
+++ b/packages/cli/src/rest/__tests__/rca.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest'
+import Rca from '../rca.js'
+
+describe('Rca REST client', () => {
+  it('triggers an error group RCA without a body when no user context is given', async () => {
+    const api = {
+      post: vi.fn().mockResolvedValue({ data: { id: 'rca-id' } }),
+    }
+    const rca = new Rca(api as any)
+
+    await rca.trigger('error-group-id')
+
+    expect(api.post).toHaveBeenCalledWith(
+      '/v1/root-cause-analyses/error-groups/error-group-id',
+      undefined,
+    )
+  })
+
+  it('passes user context as the body when triggering an error group RCA', async () => {
+    const api = {
+      post: vi.fn().mockResolvedValue({ data: { id: 'rca-id' } }),
+    }
+    const rca = new Rca(api as any)
+
+    await rca.trigger('error-group-id', 'some extra context')
+
+    expect(api.post).toHaveBeenCalledWith(
+      '/v1/root-cause-analyses/error-groups/error-group-id',
+      { userContext: 'some extra context' },
+    )
+  })
+
+  it('triggers a test session error group RCA without a body when no user context is given', async () => {
+    const api = {
+      post: vi.fn().mockResolvedValue({ data: { id: 'rca-id' } }),
+    }
+    const rca = new Rca(api as any)
+
+    await rca.triggerTestSessionErrorGroup('ts-error-group-id')
+
+    expect(api.post).toHaveBeenCalledWith(
+      '/v1/root-cause-analyses/test-session-error-groups/ts-error-group-id',
+      undefined,
+    )
+  })
+
+  it('passes user context as the body when triggering a test session error group RCA', async () => {
+    const api = {
+      post: vi.fn().mockResolvedValue({ data: { id: 'rca-id' } }),
+    }
+    const rca = new Rca(api as any)
+
+    await rca.triggerTestSessionErrorGroup('ts-error-group-id', 'some extra context')
+
+    expect(api.post).toHaveBeenCalledWith(
+      '/v1/root-cause-analyses/test-session-error-groups/ts-error-group-id',
+      { userContext: 'some extra context' },
+    )
+  })
+})

--- a/packages/cli/src/rest/rca.ts
+++ b/packages/cli/src/rest/rca.ts
@@ -13,15 +13,17 @@ class Rca {
     this.api = api
   }
 
-  trigger (errorGroupId: string) {
+  trigger (errorGroupId: string, userContext?: string) {
     return this.api.post<TriggerRcaResponse>(
       `/v1/root-cause-analyses/error-groups/${errorGroupId}`,
+      userContext ? { userContext } : undefined,
     )
   }
 
-  triggerTestSessionErrorGroup (testSessionErrorGroupId: string) {
+  triggerTestSessionErrorGroup (testSessionErrorGroupId: string, userContext?: string) {
     return this.api.post<TriggerRcaResponse>(
       `/v1/root-cause-analyses/test-session-error-groups/${testSessionErrorGroupId}`,
+      userContext ? { userContext } : undefined,
     )
   }
 


### PR DESCRIPTION
## What

Adds a `--user-context <text>` flag to `checkly rca run`, letting callers pass extra context into RCA generation:

```
checkly rca run --error-group <id> --user-context "..."
checkly rca run --test-session-error-group <id> --user-context "..."
```

## Changes

- **`commands/rca/run.ts`** — new `--user-context` flag (and updated `usage`); passed through to both trigger calls.
- **`rest/rca.ts`** — `trigger()` and `triggerTestSessionErrorGroup()` accept an optional `userContext` and send it as the POST body `{ userContext }` (or `undefined` when omitted, preserving the existing no-body behavior).
- **`rest/__tests__/rca.spec.ts`** — new unit tests covering both endpoints, with and without user context.

The `detail|json|md` output shape is unchanged — the flag only affects the request payload. Both public endpoints already accept the optional `{ userContext }` body on the backend.