### PR TITLE
Fix detached test session output

### DIFF
--- a/packages/cli/src/ai-context/references/investigate-test-sessions.md
+++ b/packages/cli/src/ai-context/references/investigate-test-sessions.md
@@ -9,20 +9,23 @@ Read-only inspection commands execute immediately. `rca run` starts a new analys
 `checkly test`, `checkly trigger`, and `checkly pw-test` record results as a test session by default. Use `--no-record` only when the user explicitly does not want a recorded session.
 
 ```bash
-npx checkly test --test-session-name "Checkout regression"
-npx checkly test --record --test-session-name "Checkout regression"
-npx checkly trigger --tags production --test-session-name "Production smoke"
-npx checkly pw-test --test-session-name "Playwright suite"
+npx checkly test --detach --test-session-name "Checkout regression"
+npx checkly test --record --detach --test-session-name "Checkout regression"
+npx checkly trigger --detach --tags production --test-session-name "Production smoke"
+npx checkly pw-test --detach --test-session-name "Playwright suite"
 ```
+
+For agent workflows, prefer `--detach` when starting recorded sessions. The command schedules the session, prints the `Test session ID`, and exits without waiting for completion. Inspect the session with `npx checkly test-sessions get <test-session-id> --watch` instead of relying on Checkly UI links.
 
 Useful flags:
 - `--location <region>` or `--private-location <slug>` - choose where checks run.
 - `-e, --env KEY=value` or `--env-file <path>` - pass runtime environment variables.
-- `--timeout <seconds>` - wait for session completion before the command exits.
-- `-d, --detach` - keep cloud execution running if the local CLI is cancelled.
-- `-r, --reporter json` - capture machine-readable run output, including test session IDs when available.
+- `--timeout <seconds>` - wait for session completion before the command exits; ignored when `--detach` exits after scheduling.
+- `-d, --detach` - start the session in the cloud, print the test session ID, and exit immediately; preferred for agents starting recorded sessions.
 
-If the command output includes a test session ID or link, use it directly with `test-sessions get`.
+Do not combine `--detach` with file reporters such as `--reporter json` or `--reporter github`. Detached runs exit before results are available, so no result report can be written. After scheduling with `--detach`, use `test-sessions get --output json` for machine-readable session details.
+
+If the command output includes a test session ID or link, use the ID directly with `test-sessions get`.
 
 ## Find a test session
 

--- a/packages/cli/src/commands/pw-test.ts
+++ b/packages/cli/src/commands/pw-test.ts
@@ -8,7 +8,7 @@ import {
   splitConfigFilePath, writeChecklyConfigFile,
 } from '../services/util.js'
 import { getChecklyConfigFile, loadChecklyConfig, PlaywrightSlimmedProp } from '../services/checkly-config-loader.js'
-import { prepareReportersTypes, prepareRunLocation, splitChecklyAndPlaywrightFlags } from '../helpers/test-helper.js'
+import { prepareReportersTypes, prepareRunLocation, splitChecklyAndPlaywrightFlags, validateDetachReporterTypes } from '../helpers/test-helper.js'
 import * as api from '../rest/api.js'
 import config from '../services/config.js'
 import { parseProject } from '../services/project-parser.js'
@@ -120,7 +120,7 @@ export default class PwTestCommand extends AuthCommand {
     }),
     'detach': Flags.boolean({
       char: 'd',
-      description: 'Keep checks running in the cloud after cancelling the CLI process.',
+      description: 'Start checks in the cloud and exit after printing the test session ID.',
       default: false,
     }),
   }
@@ -191,6 +191,9 @@ export default class PwTestCommand extends AuthCommand {
     }, api, config.getAccountId())
 
     const reporterTypes = prepareReportersTypes(reporterFlag as ReporterType[], checklyConfig.cli?.reporters)
+    if (detach) {
+      validateDetachReporterTypes(reporterTypes)
+    }
     const account = this.account
     const availableRuntimes = await api.runtimes.getAll()
     const testEnvVars = await getEnvs(envFile, env)

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -22,7 +22,7 @@ import { printLn, formatCheckTitle, CheckStatus } from '../reporters/util.js'
 import { uploadSnapshots } from '../services/snapshot-service.js'
 import { isEntrypoint } from '../constructs/construct.js'
 import { BrowserCheckBundle } from '../constructs/browser-check-bundle.js'
