### PR TITLE
fix(cli): prefer project lockfile over invocation package manager

### DIFF
--- a/packages/cli/src/helpers/onboarding/boilerplate.ts
+++ b/packages/cli/src/helpers/onboarding/boilerplate.ts
@@ -38,9 +38,7 @@ function sanitizeLogicalId (name: string): string {
 }
 
 async function detectProjectPackageManager (projectDir: string): Promise<{ name: string, installCmd: string }> {
-  // Skip user agent detection — when invoked via npx, it always reports npm
-  // regardless of the project's actual package manager. Lockfile/config detection is reliable.
-  const pm = await detectPackageManager(projectDir, { skipUserAgent: true })
+  const pm = await detectPackageManager(projectDir)
   const runnable = pm.installCommand()
   return { name: pm.name, installCmd: runnable.unsafeDisplayCommand }
 }

--- a/packages/cli/src/services/check-parser/package-files/__tests__/package-manager.spec.ts
+++ b/packages/cli/src/services/check-parser/package-files/__tests__/package-manager.spec.ts
@@ -1,0 +1,464 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  detectAllNearestLockfiles,
+  detectPackageManager,
+  knownPackageManagers,
+  NoLockfileFoundError,
+  npmPackageManager,
+  PackageManagerDetector,
+  YarnDetector,
+} from '../package-manager.js'
+
+// Detection consults, in order: the npm_config_user_agent env var, the JS
+// runtime, lockfiles, config files, and finally executables on PATH. The
+// env var and runtime describe how the CLI was *launched*, not what the
+// project uses, so these tests verify that a project's lockfile — when one
+// exists — wins over those ambient signals, while behavior is unchanged when
+// no lockfile exists.
+describe('detectPackageManager', () => {
+  // Restricting the detector set keeps tests hermetic: it excludes the
+  // bun/deno detectors (whose detectRuntime() reads process.versions and could
+  // fire under an exotic test runner) and bounds which package managers the
+  // executable-on-PATH fallback can ever return.
+  // Returns the detectors named, in the exact order requested (Array.filter
+  // would instead preserve knownPackageManagers' order, which matters when a
+  // test depends on detector precedence).
+  const detectorsNamed = (...names: string[]): PackageManagerDetector[] =>
+    names.map(name => {
+      const detector = knownPackageManagers.find(candidate => candidate.name === name)
+      if (detector === undefined) {
+        throw new Error(`No known package manager detector named ${name}`)
+      }
+      return detector
+    })
+
+  const pnpmNpm = detectorsNamed('pnpm', 'npm')
+  const pnpmYarnNpm = detectorsNamed('pnpm', 'yarn', 'npm')
+
+  const tmpDirs: string[] = []
+  let savedUserAgent: string | undefined
+
+  beforeEach(() => {
+    savedUserAgent = process.env['npm_config_user_agent']
+  })
+
+  afterEach(async () => {
+    setUserAgent(savedUserAgent)
+    vi.restoreAllMocks()
+    await Promise.all(tmpDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })))
+  })
+
+  function setUserAgent (userAgent: string | undefined): void {
+    if (userAgent === undefined) {
+      delete process.env['npm_config_user_agent']
+    } else {
+      process.env['npm_config_user_agent'] = userAgent
+    }
+  }
+
+  // Builds an isolated temp directory tree containing the given files (keyed by
+  // relative path, with their contents as values — lockfiles only need to
+  // exist, so the content is irrelevant). Returns the realpath'd root so the
+  // `root` option, which bounds the lineage walk via a string comparison,
+  // terminates correctly on macOS (/var -> /private/var).
+  async function makeTree (files: Record<string, string>): Promise<string> {
+    const root = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), 'checkly-pm-spec-')),
+    )
+    tmpDirs.push(root)
+
+    for (const [relativePath, content] of Object.entries(files)) {
+      const fullPath = path.join(root, relativePath)
+      await fs.mkdir(path.dirname(fullPath), { recursive: true })
+      await fs.writeFile(fullPath, content)
+    }
+
+    return root
+  }
+
+  describe('lockfile wins over ambient signals', () => {
+    it('prefers the project lockfile over an npm user agent (npx in a pnpm repo)', async () => {
+      // The headline bug: a pnpm project invoked via `npx checkly` reports an
+      // npm user agent but must still resolve to pnpm.
+      setUserAgent('npm/10.0.0 node/v20.19.0')
+      const root = await makeTree({ 'pnpm-lock.yaml': '' })
+
+      const pm = await detectPackageManager(root, { detectors: pnpmNpm, root })
+
+      expect(pm.name).toBe('pnpm')
+    })
+
+    it('prefers the project lockfile over a pnpm user agent (CLI run under pnpm)', async () => {
+      // The internal-tests bug: `pnpm vitest` leaks a pnpm user agent into the
+      // CLI process, but a fixture with an npm lockfile must resolve to npm.
+      setUserAgent('pnpm/8.0.0 node/v20.19.0')
+      const root = await makeTree({ 'package-lock.json': '' })
+
+      const pm = await detectPackageManager(root, { detectors: pnpmNpm, root })
+
+      expect(pm.name).toBe('npm')
+    })
+
+    it('returns the package manager when user agent and lockfile agree', async () => {
+      setUserAgent('pnpm/8.0.0 node/v20.19.0')
+      const root = await makeTree({ 'pnpm-lock.yaml': '' })
+
+      const pm = await detectPackageManager(root, { detectors: pnpmNpm, root })
+
+      expect(pm.name).toBe('pnpm')
+    })
+
+    it('detects yarn from yarn.lock despite an npm user agent', async () => {
+      setUserAgent('npm/10.0.0 node/v20.19.0')
+      const root = await makeTree({ 'yarn.lock': '' })
+
+      const pm = await detectPackageManager(root, { detectors: pnpmYarnNpm, root })
+
+      expect(pm.name).toBe('yarn')
+    })
+  })
+
+  describe('no lockfile falls back to ambient detection', () => {
+    it('falls back to the user agent when no lockfile exists', async () => {
+      setUserAgent('yarn/1.22.0 node/v20.19.0')
+      const root = await makeTree({})
+
+      const pm = await detectPackageManager(root, { detectors: pnpmYarnNpm, root })
+
+      expect(pm.name).toBe('yarn')
+    })
+
+    it('falls back to config file detection when there is no lockfile and no user agent', async () => {
+      setUserAgent(undefined)
+      const root = await makeTree({ 'pnpm-workspace.yaml': '' })
+
+      const pm = await detectPackageManager(root, { detectors: pnpmNpm, root })
+
+      expect(pm.name).toBe('pnpm')
+    })
+
+    it('keeps the user agent ahead of a config file when there is no lockfile', async () => {
+      // A config file is a weaker signal than the user agent; with no lockfile
+      // to override it, the npm user agent still wins over pnpm-workspace.yaml.
+      setUserAgent('npm/10.0.0 node/v20.19.0')
+      const root = await makeTree({ 'pnpm-workspace.yaml': '' })
+
+      const pm = await detectPackageManager(root, { detectors: pnpmNpm, root })
+
+      expect(pm.name).toBe('npm')
+    })
+
+    it('falls back to npm when nothing matches', async () => {
+      // Restricting detectors to npm makes the result deterministic regardless
+      // of which package managers are installed on PATH.
+      setUserAgent(undefined)
+      const root = await makeTree({})
+
+      const pm = await detectPackageManager(root, { detectors: [npmPackageManager], root })
+
+      expect(pm.name).toBe('npm')
+    })
+  })
+
+  describe('lineage walking', () => {
+    it('finds a lockfile in a parent directory', async () => {
+      setUserAgent(undefined)
+      const root = await makeTree({
+        'pnpm-lock.yaml': '',
+        'sub/package.json': '{}',
+      })
+
+      const pm = await detectPackageManager(path.join(root, 'sub'), { detectors: pnpmNpm, root })
+
+      expect(pm.name).toBe('pnpm')
+    })
+
+    it('prefers the nearest directory lockfile over a farther one', async () => {
+      // A npm lockfile in the start directory wins over a pnpm lockfile in a
+      // parent, even when the user agent points at pnpm: the nearest directory
+      // containing any lockfile decides.
+      setUserAgent('pnpm/8.0.0 node/v20.19.0')
+      const root = await makeTree({
+        'pnpm-lock.yaml': '',
+        'sub/package-lock.json': '',
+      })
+
+      const pm = await detectPackageManager(path.join(root, 'sub'), { detectors: pnpmNpm, root })
+
+      expect(pm.name).toBe('npm')
+    })
+
+    it('stops at the root directory and does not escape into ancestors', async () => {
+      // The lockfile lives above `root`, so the bounded walk must not find it
+      // and detection falls back to the user agent.
+      setUserAgent('yarn/1.22.0 node/v20.19.0')
+      const outer = await makeTree({ 'pnpm-lock.yaml': '' })
+      const inner = path.join(outer, 'project')
+      await fs.mkdir(inner, { recursive: true })
+
+      const pm = await detectPackageManager(inner, { detectors: pnpmYarnNpm, root: inner })
+
+      expect(pm.name).toBe('yarn')
+    })
+  })
+
+  describe('multiple lockfiles in the same directory', () => {
+    it('lets the user agent break the tie', async () => {
+      setUserAgent('pnpm/8.0.0 node/v20.19.0')
+      const root = await makeTree({
+        'pnpm-lock.yaml': '',
+        'package-lock.json': '',
+      })
+
+      const pm = await detectPackageManager(root, { detectors: pnpmNpm, root })
+
+      expect(pm.name).toBe('pnpm')
+    })
+
+    it('honors the same tie the other way for an npm user agent', async () => {
+      setUserAgent('npm/10.0.0 node/v20.19.0')
+      const root = await makeTree({
+        'pnpm-lock.yaml': '',
+        'package-lock.json': '',
+      })
+
+      const pm = await detectPackageManager(root, { detectors: pnpmNpm, root })
+
+      expect(pm.name).toBe('npm')
+    })
+
+    it('falls back to detector order when no user agent disambiguates', async () => {
+      // With no user agent and two co-located lockfiles, the first matching
+      // detector in the provided order wins.
+      setUserAgent(undefined)
+      const root = await makeTree({
+        'pnpm-lock.yaml': '',
+        'package-lock.json': '',
+      })
+
+      const npmFirst = await detectPackageManager(root, { detectors: detectorsNamed('npm', 'pnpm'), root })
+      expect(npmFirst.name).toBe('npm')
+
+      const pnpmFirst = await detectPackageManager(root, { detectors: detectorsNamed('pnpm', 'npm'), root })
+      expect(pnpmFirst.name).toBe('pnpm')
+    })
+  })
+
+  describe('runtime detection is gated the same way as the user agent', () => {
+    // Force a detector's runtime check on so the runtime branch is exercised
+    // without depending on the actual JS runtime the tests run under.
+    function yarnWithRuntime (): YarnDetector {
+      const detector = new YarnDetector()
+      vi.spyOn(detector, 'detectRuntime').mockReturnValue(true)
+      return detector
+    }
+
+    it('prefers the project lockfile over the detected runtime', async () => {
+      setUserAgent(undefined)
+      const root = await makeTree({ 'package-lock.json': '' })
+
+      const pm = await detectPackageManager(root, {
+        detectors: [yarnWithRuntime(), npmPackageManager],
+        root,
+      })
+
+      expect(pm.name).toBe('npm')
+    })
+
+    it('uses the runtime package manager when it is backed by a lockfile', async () => {
+      setUserAgent(undefined)
+      const root = await makeTree({ 'yarn.lock': '' })
+
+      const pm = await detectPackageManager(root, {
+        detectors: [yarnWithRuntime(), npmPackageManager],
+        root,
+      })
+
+      expect(pm.name).toBe('yarn')
+    })
+
+    it('falls back to the runtime when no lockfile exists', async () => {
+      setUserAgent(undefined)
+      const root = await makeTree({})
+
+      const pm = await detectPackageManager(root, {
+        detectors: [yarnWithRuntime(), npmPackageManager],
+        root,
+      })
+
+      expect(pm.name).toBe('yarn')
+    })
+  })
+
+  describe('executable on PATH fallback', () => {
+    // The executable tier only runs when no lockfile, user agent, runtime, or
+    // config file resolves. Spy on detectExecutable to keep it off the real
+    // PATH and make the outcome deterministic.
+    it('uses an executable on PATH as a last resort before npm', async () => {
+      setUserAgent(undefined)
+      const root = await makeTree({})
+      const yarn = new YarnDetector()
+      vi.spyOn(yarn, 'detectExecutable').mockResolvedValue(undefined)
+
+      const pm = await detectPackageManager(root, { detectors: [yarn], root })
+
+      expect(pm.name).toBe('yarn')
+    })
+
+    it('returns npm when even executable detection finds nothing', async () => {
+      // Exercises the ultimate `return npmPackageManager` fallback.
+      setUserAgent(undefined)
+      const root = await makeTree({})
+      const yarn = new YarnDetector()
+      vi.spyOn(yarn, 'detectExecutable').mockRejectedValue(new Error('not on PATH'))
+
+      const pm = await detectPackageManager(root, { detectors: [yarn], root })
+
+      expect(pm.name).toBe('npm')
+    })
+  })
+
+  describe('user agent edge cases', () => {
+    it('ignores a user agent that matches no known detector', async () => {
+      // A bun user agent with bun excluded from the detector set must not
+      // prevent the npm lockfile from being detected.
+      setUserAgent('bun/1.1.0 node/v20.19.0')
+      const root = await makeTree({ 'package-lock.json': '' })
+
+      const pm = await detectPackageManager(root, { detectors: pnpmNpm, root })
+
+      expect(pm.name).toBe('npm')
+    })
+  })
+
+  describe('cnpm (shares npm\'s package-lock.json)', () => {
+    const cnpmNpm = detectorsNamed('cnpm', 'npm')
+
+    it('detects cnpm from the user agent when no lockfile exists', async () => {
+      setUserAgent('npminstall/7.0.0 node/v20.19.0')
+      const root = await makeTree({})
+
+      const pm = await detectPackageManager(root, { detectors: cnpmNpm, root })
+
+      expect(pm.name).toBe('cnpm')
+    })
+
+    it('detects cnpm when its user agent and a package-lock.json are both present', async () => {
+      // cnpm claims package-lock.json, so the cnpm user agent is now
+      // lockfile-backed and wins over the bare lockfile.
+      setUserAgent('npminstall/7.0.0 node/v20.19.0')
+      const root = await makeTree({ 'package-lock.json': '' })
+
+      const pm = await detectPackageManager(root, { detectors: cnpmNpm, root })
+
+      expect(pm.name).toBe('cnpm')
+    })
+
+    it('defaults a bare package-lock.json to npm, not cnpm', async () => {
+      // No cnpm user agent: with the full detector set npm is ordered ahead of
+      // cnpm, so a plain package-lock.json resolves to npm.
+      setUserAgent(undefined)
+      const root = await makeTree({ 'package-lock.json': '' })
+
+      const pm = await detectPackageManager(root)
+
+      expect(pm.name).toBe('npm')
+    })
+
+    it('keeps an npm user agent resolving to npm despite the shared lockfile', async () => {
+      setUserAgent('npm/10.0.0 node/v20.19.0')
+      const root = await makeTree({ 'package-lock.json': '' })
+
+      const pm = await detectPackageManager(root, { detectors: cnpmNpm, root })
+
+      expect(pm.name).toBe('npm')
+    })
+
+    it('does not mis-detect cnpm in a pnpm project (no cross-PM regression)', async () => {
+      // Running cnpm inside a pnpm repo: there's no package-lock.json to back
+      // the cnpm user agent, so the pnpm lockfile still wins.
+      setUserAgent('npminstall/7.0.0 node/v20.19.0')
+      const root = await makeTree({ 'pnpm-lock.yaml': '' })
+
+      const pm = await detectPackageManager(root, {
+        detectors: detectorsNamed('cnpm', 'pnpm', 'npm'),
+        root,
+      })
+
+      expect(pm.name).toBe('pnpm')
+    })
+  })
+
+  describe('default detector set', () => {
+    it('uses all known package managers when no options are provided', async () => {
+      // No detectors and no root: exercises the `?? knownPackageManagers`
+      // default. The lockfile sits in the start directory, so the unbounded
+      // lineage walk resolves it immediately without escaping into ancestors.
+      setUserAgent('npm/10.0.0 node/v20.19.0')
+      const root = await makeTree({ 'pnpm-lock.yaml': '' })
+
+      const pm = await detectPackageManager(root)
+
+      expect(pm.name).toBe('pnpm')
+    })
+  })
+})
+
+describe('detectAllNearestLockfiles', () => {
+  const tmpDirs: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(tmpDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })))
+  })
+
+  async function makeTree (files: Record<string, string>): Promise<string> {
+    const root = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), 'checkly-pm-all-spec-')),
+    )
+    tmpDirs.push(root)
+
+    for (const [relativePath, content] of Object.entries(files)) {
+      const fullPath = path.join(root, relativePath)
+      await fs.mkdir(path.dirname(fullPath), { recursive: true })
+      await fs.writeFile(fullPath, content)
+    }
+
+    return root
+  }
+
+  const pnpmNpm = knownPackageManagers.filter(detector => ['pnpm', 'npm'].includes(detector.name))
+
+  it('returns every lockfile found in the nearest directory that has one', async () => {
+    const root = await makeTree({
+      'pnpm-lock.yaml': '',
+      'package-lock.json': '',
+    })
+
+    const results = await detectAllNearestLockfiles(root, { detectors: pnpmNpm, root })
+
+    expect(results.map(result => result.packageManager.name).sort()).toEqual(['npm', 'pnpm'])
+  })
+
+  it('stops at the nearest directory and does not collect from ancestors', async () => {
+    const root = await makeTree({
+      'pnpm-lock.yaml': '',
+      'sub/package-lock.json': '',
+    })
+
+    const results = await detectAllNearestLockfiles(path.join(root, 'sub'), { detectors: pnpmNpm, root })
+
+    expect(results.map(result => result.packageManager.name)).toEqual(['npm'])
+  })
+
+  it('throws NoLockfileFoundError when no lockfile exists in the lineage', async () => {
+    const root = await makeTree({})
+
+    await expect(detectAllNearestLockfiles(root, { detectors: pnpmNpm, root }))
+      .rejects.toBeInstanceOf(NoLockfileFoundError)
+  })
+})