-import { prepareReportersTypes, prepareRunLocation } from '../helpers/test-helper.js'
+import { prepareReportersTypes, prepareRunLocation, validateDetachReporterTypes } from '../helpers/test-helper.js'
 import { Runtime } from '../runtimes/index.js'
 import { Bundler } from '../services/check-parser/bundler.js'
 
@@ -121,7 +121,7 @@ export default class Test extends AuthCommand {
     }),
     'detach': Flags.boolean({
       char: 'd',
-      description: 'Keep checks running in the cloud after cancelling the CLI process.',
+      description: 'Start checks in the cloud and exit after printing the test session ID.',
       default: false,
     }),
   }
@@ -178,6 +178,9 @@ export default class Test extends AuthCommand {
     config.getAccountId())
     const verbose = this.prepareVerboseFlag(verboseFlag, checklyConfig.cli?.verbose)
     const reporterTypes = prepareReportersTypes(reporterFlag as ReporterType[], checklyConfig.cli?.reporters)
+    if (detach) {
+      validateDetachReporterTypes(reporterTypes)
+    }
     const account = this.account
     const availableRuntimes = await api.runtimes.getAll()
 

--- a/packages/cli/src/commands/trigger.ts
+++ b/packages/cli/src/commands/trigger.ts
@@ -20,6 +20,7 @@ import { printLn } from '../reporters/util.js'
 import { NoMatchingChecksError, TestResultsShortLinks } from '../rest/test-sessions.js'
 import { Session, RetryStrategyBuilder } from '../constructs/index.js'
 import { DEFAULT_REGION } from '../helpers/constants.js'
+import { validateDetachReporterTypes } from '../helpers/test-helper.js'
 
 const MAX_RETRIES = 3
 
@@ -108,7 +109,7 @@ export default class Trigger extends AuthCommand {
     }),
     'detach': Flags.boolean({
       char: 'd',
-      description: 'Keep checks running in the cloud after cancelling the CLI process.',
+      description: 'Start checks in the cloud and exit after printing the test session ID.',
       default: false,
     }),
   }
@@ -149,6 +150,9 @@ export default class Trigger extends AuthCommand {
     })
     const verbose = this.prepareVerboseFlag(verboseFlag, checklyConfig?.cli?.verbose)
     const reporterTypes = this.prepareReportersTypes(reporterFlag as ReporterType[], checklyConfig?.cli?.reporters)
+    if (detach) {
+      validateDetachReporterTypes(reporterTypes)
+    }
     const reporters = createReporters(reporterTypes, location, verbose)
     const testRetryStrategy = this.prepareTestRetryStrategy(retries, checklyConfig?.cli?.retries)
 

--- a/packages/cli/src/constructs/__tests__/check.spec.ts
+++ b/packages/cli/src/constructs/__tests__/check.spec.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { Frequency } from '../frequency.js'
+import { Project, Session } from '../project.js'
+import { ApiCheck } from '../api-check.js'
+
+describe('Check', () => {
+  beforeEach(() => {
+    Session.project = new Project('project-id', {
+      name: 'Test Project',
+      repoUrl: 'https://github.com/checkly/checkly-cli',
+    })
+  })
+
+  afterEach(() => {
+    Session.reset()
+  })
+
+  it('synthesizes Frequency instances as numeric frequency fields', () => {
+    const check = new ApiCheck('api-health', {
+      name: 'API Health',
+      frequency: Frequency.EVERY_10M,
+      request: {
+        method: 'GET',
+        url: 'https://api.example.com/health',
+      },
+    })
+
+    expect(check.synthesize()).toMatchObject({
+      frequency: 10,
+      frequencyOffset: undefined,
+    })
+  })
+
+  it('synthesizes frequency-like values from separate module instances as numeric fields', () => {
+    const check = new ApiCheck('api-health', {
+      name: 'API Health',
+      frequency: { frequency: 10 } as any,
+      request: {
+        method: 'GET',
+        url: 'https://api.example.com/health',
+      },
+    })
+
+    expect(check.synthesize()).toMatchObject({
+      frequency: 10,
+      frequencyOffset: undefined,
+    })
+  })
+
+  it('synthesizes frequency-like default values as numeric fields', () => {
+    Session.checkDefaults = {
+      frequency: { frequency: 10 } as any,
+    }
+    const check = new ApiCheck('api-health', {
+      name: 'API Health',
+      request: {
+        method: 'GET',
+        url: 'https://api.example.com/health',
+      },
+    })
+
+    expect(check.synthesize()).toMatchObject({
+      frequency: 10,
+      frequencyOffset: undefined,
+    })
+  })
+})

--- a/packages/cli/src/constructs/check.ts
+++ b/packages/cli/src/constructs/check.ts
@@ -25,6 +25,21 @@ import { validateDeprecatedDoubleCheck } from './internal/common-diagnostics.js'
 import { InvalidPropertyValueDiagnostic } from './construct-diagnostics.js'
 import { CheckConfigDefaults } from '../services/checkly-config-loader.js'
 
+type FrequencyLike = {
+  frequency: number
+  frequencyOffset?: number
+}
+
+function isFrequencyLike (value: unknown): value is FrequencyLike {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  const maybeFrequency = value as Partial<FrequencyLike>
+  return typeof maybeFrequency.frequency === 'number'
+    && (maybeFrequency.frequencyOffset === undefined || typeof maybeFrequency.frequencyOffset === 'number')
+}
+
 /**
  * Retry strategies supported by checks.
  */
@@ -277,7 +292,7 @@ export abstract class Check extends Construct {
     this.locations = config.locations
     this.privateLocations = config.privateLocations
     this.tags = config.tags
-    if (config.frequency instanceof Frequency) {
+    if (isFrequencyLike(config.frequency)) {
       this.frequency = config.frequency.frequency
       this.frequencyOffset = config.frequency.frequencyOffset
     } else {

--- a/packages/cli/src/helpers/__tests__/test-helper.spec.ts
+++ b/packages/cli/src/helpers/__tests__/test-helper.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { prepareReportersTypes } from '../test-helper.js'
+import { prepareReportersTypes, validateDetachReporterTypes } from '../test-helper.js'
 
 vi.mock('ci-info', () => ({ isCI: false }))
 
@@ -32,5 +32,25 @@ describe('prepareReportersTypes', () => {
   it('CLI --reporter flag supports multiple values', () => {
     const result = prepareReportersTypes(['list', 'json'], ['list', 'dot'])
     expect(result).toEqual(['list', 'json'])
+  })
+})
+
+describe('validateDetachReporterTypes', () => {
+  it('allows streaming reporters in detach mode', () => {
+    expect(() => validateDetachReporterTypes(['list', 'dot', 'ci'])).not.toThrow()
+  })
+
+  it('rejects json reporter in detach mode', () => {
+    expect(() => validateDetachReporterTypes(['json'])).toThrow('--detach does not support --reporter json')
+  })
+
+  it('rejects github reporter in detach mode', () => {
+    expect(() => validateDetachReporterTypes(['github'])).toThrow('--detach does not support --reporter github')
+  })
+
+  it('rejects file reporters mixed with streaming reporters in detach mode', () => {
+    expect(() => validateDetachReporterTypes(['list', 'json', 'github'])).toThrow(
+      '--detach does not support --reporter json, --reporter github',
+    )
   })
 })

--- a/packages/cli/src/helpers/test-helper.ts
+++ b/packages/cli/src/helpers/test-helper.ts
@@ -5,6 +5,8 @@ import { ReporterType } from '../reporters/reporter.js'
 import { isCI } from 'ci-info'
 import { DEFAULT_REGION } from './constants.js'
 
+const unsupportedDetachedReporterTypes: ReporterType[] = ['json', 'github']
+
 export async function prepareRunLocation (
   configOptions: { runLocation?: keyof Region, privateRunLocation?: string } = {},
   cliFlags: { runLocation?: keyof Region, privateRunLocation?: string } = {},
@@ -60,6 +62,18 @@ export function prepareReportersTypes (
     return [isCI ? 'ci' : 'list']
   }
   return reporterFlag?.length ? reporterFlag : cliReporters
+}
+
+export function validateDetachReporterTypes (reporterTypes: ReporterType[]): void {
+  const unsupported = [...new Set(reporterTypes.filter(type => unsupportedDetachedReporterTypes.includes(type)))]
+
+  if (unsupported.length) {
+    throw new Error(
+      `--detach does not support ${unsupported.map(type => `--reporter ${type}`).join(', ')}. `
+      + 'Detached runs exit after scheduling, before result reports can be written. '
+      + 'Omit --detach to write a report, or use `checkly test-sessions get <test-session-id> --output json` after scheduling.',
+    )
+  }
 }
 
 export function splitChecklyAndPlaywrightFlags (args: string[]) {

--- a/packages/cli/src/reporters/__tests__/abstract-list.spec.ts
+++ b/packages/cli/src/reporters/__tests__/abstract-list.spec.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import ListReporter from '../list.js'
+import * as api from '../../rest/api.js'
 import type { SequenceId } from '../../services/abstract-check-runner.js'
 
 vi.mock('../../rest/api.js', () => ({
@@ -29,6 +30,8 @@ const PUBLIC_RUN_LOCATION = { type: 'PUBLIC' as const, region: 'eu-west-1' }
 
 const SOURCE_FILE = 'folder/api.check.ts'
 const SEQUENCE_ID: SequenceId = 'seq-001'
+const TEST_SESSION_ID = '8166fa86-c9b4-4162-8541-d380c6c212d8'
+const TEST_SESSION_URL = `https://app.checklyhq.com/accounts/test-account-123/test-sessions/${TEST_SESSION_ID}`
 
 function makeCheck (sourceFile = SOURCE_FILE) {
   return {
@@ -47,16 +50,41 @@ function makePassingResult (sourceFile = SOURCE_FILE) {
   }
 }
 
-function makeReporterWithOneCheck () {
+function makeReporterWithOneCheck (testSessionId?: string) {
   const reporter = new ListReporter(PUBLIC_RUN_LOCATION, false)
   const check = makeCheck()
-  reporter.onBegin([{ check, sequenceId: SEQUENCE_ID }])
+  reporter.onBegin([{ check, sequenceId: SEQUENCE_ID }], testSessionId)
   return { reporter, check }
+}
+
+function countOccurrences (text: string, substring: string): number {
+  return text.split(substring).length - 1
 }
 
 describe('AbstractListReporter', () => {
   beforeEach(() => {
     printLnMock.mockClear()
+    vi.mocked(api.testSessions.getShortLink).mockReset()
+  })
+
+  it('should print a test session ID and inspect command when a session is recorded', () => {
+    makeReporterWithOneCheck(TEST_SESSION_ID)
+
+    const calls = printLnMock.mock.calls.map(([text]: [string]) => text)
+    const output = calls.join('\n')
+    expect(output).toContain(`Test session ID: ${TEST_SESSION_ID}`)
+    expect(output).toContain(`Inspect session: checkly test-sessions get ${TEST_SESSION_ID} --watch`)
+    expect(output).toContain(`Open session: ${TEST_SESSION_URL}`)
+  })
+
+  it('should not print test session reference lines when no session is recorded', () => {
+    makeReporterWithOneCheck()
+
+    const calls = printLnMock.mock.calls.map(([text]: [string]) => text)
+    const output = calls.join('\n')
+    expect(output).not.toContain('Test session ID:')
+    expect(output).not.toContain('Inspect session:')
+    expect(output).not.toContain('Open session:')
   })
 
   it('should call printLn with check status output after onCheckEnd', () => {
@@ -79,7 +107,7 @@ describe('AbstractListReporter', () => {
   })
 
   it('should include cancellation message with --detach hint after onCancel', () => {
-    const { reporter } = makeReporterWithOneCheck()
+    const { reporter } = makeReporterWithOneCheck(TEST_SESSION_ID)
 
     reporter.onCancel()
 
@@ -87,15 +115,49 @@ describe('AbstractListReporter', () => {
     const summary = calls.join('\n')
     expect(summary).toContain('Cancelling checks')
     expect(summary).toContain('--detach')
+    expect(summary).toContain(`Test session ID: ${TEST_SESSION_ID}`)
+    expect(summary).toContain(`Inspect session: checkly test-sessions get ${TEST_SESSION_ID} --watch`)
+    expect(summary).toContain(`Open session: ${TEST_SESSION_URL}`)
+    expect(countOccurrences(summary, `Test session ID: ${TEST_SESSION_ID}`)).toBe(1)
+    expect(countOccurrences(summary, `Inspect session: checkly test-sessions get ${TEST_SESSION_ID} --watch`)).toBe(1)
+    expect(countOccurrences(summary, `Open session: ${TEST_SESSION_URL}`)).toBe(1)
   })
 
   it('should include detach message after onDetach', () => {
-    const { reporter } = makeReporterWithOneCheck()
+    const { reporter } = makeReporterWithOneCheck(TEST_SESSION_ID)
 
     reporter.onDetach()
 
     const calls = printLnMock.mock.calls.map(([text]: [string]) => text)
     const summary = calls.join('\n')
     expect(summary).toContain('continue running')
+    expect(summary).toContain(`Test session ID: ${TEST_SESSION_ID}`)
+    expect(summary).toContain(`Inspect session: checkly test-sessions get ${TEST_SESSION_ID} --watch`)
+    expect(summary).toContain(`Open session: ${TEST_SESSION_URL}`)
+    expect(countOccurrences(summary, `Test session ID: ${TEST_SESSION_ID}`)).toBe(1)
+    expect(countOccurrences(summary, `Inspect session: checkly test-sessions get ${TEST_SESSION_ID} --watch`)).toBe(1)
+    expect(countOccurrences(summary, `Open session: ${TEST_SESSION_URL}`)).toBe(1)
+  })
+
+  it('should render existing detailed session summary link output', async () => {
+    vi.mocked(api.testSessions.getShortLink).mockResolvedValue({
+      data: {
+        link: 'https://chkly.link/session-summary',
+      },
+    } as any)
+    const { reporter } = makeReporterWithOneCheck(TEST_SESSION_ID)
+
+    await reporter._printTestSessionsUrl()
+
+    const calls = printLnMock.mock.calls.map(([text]: [string]) => text)
+    const output = calls.join('\n')
+    expect(output).toContain(`Test session ID: ${TEST_SESSION_ID}`)
+    expect(output).toContain(`Inspect session: checkly test-sessions get ${TEST_SESSION_ID} --watch`)
+    expect(output).toContain(`Open session: ${TEST_SESSION_URL}`)
+    expect(output).toContain('Detailed session summary at:')
+    expect(output).toContain('https://chkly.link/session-summary')
+    expect(countOccurrences(output, `Test session ID: ${TEST_SESSION_ID}`)).toBe(1)
+    expect(countOccurrences(output, `Inspect session: checkly test-sessions get ${TEST_SESSION_ID} --watch`)).toBe(1)
+    expect(countOccurrences(output, `Open session: ${TEST_SESSION_URL}`)).toBe(1)
   })
 })

--- a/packages/cli/src/reporters/abstract-list.ts
+++ b/packages/cli/src/reporters/abstract-list.ts
@@ -33,6 +33,7 @@ export default abstract class AbstractListReporter implements Reporter {
   numChecks?: number
   verbose: boolean
   testSessionId?: string
+  private hasPrintedTestSessionReference = false
   _isSchedulingDelayExceeded?: boolean
   showStreamingHeaders: boolean
 
@@ -63,6 +64,7 @@ export default abstract class AbstractListReporter implements Reporter {
         numRetries: 0,
       })
     })
+    this._printTestSessionReference()
   }
 
   onCheckInProgress (check: any, sequenceId: SequenceId) {
@@ -201,12 +203,20 @@ export default abstract class AbstractListReporter implements Reporter {
     if (!opts.skipCheckCount) {
       if (this._isCancelling) {
         status.push('')
-        status.push(chalk.yellow('Cancelling checks... Use --detach to keep checks running in the cloud.'))
+        status.push(chalk.yellow('Cancelling checks... Use --detach to start checks in the cloud and exit after scheduling.'))
+        if (!this.hasPrintedTestSessionReference) {
+          status.push(...this._getTestSessionReferenceLines())
+          this.hasPrintedTestSessionReference = true
+        }
       }
 
       if (this._isDetaching) {
         status.push('')
         status.push(chalk.yellow('Checks will continue running in the cloud.'))
+        if (!this.hasPrintedTestSessionReference) {
+          status.push(...this._getTestSessionReferenceLines())
+          this.hasPrintedTestSessionReference = true
+        }
       }
 
       status.push('')
@@ -271,6 +281,7 @@ export default abstract class AbstractListReporter implements Reporter {
 
   async _printTestSessionsUrl () {
     if (this.testSessionId) {
+      this._printTestSessionReference()
       try {
         const { data: { link } } = await testSessions.getShortLink(this.testSessionId)
         printLn(`${chalk.white('Detailed session summary at:')} ${chalk.underline.cyan(link)}`, 2)
@@ -278,6 +289,32 @@ export default abstract class AbstractListReporter implements Reporter {
         printLn(`${chalk.white('Detailed session summary at:')} ${chalk.underline.cyan(getTestSessionUrl(this.testSessionId))}`, 2)
       }
     }
+  }
+
+  _getTestSessionReferenceLines (): string[] {
+    if (!this.testSessionId) {
+      return []
+    }
+
+    return [
+      `${chalk.white('Test session ID:')} ${this.testSessionId}`,
+      `${chalk.white('Inspect session:')} ${chalk.cyan(`checkly test-sessions get ${this.testSessionId} --watch`)}`,
+      `${chalk.white('Open session:')} ${chalk.underline.cyan(getTestSessionUrl(this.testSessionId))}`,
+    ]
+  }
+
+  _printTestSessionReference (): void {
+    if (this.hasPrintedTestSessionReference) {
+      return
+    }
+
+    const lines = this._getTestSessionReferenceLines()
+    if (!lines.length) {
+      return
+    }
+
+    printLn(lines.join('\n'), 2)
+    this.hasPrintedTestSessionReference = true
   }
 
   _printTip (tip: string): void {

--- a/packages/cli/src/services/__tests__/abstract-check-runner.spec.ts
+++ b/packages/cli/src/services/__tests__/abstract-check-runner.spec.ts
@@ -83,7 +83,7 @@ describe('AbstractCheckRunner — SIGINT / cancellation', () => {
     expect(sigintCalls).toHaveLength(1)
   })
 
-  it('registers a SIGINT handler during run() when detach is true', async () => {
+  it('does not register a SIGINT handler when detach is true', async () => {
     const onSpy = vi.spyOn(process, 'on').mockReturnValue(process)
     vi.spyOn(process, 'off').mockReturnValue(process)
 
@@ -91,29 +91,26 @@ describe('AbstractCheckRunner — SIGINT / cancellation', () => {
     await runner.run()
 
     const sigintCalls = onSpy.mock.calls.filter(([event]) => event === 'SIGINT')
-    expect(sigintCalls).toHaveLength(1)
+    expect(sigintCalls).toHaveLength(0)
   })
 
-  it('emits Events.DETACH and exits with 0 on SIGINT when detach is true', async () => {
-    let sigintHandler: (() => void) | undefined
-    vi.spyOn(process, 'on').mockImplementation((event: string | symbol, listener: any) => {
-      if (event === 'SIGINT') sigintHandler = listener
-      return process
-    })
+  it('emits RUN_STARTED and DETACH immediately when detach is true', async () => {
+    vi.spyOn(process, 'on').mockReturnValue(process)
     vi.spyOn(process, 'off').mockReturnValue(process)
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
 
     const runner = makeRunner(true)
 
+    const runStartedEvents: unknown[] = []
     const detachEvents: unknown[] = []
+    runner.on(Events.RUN_STARTED, (checks, testSessionId) => runStartedEvents.push({ checks, testSessionId }))
     runner.on(Events.DETACH, () => detachEvents.push(true))
+    runner.on(Events.RUN_FINISHED, () => detachEvents.push('finished'))
 
     await runner.run()
 
-    sigintHandler?.()
-
+    expect(runStartedEvents).toEqual([{ checks: [], testSessionId: 'ts-stub' }])
     expect(detachEvents).toHaveLength(1)
-    expect(exitSpy).toHaveBeenCalledWith(0)
+    expect(detachEvents[0]).toBe(true)
   })
 
   it('removes the SIGINT handler in the finally block after run() completes', async () => {
@@ -214,6 +211,16 @@ describe('AbstractCheckRunner — SocketClient lifecycle', () => {
     await runner.run()
 
     expect(SocketClient.connect).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not connect SocketClient when detach is true', async () => {
+    vi.spyOn(process, 'on').mockReturnValue(process)
+    vi.spyOn(process, 'off').mockReturnValue(process)
+
+    const runner = makeRunner(true)
+    await runner.run()
+
+    expect(SocketClient.connect).not.toHaveBeenCalled()
   })
 
   it('calls endAsync on the socket client in the finally block', async () => {

--- a/packages/cli/src/services/abstract-check-runner.ts
+++ b/packages/cli/src/services/abstract-check-runner.ts
@@ -83,9 +83,21 @@ export default abstract class AbstractCheckRunner extends EventEmitter {
     let sigintHandler: (() => void) | null = null
     let previousSigintListeners: Array<(...args: any[]) => void> = []
     try {
+      const checkRunSuiteId = uuid.v4()
+
+      if (this.detach) {
+        const { testSessionId, checks } = await this.scheduleChecks(checkRunSuiteId)
+        this.testSessionId = testSessionId
+        this.checks = new Map(
+          checks.map(({ check, sequenceId }) => [sequenceId, { check }]),
+        )
+        this.emit(Events.RUN_STARTED, checks, testSessionId)
+        this.emit(Events.DETACH)
+        return
+      }
+
       socketClient = await SocketClient.connect()
 
-      const checkRunSuiteId = uuid.v4()
       // Configure the socket listener and allChecksFinished listener before starting checks to avoid race conditions
       await this.configureResultListener(checkRunSuiteId, socketClient)
 
@@ -113,10 +125,7 @@ export default abstract class AbstractCheckRunner extends EventEmitter {
         }
         lastSigintAt = now
 
-        if (this.detach) {
-          this.emit(Events.DETACH)
-          process.exit(0)
-        } else if (hasCancelled) {
+        if (hasCancelled) {
           process.exit(1)
         } else {
           hasCancelled = true


### PR DESCRIPTION
## Summary

- Make `--detach` for `test`, `trigger`, and `pw-test` return immediately after scheduling a recorded test session.
- Print the test session ID, `test-sessions get <id> --watch`, and the canonical app URL once, so agents and humans have actionable handles without waiting for result streaming.
- Reject `--detach` with file reporters (`json`, `github`) because detached runs exit before result reports can be written.
- Update the test-session skill guidance to prefer `--detach` for agent workflows and use `test-sessions get --output json` for machine-readable follow-up.
- Normalize frequency-like construct values before synthesizing check payloads, avoiding leaked `Frequency` objects when the config and CLI load separate module instances.

## Validation

- `pnpm --filter checkly exec vitest --run ./src/helpers/__tests__/test-helper.spec.ts ./src/services/__tests__/abstract-check-runner.spec.ts ./src/reporters/__tests__/abstract-list.spec.ts ./src/commands/__tests__/command-metadata.spec.ts`
- `pnpm --filter checkly exec vitest --run ./src/services/__tests__/abstract-check-runner.spec.ts ./src/reporters/__tests__/abstract-list.spec.ts ./src/constructs/__tests__/check.spec.ts ./src/commands/__tests__/command-metadata.spec.ts ./src/reporters/__tests__/json-builder.spec.ts ./src/reporters/__tests__/github-md-builder.spec.ts`
- `pnpm --filter checkly run prepare:dist`
- `pnpm --filter checkly run prepare:ai-context`
- `pnpm --filter checkly run prepack`
- `CHECKLY_SKIP_AUTH=1 packages/cli/bin/run skills investigate test-sessions`
- `CHECKLY_SKIP_AUTH=1 packages/cli/bin/run test --help`
- `CHECKLY_SKIP_AUTH=1 packages/cli/bin/run trigger --detach --reporter json` exits with a clear unsupported-reporter error
- `git diff --check`