--- a/packages/cli/src/services/check-parser/package-files/__tests__/package-manager.spec.ts
+++ b/packages/cli/src/services/check-parser/package-files/__tests__/package-manager.spec.ts
@@ -5,10 +5,12 @@ import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  CNpmDetector,
   detectNearestLockfiles,
   detectPackageManager,
   knownPackageManagers,
   NoLockfileFoundError,
+  NpmDetector,
   npmPackageManager,
   PackageManagerDetector,
   YarnDetector,
@@ -25,9 +27,10 @@ describe('detectPackageManager', () => {
   // bun/deno detectors (whose detectRuntime() reads process.versions and could
   // fire under an exotic test runner) and bounds which package managers the
   // executable-on-PATH fallback can ever return.
-  // Returns the detectors named, in the exact order requested (Array.filter
-  // would instead preserve knownPackageManagers' order, which matters when a
-  // test depends on detector precedence).
+  // Returns the detectors named, in the exact order requested. Detection
+  // precedence is governed by each detector's priority(method), not by input
+  // order, so several tests pass the same detectors in different orders to prove
+  // the result is identical.
   const detectorsNamed = (...names: string[]): PackageManagerDetector[] =>
     names.map(name => {
       const detector = knownPackageManagers.find(candidate => candidate.name === name)
@@ -232,9 +235,10 @@ describe('detectPackageManager', () => {
       expect(pm.name).toBe('npm')
     })
 
-    it('falls back to detector order when no user agent disambiguates', async () => {
-      // With no user agent and two co-located lockfiles, the first matching
-      // detector in the provided order wins.
+    it('breaks the tie by priority regardless of detector input order', async () => {
+      // With no user agent and two co-located lockfiles, the higher-priority
+      // detector (pnpm 60 > npm 20) wins no matter the order detectors are
+      // supplied in — input order does not affect the result.
       setUserAgent(undefined)
       const root = await makeTree({
         'pnpm-lock.yaml': '',
@@ -242,7 +246,7 @@ describe('detectPackageManager', () => {
       })
 
       const npmFirst = await detectPackageManager(root, { detectors: detectorsNamed('npm', 'pnpm'), root })
-      expect(npmFirst.name).toBe('npm')
+      expect(npmFirst.name).toBe('pnpm')
 
       const pnpmFirst = await detectPackageManager(root, { detectors: detectorsNamed('pnpm', 'npm'), root })
       expect(pnpmFirst.name).toBe('pnpm')
@@ -321,6 +325,34 @@ describe('detectPackageManager', () => {
 
       expect(pm.name).toBe('npm')
     })
+
+    it('prefers an installed cnpm over npm because npm is deprioritized for executables', async () => {
+      // npm is almost always on PATH, so its presence is no signal: with both
+      // cnpm and npm installed and nothing else to go on, cnpm wins.
+      setUserAgent(undefined)
+      const root = await makeTree({})
+      const npm = new NpmDetector()
+      const cnpm = new CNpmDetector()
+      vi.spyOn(npm, 'detectExecutable').mockResolvedValue(undefined)
+      vi.spyOn(cnpm, 'detectExecutable').mockResolvedValue(undefined)
+
+      const pm = await detectPackageManager(root, { detectors: [npm, cnpm], root })
+
+      expect(pm.name).toBe('cnpm')
+    })
+
+    it('still selects npm when it is the only executable present', async () => {
+      setUserAgent(undefined)
+      const root = await makeTree({})
+      const npm = new NpmDetector()
+      const cnpm = new CNpmDetector()
+      vi.spyOn(npm, 'detectExecutable').mockResolvedValue(undefined)
+      vi.spyOn(cnpm, 'detectExecutable').mockRejectedValue(new Error('not on PATH'))
+
+      const pm = await detectPackageManager(root, { detectors: [npm, cnpm], root })
+
+      expect(pm.name).toBe('npm')
+    })
   })
 
   describe('user agent edge cases', () => {
@@ -359,15 +391,21 @@ describe('detectPackageManager', () => {
       expect(pm.name).toBe('cnpm')
     })
 
-    it('defaults a bare package-lock.json to npm, not cnpm', async () => {
-      // No cnpm user agent: with the full detector set npm is ordered ahead of
-      // cnpm, so a plain package-lock.json resolves to npm.
+    it('defaults a bare package-lock.json to npm, not cnpm, regardless of detector order', async () => {
+      // No cnpm user agent: npm has a higher lockfile priority (20) than cnpm
+      // (10), so a plain package-lock.json resolves to npm whichever order the
+      // detectors are supplied in, and with the full default set.
       setUserAgent(undefined)
       const root = await makeTree({ 'package-lock.json': '' })
 
-      const pm = await detectPackageManager(root)
+      const npmFirst = await detectPackageManager(root, { detectors: detectorsNamed('npm', 'cnpm'), root })
+      expect(npmFirst.name).toBe('npm')
 
-      expect(pm.name).toBe('npm')
+      const cnpmFirst = await detectPackageManager(root, { detectors: detectorsNamed('cnpm', 'npm'), root })
+      expect(cnpmFirst.name).toBe('npm')
+
+      const defaultSet = await detectPackageManager(root)
+      expect(defaultSet.name).toBe('npm')
     })
 
     it('keeps an npm user agent resolving to npm despite the shared lockfile', async () => {

--- a/packages/cli/src/services/check-parser/package-files/__tests__/package-manager.spec.ts
+++ b/packages/cli/src/services/check-parser/package-files/__tests__/package-manager.spec.ts
@@ -5,7 +5,7 @@ import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
-  detectAllNearestLockfiles,
+  detectNearestLockfiles,
   detectPackageManager,
   knownPackageManagers,
   NoLockfileFoundError,
@@ -409,7 +409,7 @@ describe('detectPackageManager', () => {
   })
 })
 
-describe('detectAllNearestLockfiles', () => {
+describe('detectNearestLockfiles', () => {
   const tmpDirs: string[] = []
 
   afterEach(async () => {
@@ -439,7 +439,7 @@ describe('detectAllNearestLockfiles', () => {
       'package-lock.json': '',
     })
 
-    const results = await detectAllNearestLockfiles(root, { detectors: pnpmNpm, root })
+    const results = await detectNearestLockfiles(root, { detectors: pnpmNpm, root })
 
     expect(results.map(result => result.packageManager.name).sort()).toEqual(['npm', 'pnpm'])
   })
@@ -450,7 +450,7 @@ describe('detectAllNearestLockfiles', () => {
       'sub/package-lock.json': '',
     })
 
-    const results = await detectAllNearestLockfiles(path.join(root, 'sub'), { detectors: pnpmNpm, root })
+    const results = await detectNearestLockfiles(path.join(root, 'sub'), { detectors: pnpmNpm, root })
 
     expect(results.map(result => result.packageManager.name)).toEqual(['npm'])
   })
@@ -458,7 +458,7 @@ describe('detectAllNearestLockfiles', () => {
   it('throws NoLockfileFoundError when no lockfile exists in the lineage', async () => {
     const root = await makeTree({})
 
-    await expect(detectAllNearestLockfiles(root, { detectors: pnpmNpm, root }))
+    await expect(detectNearestLockfiles(root, { detectors: pnpmNpm, root }))
       .rejects.toBeInstanceOf(NoLockfileFoundError)
   })
 })

--- a/packages/cli/src/services/check-parser/package-files/__tests__/package-manager.spec.ts
+++ b/packages/cli/src/services/check-parser/package-files/__tests__/package-manager.spec.ts
@@ -6,9 +6,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   CNpmDetector,
+  detectNearestConfigFiles,
   detectNearestLockfiles,
   detectPackageManager,
   knownPackageManagers,
+  NoConfigFileFoundError,
   NoLockfileFoundError,
   NpmDetector,
   npmPackageManager,
@@ -143,6 +145,19 @@ describe('detectPackageManager', () => {
       const pm = await detectPackageManager(root, { detectors: pnpmNpm, root })
 
       expect(pm.name).toBe('pnpm')
+    })
+
+    it('breaks a co-located config-file tie by priority regardless of detector order', async () => {
+      // Two config files in the same directory: the higher-priority detector
+      // (pnpm 60 > deno 40) wins whichever order detectors are supplied in.
+      setUserAgent(undefined)
+      const root = await makeTree({ 'pnpm-workspace.yaml': '', 'deno.json': '' })
+
+      const denoFirst = await detectPackageManager(root, { detectors: detectorsNamed('deno', 'pnpm'), root })
+      expect(denoFirst.name).toBe('pnpm')
+
+      const pnpmFirst = await detectPackageManager(root, { detectors: detectorsNamed('pnpm', 'deno'), root })
+      expect(pnpmFirst.name).toBe('pnpm')
     })
 
     it('keeps the user agent ahead of a config file when there is no lockfile', async () => {
@@ -498,5 +513,59 @@ describe('detectNearestLockfiles', () => {
 
     await expect(detectNearestLockfiles(root, { detectors: pnpmNpm, root }))
       .rejects.toBeInstanceOf(NoLockfileFoundError)
+  })
+})
+
+describe('detectNearestConfigFiles', () => {
+  const tmpDirs: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(tmpDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })))
+  })
+
+  async function makeTree (files: Record<string, string>): Promise<string> {
+    const root = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), 'checkly-pm-config-spec-')),
+    )
+    tmpDirs.push(root)
+
+    for (const [relativePath, content] of Object.entries(files)) {
+      const fullPath = path.join(root, relativePath)
+      await fs.mkdir(path.dirname(fullPath), { recursive: true })
+      await fs.writeFile(fullPath, content)
+    }
+
+    return root
+  }
+
+  const pnpmDeno = knownPackageManagers.filter(detector => ['pnpm', 'deno'].includes(detector.name))
+
+  it('returns every config file found in the nearest directory that has one', async () => {
+    const root = await makeTree({
+      'pnpm-workspace.yaml': '',
+      'deno.json': '',
+    })
+
+    const results = await detectNearestConfigFiles(root, { detectors: pnpmDeno, root })
+
+    expect(results.map(result => result.packageManager.name).sort()).toEqual(['deno', 'pnpm'])
+  })
+
+  it('stops at the nearest directory and does not collect from ancestors', async () => {
+    const root = await makeTree({
+      'pnpm-workspace.yaml': '',
+      'sub/deno.json': '',
+    })
+
+    const results = await detectNearestConfigFiles(path.join(root, 'sub'), { detectors: pnpmDeno, root })
+
+    expect(results.map(result => result.packageManager.name)).toEqual(['deno'])
+  })
+
+  it('throws NoConfigFileFoundError when no config file exists in the lineage', async () => {
+    const root = await makeTree({})
+
+    await expect(detectNearestConfigFiles(root, { detectors: pnpmDeno, root }))
+      .rejects.toBeInstanceOf(NoConfigFileFoundError)
   })
 })

--- a/packages/cli/src/services/check-parser/package-files/package-manager.ts
+++ b/packages/cli/src/services/check-parser/package-files/package-manager.ts
@@ -614,7 +614,7 @@ async function detectPackageManagerImpl (
   } = options
 
   const lockfileDetected = new Set(Array.from(
-    await detectAllNearestLockfiles(dir, {
+    await detectNearestLockfiles(dir, {
       detectors,
       root: options?.root,
     }).catch(() => []),
@@ -743,55 +743,12 @@ export interface DetectNearestLockfileOptions {
  * Searches `dir` and every parent directory (up to and including
  * `options.root`) for a lockfile of any of the given `options.detectors`
  * (or all known package manager detectors if not given). The search stops
- * when a directory containing a lockfile is found.
- *
- * In case the directory contains multiple lockfiles, the result is
- * non-determistic.
- *
- * @returns The detected lockfile.
- * @throws {NoLockfileFoundError} If no directory containing a lockfile is found.
- */
-export async function detectNearestLockfile (
-  dir: string,
-  options?: DetectNearestLockfileOptions,
-): Promise<NearestLockFile> {
-  const detectors = options?.detectors ?? knownPackageManagers
-
-  const searchPaths: string[] = []
-
-  for (const searchPath of lineage(dir, { root: options?.root })) {
-    try {
-      searchPaths.push(searchPath)
-
-      // Assume that only a single kind of lockfile exists, which means the
-      // resolve order does not matter.
-      return await Promise.any(detectors.map(async detector => {
-        const lockfile = await detector.detectLockfile(searchPath)
-        return {
-          packageManager: detector,
-          lockfile,
-        }
-      }))
-    } catch {
-      // Nothing detected.
-    }
-  }
-
-  const lockfiles = [...new Set(detectors.flatMap(detector => detector.representativeLockfiles))]
-
-  throw new NoLockfileFoundError(searchPaths, lockfiles)
-}
-
-/**
- * Searches `dir` and every parent directory (up to and including
- * `options.root`) for a lockfile of any of the given `options.detectors`
- * (or all known package manager detectors if not given). The search stops
  * when a directory containing lockfiles is found.
  *
  * @returns All detected lockfiles in the directory.
  * @throws {NoLockfileFoundError} If no directory containing a lockfile is found.
  */
-export async function detectAllNearestLockfiles (
+export async function detectNearestLockfiles (
   dir: string,
   options?: DetectNearestLockfileOptions,
 ): Promise<NearestLockFile[]> {
@@ -967,11 +924,11 @@ async function initWorkspace (
   detector: PackageManagerDetector,
   options: Pick<WorkspaceOptions, 'root' | 'packages'>,
 ) {
-  const lockfile: OptionalWorkspaceFile = await detectNearestLockfile(options.root.path, {
+  const lockfile: OptionalWorkspaceFile = await detectNearestLockfiles(options.root.path, {
     root: options.root.path,
     detectors: [detector],
   }).then(
-    ({ lockfile }) => Ok(lockfile),
+    ([{ lockfile }]) => Ok(lockfile),
     reason => Err(reason),
   )
 

--- a/packages/cli/src/services/check-parser/package-files/package-manager.ts
+++ b/packages/cli/src/services/check-parser/package-files/package-manager.ts
@@ -705,16 +705,20 @@ async function detectPackageManagerImpl (
     return undefined
   }
 
-  // Next, try to find a config file.
-  try {
-    const { packageManager } = await detectNearestConfigFile(dir, {
+  // Next, try to find a config file. As with lockfiles, when several package
+  // managers have a config file in the nearest directory, the highest-priority
+  // one wins.
+  const configDetected = new Set(Array.from(
+    await detectNearestConfigFiles(dir, {
       detectors,
       root: options?.root,
-    })
+    }).catch(() => []),
+    ({ packageManager }) => packageManager,
+  ))
 
-    return packageManager
-  } catch {
-    // Nothing detected.
+  const configWinner = ordered('configFile').find(detector => configDetected.has(detector))
+  if (configWinner !== undefined) {
+    return configWinner
   }
 
   // Finally, try to find a relevant executable.
@@ -863,35 +867,45 @@ export interface DetectNearestConfigFileOptions {
   root?: string
 }
 
-export async function detectNearestConfigFile (
+/**
+ * Searches `dir` and every parent directory (up to and including
+ * `options.root`) for a config file of any of the given `options.detectors`
+ * (or all known package manager detectors if not given). The search stops
+ * when a directory containing config files is found.
+ *
+ * @returns All detected config files in the directory.
+ * @throws {NoConfigFileFoundError} If no directory containing a config file is found.
+ */
+export async function detectNearestConfigFiles (
   dir: string,
   options?: DetectNearestConfigFileOptions,
-): Promise<NearestConfigFile> {
+): Promise<NearestConfigFile[]> {
   const detectors = options?.detectors ?? knownPackageManagers
 
   const searchPaths: string[] = []
 
   for (const searchPath of lineage(dir, { root: options?.root })) {
-    try {
-      searchPaths.push(searchPath)
+    searchPaths.push(searchPath)
 
-      // Assume that only a single kind of config file exists, which means
-      // the resolve order does not matter.
-      return await Promise.any(detectors.map(async detector => {
+    const results = await Promise.all(detectors.map(async detector => {
+      try {
         const configFile = await detector.detectConfigFile(searchPath)
         return {
           packageManager: detector,
           configFile,
         }
-      }))
-    } catch {
-      // Nothing detected.
+      } catch {
+        return null
+      }
+    }))
+
+    const found = results.filter(value => value !== null)
+    if (found.length > 0) {
+      return found
     }
   }
 
-  const configFiles = detectors.reduce<string[]>((acc, detector) => {
-    return acc.concat(detector.representativeConfigFile ?? [])
-  }, [])
+  const configFiles = [...new Set(detectors.flatMap(detector => detector.representativeConfigFile ?? []))]
 
   throw new NoConfigFileFoundError(searchPaths, configFiles)
 }
@@ -984,11 +998,11 @@ async function initWorkspace (
     reason => Err(reason),
   )
 
-  const configFile: OptionalWorkspaceFile = await detectNearestConfigFile(options.root.path, {
+  const configFile: OptionalWorkspaceFile = await detectNearestConfigFiles(options.root.path, {
     root: options.root.path,
     detectors: [detector],
   }).then(
-    ({ configFile }) => Ok(configFile),
+    ([{ configFile }]) => Ok(configFile),
     reason => Err(reason),
   )
 

--- a/packages/cli/src/services/check-parser/package-files/package-manager.ts
+++ b/packages/cli/src/services/check-parser/package-files/package-manager.ts
@@ -42,8 +42,24 @@ export interface PackageManager {
 
 class NotDetectedError extends Error {}
 
+export type DetectionMethod =
+  | 'userAgent'
+  | 'runtime'
+  | 'lockfile'
+  | 'configFile'
+  | 'executable'
+
 export abstract class PackageManagerDetector {
   abstract get name (): string
+
+  /**
+   * Tie-break precedence when more than one detector matches the same detection
+   * method. Higher wins (detectors are sorted descending). Lets a detector rank
+   * itself differently per method — e.g. npm deprioritizes its executable
+   * because npm is almost always on PATH, so its mere presence is no signal.
+   */
+  abstract priority (method: DetectionMethod): number
+
   abstract detectUserAgent (userAgent: string): boolean
   abstract detectRuntime (): boolean
   abstract get representativeLockfiles (): string[]
@@ -74,6 +90,14 @@ export abstract class PackageManagerDetector {
 export class NpmDetector extends PackageManagerDetector implements PackageManager {
   get name (): string {
     return 'npm'
+  }
+
+  priority (method: DetectionMethod): number {
+    // npm is nearly always installed, so finding the npm binary on PATH is not
+    // a meaningful signal — rank it below every other built-in detector for the
+    // executable method. Its normal priority applies elsewhere, so it still
+    // wins the package-lock.json lockfile tie over cnpm.
+    return method === 'executable' ? 0 : 20
   }
 
   detectUserAgent (userAgent: string): boolean {
@@ -127,6 +151,10 @@ export class CNpmDetector extends PackageManagerDetector implements PackageManag
     return 'cnpm'
   }
 
+  priority (): number {
+    return 10
+  }
+
   detectUserAgent (userAgent: string): boolean {
     return userAgent.startsWith('npminstall/')
   }
@@ -138,8 +166,8 @@ export class CNpmDetector extends PackageManagerDetector implements PackageManag
   get representativeLockfiles (): string[] {
     // cnpm has no lockfile of its own — it uses npm's package-lock.json. We
     // claim it here so a cnpm user agent can be matched against a real
-    // lockfile. npm is ordered ahead of cnpm in knownPackageManagers, so a
-    // bare package-lock.json with no cnpm user agent still resolves to npm.
+    // lockfile. npm has a higher lockfile priority than cnpm, so a bare
+    // package-lock.json with no cnpm user agent still resolves to npm.
     return ['package-lock.json']
   }
 
@@ -180,6 +208,10 @@ export class CNpmDetector extends PackageManagerDetector implements PackageManag
 export class PNpmDetector extends PackageManagerDetector implements PackageManager {
   get name (): string {
     return 'pnpm'
+  }
+
+  priority (): number {
+    return 60
   }
 
   detectUserAgent (userAgent: string): boolean {
@@ -301,6 +333,10 @@ export class YarnDetector extends PackageManagerDetector implements PackageManag
     return 'yarn'
   }
 
+  priority (): number {
+    return 30
+  }
+
   detectUserAgent (userAgent: string): boolean {
     return userAgent.startsWith('yarn/')
   }
@@ -350,6 +386,10 @@ export class YarnDetector extends PackageManagerDetector implements PackageManag
 export class DenoDetector extends PackageManagerDetector implements PackageManager {
   get name (): string {
     return 'deno'
+  }
+
+  priority (): number {
+    return 40
   }
 
   detectUserAgent (userAgent: string): boolean {
@@ -444,6 +484,10 @@ export class DenoDetector extends PackageManagerDetector implements PackageManag
 export class BunDetector extends PackageManagerDetector implements PackageManager {
   get name (): string {
     return 'bun'
+  }
+
+  priority (): number {
+    return 50
   }
 
   detectUserAgent (userAgent: string): boolean {
@@ -586,9 +630,9 @@ export class PathLookup {
 
 export const npmPackageManager = new NpmDetector()
 
-// The order of the detectors is relevant to the lookup order. npm precedes
-// cnpm so that a bare package-lock.json (which both claim) resolves to npm
-// unless a cnpm user agent is present.
+// Detection precedence is governed by each detector's priority(method), not by
+// this array's order, so listing is free to stay readable. (The order is still
+// used verbatim for the `checkly import` package-manager prompt menu.)
 export const knownPackageManagers: PackageManagerDetector[] = [
   new PNpmDetector(),
   new BunDetector(),
@@ -613,6 +657,11 @@ async function detectPackageManagerImpl (
     requireLockfile,
   } = options
 
+  // Detectors are evaluated highest-priority-first within each detection
+  // method, so the order they were supplied in never affects the result.
+  const ordered = (method: DetectionMethod): PackageManagerDetector[] =>
+    [...detectors].sort((a, b) => b.priority(method) - a.priority(method))
+
   const lockfileDetected = new Set(Array.from(
     await detectNearestLockfiles(dir, {
       detectors,
@@ -624,7 +673,7 @@ async function detectPackageManagerImpl (
   // Try user agent first.
   const userAgent = process.env['npm_config_user_agent']
   if (userAgent !== undefined) {
-    for (const detector of detectors) {
+    for (const detector of ordered('userAgent')) {
       if (detector.detectUserAgent(userAgent)) {
         if ((!requireLockfile || lockfileDetected.has(detector))) {
           return detector
@@ -634,7 +683,7 @@ async function detectPackageManagerImpl (
   }
 
   // Next, try runtime.
-  for (const detector of detectors) {
+  for (const detector of ordered('runtime')) {
     if (detector.detectRuntime()) {
       if ((!requireLockfile || lockfileDetected.has(detector))) {
         return detector
@@ -642,9 +691,12 @@ async function detectPackageManagerImpl (
     }
   }
 
-  // Next, try to find a lockfile.
-  for (const detector of lockfileDetected) {
-    return detector
+  // Next, try to find a lockfile. When several package managers claim a lockfile
+  // in the nearest directory (e.g. npm and cnpm both claim package-lock.json),
+  // the highest-priority one wins.
+  const lockfileWinner = ordered('lockfile').find(detector => lockfileDetected.has(detector))
+  if (lockfileWinner !== undefined) {
+    return lockfileWinner
   }
 
   // If we get here, there's no lockfile, in which case we have to stop
@@ -670,7 +722,7 @@ async function detectPackageManagerImpl (
   // This can generate a whole bunch of path lookups. Try one by one despite
   // async support.
   const lookup = new PathLookup()
-  for (const detector of detectors) {
+  for (const detector of ordered('executable')) {
     try {
       await detector.detectExecutable(lookup)
       return detector

--- a/packages/cli/src/services/check-parser/package-files/package-manager.ts
+++ b/packages/cli/src/services/check-parser/package-files/package-manager.ts
@@ -136,7 +136,11 @@ export class CNpmDetector extends PackageManagerDetector implements PackageManag
   }
 
   get representativeLockfiles (): string[] {
-    return []
+    // cnpm has no lockfile of its own — it uses npm's package-lock.json. We
+    // claim it here so a cnpm user agent can be matched against a real
+    // lockfile. npm is ordered ahead of cnpm in knownPackageManagers, so a
+    // bare package-lock.json with no cnpm user agent still resolves to npm.
+    return ['package-lock.json']
   }
 
   get representativeConfigFile (): undefined {
@@ -582,35 +586,47 @@ export class PathLookup {
 
 export const npmPackageManager = new NpmDetector()
 
-// The order of the detectors is relevant to the lookup order.
+// The order of the detectors is relevant to the lookup order. npm precedes
+// cnpm so that a bare package-lock.json (which both claim) resolves to npm
+// unless a cnpm user agent is present.
 export const knownPackageManagers: PackageManagerDetector[] = [
   new PNpmDetector(),
   new BunDetector(),
   new DenoDetector(),
   new YarnDetector(),
-  new CNpmDetector(),
   npmPackageManager,
+  new CNpmDetector(),
 ]
 
-export interface DetectOptions {
-  detectors?: PackageManagerDetector[]
+interface DetectPackageManagerImplOptions {
+  detectors: PackageManagerDetector[]
   root?: string
-  /** Skip npm_config_user_agent detection. Use when the invoking command (e.g. npx) sets a user agent that doesn't match the project's actual package manager. */
-  skipUserAgent?: boolean
+  requireLockfile: boolean
 }
 
-export async function detectPackageManager (
+async function detectPackageManagerImpl (
   dir: string,
-  options?: DetectOptions,
-): Promise<PackageManager> {
-  const detectors = options?.detectors ?? knownPackageManagers
+  options: DetectPackageManagerImplOptions,
+): Promise<PackageManager | undefined> {
+  const {
+    detectors,
+    requireLockfile,
+  } = options
 
-  // Try user agent first (unless skipped — e.g. when invoked via npx which always reports npm).
-  if (!options?.skipUserAgent) {
-    const userAgent = process.env['npm_config_user_agent']
-    if (userAgent !== undefined) {
-      for (const detector of detectors) {
-        if (detector.detectUserAgent(userAgent)) {
+  const lockfileDetected = new Set(Array.from(
+    await detectAllNearestLockfiles(dir, {
+      detectors,
+      root: options?.root,
+    }).catch(() => []),
+    ({ packageManager }) => packageManager,
+  ))
+
+  // Try user agent first.
+  const userAgent = process.env['npm_config_user_agent']
+  if (userAgent !== undefined) {
+    for (const detector of detectors) {
+      if (detector.detectUserAgent(userAgent)) {
+        if ((!requireLockfile || lockfileDetected.has(detector))) {
           return detector
         }
       }
@@ -620,20 +636,21 @@ export async function detectPackageManager (
   // Next, try runtime.
   for (const detector of detectors) {
     if (detector.detectRuntime()) {
-      return detector
+      if ((!requireLockfile || lockfileDetected.has(detector))) {
+        return detector
+      }
     }
   }
 
   // Next, try to find a lockfile.
-  try {
-    const { packageManager } = await detectNearestLockfile(dir, {
-      detectors,
-      root: options?.root,
-    })
+  for (const detector of lockfileDetected) {
+    return detector
+  }
 
-    return packageManager
-  } catch {
-    // Nothing detected.
+  // If we get here, there's no lockfile, in which case we have to stop
+  // if it's required.
+  if (requireLockfile) {
+    return undefined
   }
 
   // Next, try to find a config file.
@@ -659,6 +676,33 @@ export async function detectPackageManager (
       return detector
     } catch {
       continue
+    }
+  }
+
+  return undefined
+}
+
+export interface DetectPackageManagerOptions {
+  detectors: PackageManagerDetector[]
+  root?: string
+}
+
+export async function detectPackageManager (
+  dir: string,
+  options?: DetectPackageManagerOptions,
+): Promise<PackageManager> {
+  const detectors = options?.detectors ?? knownPackageManagers
+
+  // Try with lockfile required first, which gives a stronger signal.
+  // Fall back to not requiring it.
+  for (const requireLockfile of [true, false]) {
+    const pm = await detectPackageManagerImpl(dir, {
+      detectors,
+      requireLockfile,
+      root: options?.root,
+    })
+    if (pm !== undefined) {
+      return pm
     }
   }
 
@@ -690,15 +734,31 @@ export class NoLockfileFoundError extends Error {
   }
 }
 
+export interface DetectNearestLockfileOptions {
+  detectors?: PackageManagerDetector[]
+  root?: string
+}
+
+/**
+ * Searches `dir` and every parent directory (up to and including
+ * `options.root`) for a lockfile of any of the given `options.detectors`
+ * (or all known package manager detectors if not given). The search stops
+ * when a directory containing a lockfile is found.
+ *
+ * In case the directory contains multiple lockfiles, the result is
+ * non-determistic.
+ *
+ * @returns The detected lockfile.
+ * @throws {NoLockfileFoundError} If no directory containing a lockfile is found.
+ */
 export async function detectNearestLockfile (
   dir: string,
-  options?: DetectOptions,
+  options?: DetectNearestLockfileOptions,
 ): Promise<NearestLockFile> {
   const detectors = options?.detectors ?? knownPackageManagers
 
   const searchPaths: string[] = []
 
-  // Next, try to find a lockfile.
   for (const searchPath of lineage(dir, { root: options?.root })) {
     try {
       searchPaths.push(searchPath)
@@ -717,7 +777,50 @@ export async function detectNearestLockfile (
     }
   }
 
-  const lockfiles = detectors.flatMap(detector => detector.representativeLockfiles)
+  const lockfiles = [...new Set(detectors.flatMap(detector => detector.representativeLockfiles))]
+
+  throw new NoLockfileFoundError(searchPaths, lockfiles)
+}
+
+/**
+ * Searches `dir` and every parent directory (up to and including
+ * `options.root`) for a lockfile of any of the given `options.detectors`
+ * (or all known package manager detectors if not given). The search stops
+ * when a directory containing lockfiles is found.
+ *
+ * @returns All detected lockfiles in the directory.
+ * @throws {NoLockfileFoundError} If no directory containing a lockfile is found.
+ */
+export async function detectAllNearestLockfiles (
+  dir: string,
+  options?: DetectNearestLockfileOptions,
+): Promise<NearestLockFile[]> {
+  const detectors = options?.detectors ?? knownPackageManagers
+
+  const searchPaths: string[] = []
+
+  for (const searchPath of lineage(dir, { root: options?.root })) {
+    searchPaths.push(searchPath)
+
+    const results = await Promise.all(detectors.map(async detector => {
+      try {
+        const lockfile = await detector.detectLockfile(searchPath)
+        return {
+          packageManager: detector,
+          lockfile,
+        }
+      } catch {
+        return null
+      }
+    }))
+
+    const found = results.filter(value => value !== null)
+    if (found.length > 0) {
+      return found
+    }
+  }
+
+  const lockfiles = [...new Set(detectors.flatMap(detector => detector.representativeLockfiles))]
 
   throw new NoLockfileFoundError(searchPaths, lockfiles)
 }
@@ -746,9 +849,14 @@ export class NoConfigFileFoundError extends Error {
   }
 }
 
+export interface DetectNearestConfigFileOptions {
+  detectors?: PackageManagerDetector[]
+  root?: string
+}
+
 export async function detectNearestConfigFile (
   dir: string,
-  options?: DetectOptions,
+  options?: DetectNearestConfigFileOptions,
 ): Promise<NearestConfigFile> {
   const detectors = options?.detectors ?? knownPackageManagers
 


### PR DESCRIPTION
## Problem

`detectPackageManager` consulted ambient signals — the `npm_config_user_agent` env var and the JS runtime — *before* the project's lockfile. These describe how the CLI was launched, not what the project uses, so:

- Running `npx checkly` in a pnpm repo reported an **npm** user agent → we detected npm → project parsing then failed to find an npm lockfile.
- Internally, `pnpm vitest` leaks a pnpm user agent into the CLI process, so tests detected pnpm even when the fixture used a different package manager.

## Fix

Detection now runs a **lockfile-required pass first**: a user-agent/runtime signal only counts when that package manager has a backing lockfile in the directory lineage. When no lockfile exists anywhere (e.g. running outside a repo), it falls back to the previous un-gated order, ultimately defaulting to npm. Behavior is therefore unchanged when there's no lockfile, and the lockfile wins whenever one is present.

### cnpm

cnpm shares npm's `package-lock.json`. `CNpmDetector` now claims it so cnpm stays detectable, and:
- a bare `package-lock.json` defaults to **npm**;
- a cnpm user agent alongside one resolves to **cnpm**;
- running cnpm inside a pnpm repo still resolves to **pnpm** (no cross-package-manager regression).

### Tie-breaking by priority (not detector order)

Detection tie-breaks previously depended on the order detectors were supplied in. Most visibly, the executable-on-PATH tier returned the first detector whose binary was found — and since **npm is almost always installed, it beat cnpm even though its presence is no signal**.

Each detector now carries an intrinsic `priority(method)` (higher wins), and every tier selects the highest-priority match rather than the first by position, so input order no longer affects the result. npm deprioritizes its *executable* (so an installed cnpm/pnpm/yarn wins the executable tier) while keeping its normal priority elsewhere — it still wins the `package-lock.json` lockfile tie over cnpm and remains the ultimate fallback.

## Tests

Unit suite (`package-manager.spec.ts`, 35 cases) covering every detection tier hermetically (temp dirs, bounded lineage, restricted detectors, spied executables/runtime, saved/restored user agent): lockfile-beats-ambient, no-lockfile fallback, lineage walking, co-located lockfiles, the cnpm cases, executable-tier priority (cnpm beats npm; npm alone still wins), config-file priority, and order-independence (same detectors in different orders yield the same result).

## Other changes

- Removed the now-redundant `skipUserAgent` workaround in `boilerplate.ts`.
- Consolidated lockfile and config-file detection into single `detectNearestLockfiles` / `detectNearestConfigFiles` finders (plural, collect-all), removing the nondeterministic `Promise.any`-based singular variants. Both tiers now select by `priority(method)`, so they're deterministic and order-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)