### PR TITLE
Add assets command group for result manifests

### DIFF
--- a/packages/cli/e2e/__tests__/help.spec.ts
+++ b/packages/cli/e2e/__tests__/help.spec.ts
@@ -56,6 +56,7 @@ describe('help', () => {
   account          View and manage your Checkly account.
   alert-channels   List and inspect alert channels in your Checkly account.
   api              Make an authenticated HTTP request to the Checkly API.
+  assets           List and download result assets.
   checks           List and inspect checks in your Checkly account.
   destroy          Destroy your project with all its related resources.
   env              Manage Checkly environment variables.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -74,6 +74,9 @@
       "alert-channels": {
         "description": "List and inspect alert channels in your Checkly account."
       },
+      "assets": {
+        "description": "List and download result assets."
+      },
       "checks": {
         "description": "List and inspect checks in your Checkly account."
       },

--- a/packages/cli/src/commands/__tests__/assets.spec.ts
+++ b/packages/cli/src/commands/__tests__/assets.spec.ts
@@ -177,23 +177,13 @@ describe('assets commands', () => {
 
     await AssetsList.prototype.run.call(ctx as any)
 
-    expect(api.assetManifests.getForTestSessionResult).toHaveBeenCalledWith('session-id', 'result-id')
+    expect(api.assetManifests.getForTestSessionResult).toHaveBeenCalledWith('session-id', 'result-id', {
+      type: 'trace',
+    })
     expect(JSON.parse(ctx.logged[0])).toEqual({
       data: [manifest.assets[1]],
-      source: {
-        kind: 'test-session-result',
-        testSessionId: 'session-id',
-        resultId: 'result-id',
-      },
-      metadata: {
-        filter: {
-          type: 'trace',
-        },
-        manifest: {
-          truncated: true,
-          entriesReturned: 5,
-          entriesTotal: 12,
-        },
+      pagination: {
+        length: 1,
       },
     })
     expect(ctx.logged[0]).not.toContain('Assets for test-session result')
@@ -249,6 +239,9 @@ describe('assets commands', () => {
 
     await AssetsList.prototype.run.call(ctx as any)
 
+    expect(api.assetManifests.getForCheckResult).toHaveBeenCalledWith('check-id', 'result-id', {
+      name: 'duplicate.txt',
+    })
     expect(ctx.logged[0]).toContain('Filter:')
     expect(ctx.logged[0]).toContain('asset=duplicate.txt')
     expect(ctx.logged[0]).toContain('a/duplicate.txt')
@@ -262,7 +255,7 @@ describe('assets commands', () => {
         'test-session-id': 'session-id',
         'result-id': 'result-id',
         'type': 'trace',
-        'asset': 'traces/*.zip',
+        'asset': 'TRACES/*.ZIP',
         'view': 'tree',
         'output': 'json',
       },
@@ -270,12 +263,17 @@ describe('assets commands', () => {
 
     await AssetsList.prototype.run.call(ctx as any)
 
+    expect(api.assetManifests.getForTestSessionResult).toHaveBeenCalledWith('session-id', 'result-id', {
+      type: 'trace',
+      name: 'TRACES/*.ZIP',
+    })
     const parsed = JSON.parse(ctx.logged[0])
     expect(parsed.data).toEqual([manifest.assets[1]])
-    expect(parsed.metadata.filter).toEqual({
-      type: 'trace',
-      asset: 'traces/*.zip',
+    expect(parsed.pagination).toEqual({
+      length: 1,
     })
+    expect(parsed).not.toHaveProperty('metadata')
+    expect(parsed).not.toHaveProperty('source')
   })
 
   it('requires a download selector', async () => {
@@ -297,7 +295,7 @@ describe('assets commands', () => {
       flags: {
         'check-id': 'check-id',
         'result-id': 'result-id',
-        'asset': 'logs.txt',
+        'asset': 'LOGS.TXT',
         'output': 'json',
         'force': false,
         'skip-existing': false,
@@ -308,6 +306,9 @@ describe('assets commands', () => {
 
     const summary = JSON.parse(ctx.logged[0])
     const expectedPath = path.join(tempDir, 'checkly-assets', 'check-result-result-id', 'logs.txt')
+    expect(api.assetManifests.getForCheckResult).toHaveBeenCalledWith('check-id', 'result-id', {
+      name: 'LOGS.TXT',
+    })
     expect(api.api.get).toHaveBeenCalledWith('/download/logs', { responseType: 'stream' })
     expect(axios.get).not.toHaveBeenCalled()
     expect(summary.directory).toBe(path.dirname(expectedPath))
@@ -382,6 +383,9 @@ describe('assets commands', () => {
 
     await AssetsDownload.prototype.run.call(ctx as any)
 
+    expect(api.assetManifests.getForCheckResult).toHaveBeenCalledWith('check-id', 'result-id', {
+      type: 'file',
+    })
     const firstPath = path.join(tempDir, 'checkly-assets', 'check-result-result-id', 'a', 'duplicate.txt')
     const secondPath = path.join(tempDir, 'checkly-assets', 'check-result-result-id', 'b', 'duplicate.txt')
     expect(ctx.logged[0]).toContain('2 assets processed (2 downloaded)')
@@ -440,6 +444,9 @@ describe('assets commands', () => {
     await AssetsDownload.prototype.run.call(ctx as any)
 
     const summary = JSON.parse(ctx.logged[0])
+    expect(api.assetManifests.getForTestSessionResult).toHaveBeenCalledWith('session-id', 'result-id', {
+      name: 'traces/*.zip',
+    })
     expect(summary.files).toHaveLength(1)
     expect(summary.files[0].path).toBe(path.join(tempDir, 'custom-assets', 'traces', 'checkout trace.zip'))
   })
@@ -459,10 +466,13 @@ describe('assets commands', () => {
 
     await AssetsDownload.prototype.run.call(ctx as any)
 
+    expect(api.assetManifests.getForCheckResult).toHaveBeenCalledWith('check-id', 'result-id', {
+      type: 'file',
+    })
     expect(ctx.style.longError).toHaveBeenCalledWith(
       'Failed to download assets.',
       expect.objectContaining({
-        message: expect.stringContaining('Asset manifest is truncated (5 of 12 entries returned). Refusing to download'),
+        message: expect.stringContaining('Asset manifest is truncated (5 of 12 entries returned). Refusing to download because the filtered manifest is still incomplete after applying --type file.'),
       }),
     )
     expect(api.api.get).not.toHaveBeenCalled()
@@ -470,8 +480,10 @@ describe('assets commands', () => {
     expect(process.exitCode).toBe(1)
   })
 
-  it('allows exact copied Asset downloads from truncated manifests', async () => {
-    vi.mocked(api.assetManifests.getForCheckResult).mockResolvedValue(truncatedManifest)
+  it('downloads exact copied Asset values from backend-filtered manifests', async () => {
+    vi.mocked(api.assetManifests.getForCheckResult).mockResolvedValue({
+      assets: [manifest.assets[1]],
+    })
     const ctx = createCommandContext({
       flags: {
         'check-id': 'check-id',
@@ -485,12 +497,17 @@ describe('assets commands', () => {
 
     await AssetsDownload.prototype.run.call(ctx as any)
 
+    expect(api.assetManifests.getForCheckResult).toHaveBeenCalledWith('check-id', 'result-id', {
+      name: 'traces/checkout trace.zip',
+    })
     expect(api.api.get).toHaveBeenCalledWith('/download/trace', { responseType: 'stream' })
     expect(JSON.parse(ctx.logged[0]).files[0].status).toBe('written')
   })
 
-  it('allows exact plain Asset downloads from truncated manifests', async () => {
-    vi.mocked(api.assetManifests.getForCheckResult).mockResolvedValue(truncatedManifest)
+  it('downloads exact plain Asset values from backend-filtered manifests', async () => {
+    vi.mocked(api.assetManifests.getForCheckResult).mockResolvedValue({
+      assets: [manifest.assets[0]],
+    })
     const ctx = createCommandContext({
       flags: {
         'check-id': 'check-id',
@@ -504,6 +521,9 @@ describe('assets commands', () => {
 
     await AssetsDownload.prototype.run.call(ctx as any)
 
+    expect(api.assetManifests.getForCheckResult).toHaveBeenCalledWith('check-id', 'result-id', {
+      name: 'logs.txt',
+    })
     expect(api.api.get).toHaveBeenCalledWith('/download/logs', { responseType: 'stream' })
     expect(JSON.parse(ctx.logged[0]).files[0].status).toBe('written')
   })

--- a/packages/cli/src/commands/__tests__/assets.spec.ts
+++ b/packages/cli/src/commands/__tests__/assets.spec.ts
@@ -1,0 +1,400 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Readable } from 'node:stream'
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import type { AssetManifest } from '../../rest/asset-manifests.js'
+
+vi.mock('../../rest/api.js', () => ({
+  assetManifests: {
+    getForCheckResult: vi.fn(),
+    getForTestSessionResult: vi.fn(),
+  },
+  api: {
+    get: vi.fn(),
+  },
+}))
+
+import * as api from '../../rest/api.js'
+import AssetsList from '../assets/list.js'
+import AssetsDownload from '../assets/download.js'
+
+const manifest: AssetManifest = {
+  assets: [
+    {
+      type: 'log',
+      name: 'logs.txt',
+      url: '/download/logs',
+      contentType: 'text/plain',
+      source: 'runner',
+    },
+    {
+      type: 'trace',
+      name: 'trace.zip',
+      url: '/download/trace',
+      contentType: 'application/zip',
+      source: 'runner',
+      archive: { entryName: 'traces/checkout trace.zip' },
+    },
+    {
+      type: 'screenshot',
+      name: 'page.png',
+      url: '/download/page',
+      contentType: 'image/png',
+      source: 'runner',
+    },
+    {
+      type: 'file',
+      name: 'duplicate.txt',
+      url: '/download/duplicate-a',
+      source: 'runner',
+      archive: { entryName: 'a/duplicate.txt' },
+    },
+    {
+      type: 'file',
+      name: 'duplicate.txt',
+      url: '/download/duplicate-b',
+      source: 'runner',
+      archive: { entryName: 'b/duplicate.txt' },
+    },
+  ],
+  truncated: true,
+  entriesReturned: 5,
+  entriesTotal: 12,
+}
+
+function createCommandContext (parsed: unknown) {
+  const logged: string[] = []
+  return {
+    parse: vi.fn().mockResolvedValue(parsed),
+    log: vi.fn((msg?: string) => {
+      if (msg) logged.push(msg)
+    }),
+    style: { outputFormat: undefined, longError: vi.fn() },
+    logged,
+  }
+}
+
+describe('assets commands', () => {
+  let originalCwd: string
+  let tempDir: string
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    process.exitCode = undefined
+    originalCwd = process.cwd()
+    tempDir = await realpath(await mkdtemp(path.join(tmpdir(), 'checkly-assets-test-')))
+    process.chdir(tempDir)
+    vi.mocked(api.assetManifests.getForCheckResult).mockResolvedValue(manifest)
+    vi.mocked(api.assetManifests.getForTestSessionResult).mockResolvedValue(manifest)
+    vi.mocked(api.api.get).mockResolvedValue({ data: Readable.from(['downloaded']) } as any)
+  })
+
+  afterEach(async () => {
+    process.chdir(originalCwd)
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('validates source flags', async () => {
+    const missing = createCommandContext({
+      flags: { 'result-id': 'result-id', 'output': 'table' },
+    })
+    await expect(AssetsList.prototype.run.call(missing as any))
+      .rejects
+      .toThrow('Use exactly one of --check-id or --test-session-id.')
+
+    const both = createCommandContext({
+      flags: {
+        'check-id': 'check-id',
+        'test-session-id': 'session-id',
+        'result-id': 'result-id',
+        'output': 'table',
+      },
+    })
+    await expect(AssetsList.prototype.run.call(both as any))
+      .rejects
+      .toThrow('Use exactly one of --check-id or --test-session-id, not both.')
+  })
+
+  it('lists check result assets as a table with copyable Asset values and truncation warning', async () => {
+    const ctx = createCommandContext({
+      flags: {
+        'check-id': 'check-id',
+        'result-id': 'result-id',
+        'type': 'all',
+        'view': 'table',
+        'output': 'table',
+      },
+    })
+
+    await AssetsList.prototype.run.call(ctx as any)
+
+    expect(api.assetManifests.getForCheckResult).toHaveBeenCalledWith('check-id', 'result-id')
+    expect(ctx.logged[0]).toContain('Assets for check result')
+    expect(ctx.logged[0]).toContain('Check ID:')
+    expect(ctx.logged[0]).toContain('check-id')
+    expect(ctx.logged[0]).toContain('Result ID:')
+    expect(ctx.logged[0]).toContain('result-id')
+    expect(ctx.logged[0]).toContain('Showing:')
+    expect(ctx.logged[0]).toContain('trace 1')
+    expect(ctx.logged[0]).toContain('logs.txt')
+    expect(ctx.logged[0]).toContain('traces/checkout trace.zip')
+    expect(ctx.logged[0]).toContain('Warning: asset manifest is truncated (5 of 12 entries returned).')
+  })
+
+  it('lists test-session result assets as filtered JSON without human warnings', async () => {
+    const ctx = createCommandContext({
+      flags: {
+        'test-session-id': 'session-id',
+        'result-id': 'result-id',
+        'type': 'trace',
+        'view': 'table',
+        'output': 'json',
+      },
+    })
+
+    await AssetsList.prototype.run.call(ctx as any)
+
+    expect(api.assetManifests.getForTestSessionResult).toHaveBeenCalledWith('session-id', 'result-id')
+    expect(JSON.parse(ctx.logged[0])).toEqual({
+      ...manifest,
+      assets: [manifest.assets[1]],
+    })
+  })
+
+  it('renders list markdown output', async () => {
+    const ctx = createCommandContext({
+      flags: {
+        'check-id': 'check-id',
+        'result-id': 'result-id',
+        'type': 'log',
+        'view': 'table',
+        'output': 'md',
+      },
+    })
+
+    await AssetsList.prototype.run.call(ctx as any)
+
+    expect(ctx.logged[0]).toContain('| Type | Name | Asset | Content Type |')
+    expect(ctx.logged[0]).toContain('| log | logs.txt | logs.txt | text/plain |')
+  })
+
+  it('renders list tree output for nested asset paths', async () => {
+    const ctx = createCommandContext({
+      flags: {
+        'check-id': 'check-id',
+        'result-id': 'result-id',
+        'type': 'all',
+        'view': 'tree',
+        'output': 'table',
+      },
+    })
+
+    await AssetsList.prototype.run.call(ctx as any)
+
+    expect(ctx.logged[0]).toContain('traces/')
+    expect(ctx.logged[0]).toContain('checkout trace.zip')
+    expect(ctx.logged[0]).toContain('Tip: use --view table to copy exact Asset values for download.')
+  })
+
+  it('requires a download selector', async () => {
+    const ctx = createCommandContext({
+      flags: {
+        'check-id': 'check-id',
+        'result-id': 'result-id',
+        'output': 'table',
+      },
+    })
+
+    await expect(AssetsDownload.prototype.run.call(ctx as any))
+      .rejects
+      .toThrow('Pass --type or --asset to select assets. Use --type all to download all assets.')
+  })
+
+  it('downloads by exact asset selector to the default directory', async () => {
+    const ctx = createCommandContext({
+      flags: {
+        'check-id': 'check-id',
+        'result-id': 'result-id',
+        'asset': 'logs.txt',
+        'output': 'json',
+        'force': false,
+        'skip-existing': false,
+        'extract': false,
+      },
+    })
+
+    await AssetsDownload.prototype.run.call(ctx as any)
+
+    const summary = JSON.parse(ctx.logged[0])
+    const expectedPath = path.join(tempDir, 'checkly-assets', 'check-result-result-id', 'logs.txt')
+    expect(api.api.get).toHaveBeenCalledWith('/download/logs', { responseType: 'stream' })
+    expect(summary.directory).toBe(path.dirname(expectedPath))
+    expect(summary.files[0].path).toBe(expectedPath)
+    expect(summary.files[0].status).toBe('written')
+    await expect(readFile(expectedPath, 'utf8')).resolves.toBe('downloaded')
+  })
+
+  it('downloads by glob selector and preserves safe archive entry paths', async () => {
+    const ctx = createCommandContext({
+      flags: {
+        'test-session-id': 'session-id',
+        'result-id': 'result-id',
+        'asset': 'traces/*.zip',
+        'dir': 'custom-assets',
+        'output': 'json',
+        'force': false,
+        'skip-existing': false,
+        'extract': false,
+      },
+    })
+
+    await AssetsDownload.prototype.run.call(ctx as any)
+
+    const summary = JSON.parse(ctx.logged[0])
+    expect(summary.files).toHaveLength(1)
+    expect(summary.files[0].path).toBe(path.join(tempDir, 'custom-assets', 'traces', 'checkout trace.zip'))
+  })
+
+  it('fails ambiguous exact asset selection with matching Asset values', async () => {
+    const ctx = createCommandContext({
+      flags: {
+        'check-id': 'check-id',
+        'result-id': 'result-id',
+        'asset': 'duplicate.txt',
+        'output': 'table',
+        'force': false,
+        'skip-existing': false,
+        'extract': false,
+      },
+    })
+
+    await AssetsDownload.prototype.run.call(ctx as any)
+
+    expect(ctx.style.longError).toHaveBeenCalledWith(
+      'Failed to download assets.',
+      expect.objectContaining({
+        message: expect.stringContaining('a/duplicate.txt'),
+      }),
+    )
+    expect(ctx.style.longError).toHaveBeenCalledWith(
+      'Failed to download assets.',
+      expect.objectContaining({
+        message: expect.stringContaining('b/duplicate.txt'),
+      }),
+    )
+    expect(process.exitCode).toBe(1)
+    expect(api.api.get).not.toHaveBeenCalled()
+  })
+
+  it('fails existing files by default', async () => {
+    const existingPath = path.join(tempDir, 'checkly-assets', 'check-result-result-id', 'logs.txt')
+    await mkdir(path.dirname(existingPath), { recursive: true })
+    await writeFile(existingPath, 'existing')
+    const ctx = createCommandContext({
+      flags: {
+        'check-id': 'check-id',
+        'result-id': 'result-id',
+        'asset': 'logs.txt',
+        'output': 'table',
+        'force': false,
+        'skip-existing': false,
+        'extract': false,
+      },
+    })
+
+    await AssetsDownload.prototype.run.call(ctx as any)
+
+    expect(ctx.style.longError).toHaveBeenCalledWith(
+      'Failed to download assets.',
+      expect.objectContaining({ message: expect.stringContaining('Refusing to overwrite existing file') }),
+    )
+    expect(process.exitCode).toBe(1)
+    await expect(readFile(existingPath, 'utf8')).resolves.toBe('existing')
+  })
+
+  it('overwrites existing files with --force', async () => {
+    const existingPath = path.join(tempDir, 'checkly-assets', 'check-result-result-id', 'logs.txt')
+    await mkdir(path.dirname(existingPath), { recursive: true })
+    await writeFile(existingPath, 'existing')
+    const ctx = createCommandContext({
+      flags: {
+        'check-id': 'check-id',
+        'result-id': 'result-id',
+        'asset': 'logs.txt',
+        'output': 'json',
+        'force': true,
+        'skip-existing': false,
+        'extract': false,
+      },
+    })
+
+    await AssetsDownload.prototype.run.call(ctx as any)
+
+    expect(JSON.parse(ctx.logged[0]).files[0].status).toBe('written')
+    await expect(readFile(existingPath, 'utf8')).resolves.toBe('downloaded')
+  })
+
+  it('skips existing files with --skip-existing', async () => {
+    const existingPath = path.join(tempDir, 'checkly-assets', 'check-result-result-id', 'logs.txt')
+    await mkdir(path.dirname(existingPath), { recursive: true })
+    await writeFile(existingPath, 'existing')
+    const ctx = createCommandContext({
+      flags: {
+        'check-id': 'check-id',
+        'result-id': 'result-id',
+        'asset': 'logs.txt',
+        'output': 'json',
+        'force': false,
+        'skip-existing': true,
+        'extract': false,
+      },
+    })
+
+    await AssetsDownload.prototype.run.call(ctx as any)
+
+    expect(JSON.parse(ctx.logged[0]).files[0].status).toBe('skipped')
+    expect(api.api.get).not.toHaveBeenCalled()
+    await expect(readFile(existingPath, 'utf8')).resolves.toBe('existing')
+  })
+
+  it('rejects mutually exclusive overwrite flags', async () => {
+    const ctx = createCommandContext({
+      flags: {
+        'check-id': 'check-id',
+        'result-id': 'result-id',
+        'asset': 'logs.txt',
+        'output': 'table',
+        'force': true,
+        'skip-existing': true,
+        'extract': false,
+      },
+    })
+
+    await expect(AssetsDownload.prototype.run.call(ctx as any))
+      .rejects
+      .toThrow('--force and --skip-existing are mutually exclusive.')
+  })
+
+  it('rejects unsupported archive extraction', async () => {
+    const ctx = createCommandContext({
+      flags: {
+        'check-id': 'check-id',
+        'result-id': 'result-id',
+        'asset': 'traces/checkout trace.zip',
+        'output': 'table',
+        'force': false,
+        'skip-existing': false,
+        'extract': true,
+      },
+    })
+
+    await AssetsDownload.prototype.run.call(ctx as any)
+
+    expect(ctx.style.longError).toHaveBeenCalledWith(
+      'Failed to download assets.',
+      expect.objectContaining({ message: expect.stringContaining('--extract is not supported') }),
+    )
+    expect(api.api.get).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cli/src/commands/__tests__/assets.spec.ts
+++ b/packages/cli/src/commands/__tests__/assets.spec.ts
@@ -74,6 +74,27 @@ const truncatedManifest: AssetManifest = {
   entriesTotal: 12,
 }
 
+const archiveOnlyManifest: AssetManifest = {
+  assets: [
+    {
+      type: 'log',
+      name: 'logs.txt',
+      url: 'https://api.checkly.test/next/assets/check-run-data/eu-central-1/account%2Fsession%2Fresult%2Fassets.zip/redirect',
+      contentType: 'application/json',
+      source: 'runner',
+      archive: { entryName: 'logs.txt' },
+    },
+    {
+      type: 'report',
+      name: 'checkly-report.json',
+      url: 'https://api.checkly.test/next/assets/check-run-data/eu-central-1/account%2Fsession%2Fresult%2Fassets.zip/redirect',
+      contentType: 'application/json',
+      source: 'runner',
+      archive: { entryName: 'output/checkly-report.json' },
+    },
+  ],
+}
+
 function createCommandContext (parsed: unknown) {
   const logged: string[] = []
   return {
@@ -158,8 +179,14 @@ describe('assets commands', () => {
     expect(ctx.logged[0]).toContain('result-id')
     expect(ctx.logged[0]).toContain('Showing:')
     expect(ctx.logged[0]).toContain('trace 1')
+    expect(ctx.logged[0]).toContain('Storage:')
+    expect(ctx.logged[0]).toContain('2 direct files, 3 files inside 3 archives')
+    expect(ctx.logged[0]).toContain('Download:')
+    expect(ctx.logged[0]).toContain('archive entries download as their containing archive')
     expect(ctx.logged[0]).toContain('logs.txt')
     expect(ctx.logged[0]).toContain('traces/checkout trace.zip')
+    expect(ctx.logged[0]).toContain('Next:')
+    expect(ctx.logged[0]).toContain('Download files:')
     expect(ctx.logged[0]).toContain('Warning: asset manifest is truncated (5 of 12 entries returned).')
   })
 
@@ -223,6 +250,27 @@ describe('assets commands', () => {
     expect(ctx.logged[0]).toContain('traces/')
     expect(ctx.logged[0]).toContain('checkout trace.zip')
     expect(ctx.logged[0]).toContain('Tip: use --view table to copy exact Asset values for download.')
+    expect(ctx.logged[0]).toContain('Next:')
+  })
+
+  it('explains archive-only manifests and shows an archive download command', async () => {
+    vi.mocked(api.assetManifests.getForTestSessionResult).mockResolvedValue(archiveOnlyManifest)
+    const ctx = createCommandContext({
+      flags: {
+        'test-session-id': 'session-id',
+        'result-id': 'result-id',
+        'type': 'all',
+        'view': 'table',
+        'output': 'table',
+      },
+    })
+
+    await AssetsList.prototype.run.call(ctx as any)
+
+    expect(ctx.logged[0]).toContain('Storage: 2 files inside 1 archive')
+    expect(ctx.logged[0]).toContain('archive entries download as the containing archive')
+    expect(ctx.logged[0]).toContain('Download archive: checkly assets download --test-session-id session-id --result-id result-id')
+    expect(ctx.logged[0]).toContain('Inspect entries:')
   })
 
   it('filters list output by exact asset name without treating duplicates as ambiguous', async () => {
@@ -285,9 +333,15 @@ describe('assets commands', () => {
       },
     })
 
-    await expect(AssetsDownload.prototype.run.call(ctx as any))
-      .rejects
-      .toThrow('Pass --type or --asset to select assets. Use --type all to download all assets.')
+    await AssetsDownload.prototype.run.call(ctx as any)
+
+    expect(ctx.style.longError).toHaveBeenCalledWith(
+      'Failed to download assets.',
+      expect.objectContaining({
+        message: 'Pass --type or --asset to select assets. Use --type all to download all assets.',
+      }),
+    )
+    expect(process.exitCode).toBe(1)
   })
 
   it('downloads by exact asset selector to the default directory', async () => {
@@ -369,7 +423,7 @@ describe('assets commands', () => {
     expect(ctx.logged[0]).not.toContain('ASSET')
   })
 
-  it('renders multiple download human output with full paths and no repeated asset column', async () => {
+  it('renders multiple archive download human output with full archive paths and no repeated asset column', async () => {
     const ctx = createCommandContext({
       flags: {
         'check-id': 'check-id',
@@ -386,8 +440,10 @@ describe('assets commands', () => {
     expect(api.assetManifests.getForCheckResult).toHaveBeenCalledWith('check-id', 'result-id', {
       type: 'file',
     })
-    const firstPath = path.join(tempDir, 'checkly-assets', 'check-result-result-id', 'a', 'duplicate.txt')
-    const secondPath = path.join(tempDir, 'checkly-assets', 'check-result-result-id', 'b', 'duplicate.txt')
+    const firstPath = path.join(tempDir, 'checkly-assets', 'check-result-result-id', '1-assets.zip')
+    const secondPath = path.join(tempDir, 'checkly-assets', 'check-result-result-id', '2-assets.zip')
+    expect(ctx.logged[0]).toContain('Warning: Selected assets include archive entries.')
+    expect(ctx.logged[0]).toContain('filters narrow the manifest list, not the archive bytes')
     expect(ctx.logged[0]).toContain('2 assets processed (2 downloaded)')
     expect(ctx.logged[0]).toContain(firstPath)
     expect(ctx.logged[0]).toContain(secondPath)
@@ -428,7 +484,7 @@ describe('assets commands', () => {
     expect(ctx.style.actionSuccess).toHaveBeenCalled()
   })
 
-  it('downloads by glob selector and preserves safe archive entry paths', async () => {
+  it('downloads by glob selector and writes the containing archive for archive entries', async () => {
     const ctx = createCommandContext({
       flags: {
         'test-session-id': 'session-id',
@@ -448,7 +504,37 @@ describe('assets commands', () => {
       name: 'traces/*.zip',
     })
     expect(summary.files).toHaveLength(1)
-    expect(summary.files[0].path).toBe(path.join(tempDir, 'custom-assets', 'traces', 'checkout trace.zip'))
+    expect(summary.files[0].displayType).toBe('archive')
+    expect(summary.files[0].path).toBe(path.join(tempDir, 'custom-assets', 'assets.zip'))
+    expect(summary.warnings).toEqual([
+      'Selected assets include archive entries. Downloading the containing archive file; filters narrow the manifest list, not the archive bytes.',
+    ])
+  })
+
+  it('downloads a single archive-only manifest without requiring a selector', async () => {
+    vi.mocked(api.assetManifests.getForTestSessionResult).mockResolvedValue(archiveOnlyManifest)
+    const ctx = createCommandContext({
+      flags: {
+        'test-session-id': 'session-id',
+        'result-id': 'result-id',
+        'output': 'json',
+        'force': false,
+        'skip-existing': false,
+      },
+    })
+
+    await AssetsDownload.prototype.run.call(ctx as any)
+
+    const summary = JSON.parse(ctx.logged[0])
+    expect(api.assetManifests.getForTestSessionResult).toHaveBeenCalledWith('session-id', 'result-id')
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://api.checkly.test/next/assets/check-run-data/eu-central-1/account%2Fsession%2Fresult%2Fassets.zip/redirect',
+      expect.objectContaining({ responseType: 'stream' }),
+    )
+    expect(summary.files).toHaveLength(1)
+    expect(summary.files[0].displayType).toBe('archive')
+    expect(summary.files[0].path).toBe(path.join(tempDir, 'checkly-assets', 'test-session-result-result-id', 'assets.zip'))
+    expect(summary.warnings).toHaveLength(1)
   })
 
   it('refuses category downloads from truncated manifests', async () => {

--- a/packages/cli/src/commands/__tests__/assets.spec.ts
+++ b/packages/cli/src/commands/__tests__/assets.spec.ts
@@ -148,7 +148,7 @@ describe('assets commands', () => {
         'test-session-id': 'session-id',
         'result-id': 'result-id',
         'type': 'trace',
-        'view': 'table',
+        'view': 'tree',
         'output': 'json',
       },
     })
@@ -160,6 +160,8 @@ describe('assets commands', () => {
       ...manifest,
       assets: [manifest.assets[1]],
     })
+    expect(ctx.logged[0]).not.toContain('Assets for test-session result')
+    expect(ctx.logged[0]).not.toContain('checkout trace.zip (trace')
   })
 
   it('renders list markdown output', async () => {

--- a/packages/cli/src/commands/__tests__/assets.spec.ts
+++ b/packages/cli/src/commands/__tests__/assets.spec.ts
@@ -15,6 +15,13 @@ vi.mock('../../rest/api.js', () => ({
   },
 }))
 
+vi.mock('axios', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}))
+
+import axios from 'axios'
 import * as api from '../../rest/api.js'
 import AssetsList from '../assets/list.js'
 import AssetsDownload from '../assets/download.js'
@@ -58,6 +65,10 @@ const manifest: AssetManifest = {
       archive: { entryName: 'b/duplicate.txt' },
     },
   ],
+}
+
+const truncatedManifest: AssetManifest = {
+  ...manifest,
   truncated: true,
   entriesReturned: 5,
   entriesTotal: 12,
@@ -96,6 +107,7 @@ describe('assets commands', () => {
     vi.mocked(api.assetManifests.getForCheckResult).mockResolvedValue(manifest)
     vi.mocked(api.assetManifests.getForTestSessionResult).mockResolvedValue(manifest)
     vi.mocked(api.api.get).mockResolvedValue({ data: Readable.from(['downloaded']) } as any)
+    vi.mocked(axios.get).mockResolvedValue({ data: Readable.from(['downloaded']) } as any)
   })
 
   afterEach(async () => {
@@ -125,6 +137,7 @@ describe('assets commands', () => {
   })
 
   it('lists check result assets as a table with copyable Asset values and truncation warning', async () => {
+    vi.mocked(api.assetManifests.getForCheckResult).mockResolvedValue(truncatedManifest)
     const ctx = createCommandContext({
       flags: {
         'check-id': 'check-id',
@@ -151,6 +164,7 @@ describe('assets commands', () => {
   })
 
   it('lists test-session result assets as filtered JSON without human warnings', async () => {
+    vi.mocked(api.assetManifests.getForTestSessionResult).mockResolvedValue(truncatedManifest)
     const ctx = createCommandContext({
       flags: {
         'test-session-id': 'session-id',
@@ -165,8 +179,22 @@ describe('assets commands', () => {
 
     expect(api.assetManifests.getForTestSessionResult).toHaveBeenCalledWith('session-id', 'result-id')
     expect(JSON.parse(ctx.logged[0])).toEqual({
-      ...manifest,
-      assets: [manifest.assets[1]],
+      data: [manifest.assets[1]],
+      source: {
+        kind: 'test-session-result',
+        testSessionId: 'session-id',
+        resultId: 'result-id',
+      },
+      metadata: {
+        filter: {
+          type: 'trace',
+        },
+        manifest: {
+          truncated: true,
+          entriesReturned: 5,
+          entriesTotal: 12,
+        },
+      },
     })
     expect(ctx.logged[0]).not.toContain('Assets for test-session result')
     expect(ctx.logged[0]).not.toContain('checkout trace.zip (trace')
@@ -207,6 +235,49 @@ describe('assets commands', () => {
     expect(ctx.logged[0]).toContain('Tip: use --view table to copy exact Asset values for download.')
   })
 
+  it('filters list output by exact asset name without treating duplicates as ambiguous', async () => {
+    const ctx = createCommandContext({
+      flags: {
+        'check-id': 'check-id',
+        'result-id': 'result-id',
+        'type': 'all',
+        'asset': 'duplicate.txt',
+        'view': 'table',
+        'output': 'table',
+      },
+    })
+
+    await AssetsList.prototype.run.call(ctx as any)
+
+    expect(ctx.logged[0]).toContain('Filter:')
+    expect(ctx.logged[0]).toContain('asset=duplicate.txt')
+    expect(ctx.logged[0]).toContain('a/duplicate.txt')
+    expect(ctx.logged[0]).toContain('b/duplicate.txt')
+    expect(ctx.logged[0]).not.toContain('logs.txt')
+  })
+
+  it('filters list JSON output by asset glob', async () => {
+    const ctx = createCommandContext({
+      flags: {
+        'test-session-id': 'session-id',
+        'result-id': 'result-id',
+        'type': 'trace',
+        'asset': 'traces/*.zip',
+        'view': 'tree',
+        'output': 'json',
+      },
+    })
+
+    await AssetsList.prototype.run.call(ctx as any)
+
+    const parsed = JSON.parse(ctx.logged[0])
+    expect(parsed.data).toEqual([manifest.assets[1]])
+    expect(parsed.metadata.filter).toEqual({
+      type: 'trace',
+      asset: 'traces/*.zip',
+    })
+  })
+
   it('requires a download selector', async () => {
     const ctx = createCommandContext({
       flags: {
@@ -239,10 +310,44 @@ describe('assets commands', () => {
     const summary = JSON.parse(ctx.logged[0])
     const expectedPath = path.join(tempDir, 'checkly-assets', 'check-result-result-id', 'logs.txt')
     expect(api.api.get).toHaveBeenCalledWith('/download/logs', { responseType: 'stream' })
+    expect(axios.get).not.toHaveBeenCalled()
     expect(summary.directory).toBe(path.dirname(expectedPath))
     expect(summary.files[0].path).toBe(expectedPath)
     expect(summary.files[0].status).toBe('written')
     await expect(readFile(expectedPath, 'utf8')).resolves.toBe('downloaded')
+  })
+
+  it('downloads absolute external asset URLs without the authenticated API client', async () => {
+    vi.mocked(api.assetManifests.getForCheckResult).mockResolvedValue({
+      assets: [{
+        type: 'log',
+        name: 'external-log.txt',
+        url: 'https://assets.example.com/external-log.txt',
+        contentType: 'text/plain',
+        source: 'runner',
+      }],
+    })
+    const ctx = createCommandContext({
+      flags: {
+        'check-id': 'check-id',
+        'result-id': 'result-id',
+        'asset': 'external-log.txt',
+        'output': 'json',
+        'force': false,
+        'skip-existing': false,
+        'extract': false,
+      },
+    })
+
+    await AssetsDownload.prototype.run.call(ctx as any)
+
+    expect(api.api.get).not.toHaveBeenCalled()
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://assets.example.com/external-log.txt',
+      expect.objectContaining({ responseType: 'stream' }),
+    )
+    expect(vi.mocked(axios.get).mock.calls[0][1]?.headers).toBeUndefined()
+    expect(JSON.parse(ctx.logged[0]).files[0].status).toBe('written')
   })
 
   it('renders single download human output as a full-path detail', async () => {
@@ -343,6 +448,53 @@ describe('assets commands', () => {
     const summary = JSON.parse(ctx.logged[0])
     expect(summary.files).toHaveLength(1)
     expect(summary.files[0].path).toBe(path.join(tempDir, 'custom-assets', 'traces', 'checkout trace.zip'))
+  })
+
+  it('refuses category downloads from truncated manifests', async () => {
+    vi.mocked(api.assetManifests.getForCheckResult).mockResolvedValue(truncatedManifest)
+    const ctx = createCommandContext({
+      flags: {
+        'check-id': 'check-id',
+        'result-id': 'result-id',
+        'type': 'file',
+        'output': 'table',
+        'force': false,
+        'skip-existing': false,
+        'extract': false,
+      },
+    })
+
+    await AssetsDownload.prototype.run.call(ctx as any)
+
+    expect(ctx.style.longError).toHaveBeenCalledWith(
+      'Failed to download assets.',
+      expect.objectContaining({
+        message: expect.stringContaining('Asset manifest is truncated (5 of 12 entries returned). Refusing to download'),
+      }),
+    )
+    expect(api.api.get).not.toHaveBeenCalled()
+    expect(axios.get).not.toHaveBeenCalled()
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('allows exact copied Asset downloads from truncated manifests', async () => {
+    vi.mocked(api.assetManifests.getForCheckResult).mockResolvedValue(truncatedManifest)
+    const ctx = createCommandContext({
+      flags: {
+        'check-id': 'check-id',
+        'result-id': 'result-id',
+        'asset': 'traces/checkout trace.zip',
+        'output': 'json',
+        'force': false,
+        'skip-existing': false,
+        'extract': false,
+      },
+    })
+
+    await AssetsDownload.prototype.run.call(ctx as any)
+
+    expect(api.api.get).toHaveBeenCalledWith('/download/trace', { responseType: 'stream' })
+    expect(JSON.parse(ctx.logged[0]).files[0].status).toBe('written')
   })
 
   it('fails ambiguous exact asset selection with matching Asset values', async () => {

--- a/packages/cli/src/commands/__tests__/assets.spec.ts
+++ b/packages/cli/src/commands/__tests__/assets.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Readable } from 'node:stream'
-import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, readdir, realpath, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import type { AssetManifest } from '../../rest/asset-manifests.js'
@@ -301,7 +301,6 @@ describe('assets commands', () => {
         'output': 'json',
         'force': false,
         'skip-existing': false,
-        'extract': false,
       },
     })
 
@@ -335,7 +334,6 @@ describe('assets commands', () => {
         'output': 'json',
         'force': false,
         'skip-existing': false,
-        'extract': false,
       },
     })
 
@@ -359,7 +357,6 @@ describe('assets commands', () => {
         'output': 'table',
         'force': false,
         'skip-existing': false,
-        'extract': false,
       },
     })
 
@@ -380,7 +377,6 @@ describe('assets commands', () => {
         'output': 'table',
         'force': false,
         'skip-existing': false,
-        'extract': false,
       },
     })
 
@@ -412,7 +408,6 @@ describe('assets commands', () => {
         'output': 'table',
         'force': false,
         'skip-existing': false,
-        'extract': false,
       },
     })
     ctx.fancy = true
@@ -439,7 +434,6 @@ describe('assets commands', () => {
         'output': 'json',
         'force': false,
         'skip-existing': false,
-        'extract': false,
       },
     })
 
@@ -460,7 +454,6 @@ describe('assets commands', () => {
         'output': 'table',
         'force': false,
         'skip-existing': false,
-        'extract': false,
       },
     })
 
@@ -487,13 +480,31 @@ describe('assets commands', () => {
         'output': 'json',
         'force': false,
         'skip-existing': false,
-        'extract': false,
       },
     })
 
     await AssetsDownload.prototype.run.call(ctx as any)
 
     expect(api.api.get).toHaveBeenCalledWith('/download/trace', { responseType: 'stream' })
+    expect(JSON.parse(ctx.logged[0]).files[0].status).toBe('written')
+  })
+
+  it('allows exact plain Asset downloads from truncated manifests', async () => {
+    vi.mocked(api.assetManifests.getForCheckResult).mockResolvedValue(truncatedManifest)
+    const ctx = createCommandContext({
+      flags: {
+        'check-id': 'check-id',
+        'result-id': 'result-id',
+        'asset': 'logs.txt',
+        'output': 'json',
+        'force': false,
+        'skip-existing': false,
+      },
+    })
+
+    await AssetsDownload.prototype.run.call(ctx as any)
+
+    expect(api.api.get).toHaveBeenCalledWith('/download/logs', { responseType: 'stream' })
     expect(JSON.parse(ctx.logged[0]).files[0].status).toBe('written')
   })
 
@@ -506,7 +517,6 @@ describe('assets commands', () => {
         'output': 'table',
         'force': false,
         'skip-existing': false,
-        'extract': false,
       },
     })
 
@@ -540,7 +550,6 @@ describe('assets commands', () => {
         'output': 'table',
         'force': false,
         'skip-existing': false,
-        'extract': false,
       },
     })
 
@@ -568,7 +577,6 @@ describe('assets commands', () => {
         'output': 'json',
         'force': true,
         'skip-existing': false,
-        'extract': false,
       },
     })
 
@@ -576,6 +584,37 @@ describe('assets commands', () => {
 
     expect(JSON.parse(ctx.logged[0]).files[0].status).toBe('written')
     await expect(readFile(existingPath, 'utf8')).resolves.toBe('downloaded')
+  })
+
+  it('preserves existing files when a forced download fails', async () => {
+    const existingPath = path.join(tempDir, 'checkly-assets', 'check-result-result-id', 'logs.txt')
+    await mkdir(path.dirname(existingPath), { recursive: true })
+    await writeFile(existingPath, 'existing')
+    async function* failingDownload () {
+      yield 'partial'
+      throw new Error('stream failed')
+    }
+    vi.mocked(api.api.get).mockResolvedValue({ data: Readable.from(failingDownload()) } as any)
+    const ctx = createCommandContext({
+      flags: {
+        'check-id': 'check-id',
+        'result-id': 'result-id',
+        'asset': 'logs.txt',
+        'output': 'table',
+        'force': true,
+        'skip-existing': false,
+      },
+    })
+
+    await AssetsDownload.prototype.run.call(ctx as any)
+
+    expect(ctx.style.longError).toHaveBeenCalledWith(
+      'Failed to download assets.',
+      expect.objectContaining({ message: 'stream failed' }),
+    )
+    expect(process.exitCode).toBe(1)
+    await expect(readFile(existingPath, 'utf8')).resolves.toBe('existing')
+    await expect(readdir(path.dirname(existingPath))).resolves.toEqual(['logs.txt'])
   })
 
   it('skips existing files with --skip-existing', async () => {
@@ -590,7 +629,6 @@ describe('assets commands', () => {
         'output': 'json',
         'force': false,
         'skip-existing': true,
-        'extract': false,
       },
     })
 
@@ -610,7 +648,6 @@ describe('assets commands', () => {
         'output': 'table',
         'force': true,
         'skip-existing': true,
-        'extract': false,
       },
     })
 
@@ -619,25 +656,7 @@ describe('assets commands', () => {
       .toThrow('--force and --skip-existing are mutually exclusive.')
   })
 
-  it('rejects unsupported archive extraction', async () => {
-    const ctx = createCommandContext({
-      flags: {
-        'check-id': 'check-id',
-        'result-id': 'result-id',
-        'asset': 'traces/checkout trace.zip',
-        'output': 'table',
-        'force': false,
-        'skip-existing': false,
-        'extract': true,
-      },
-    })
-
-    await AssetsDownload.prototype.run.call(ctx as any)
-
-    expect(ctx.style.longError).toHaveBeenCalledWith(
-      'Failed to download assets.',
-      expect.objectContaining({ message: expect.stringContaining('--extract is not supported') }),
-    )
-    expect(api.api.get).not.toHaveBeenCalled()
+  it('does not expose archive extraction before it is implemented', () => {
+    expect(AssetsDownload.flags).not.toHaveProperty('extract')
   })
 })

--- a/packages/cli/src/commands/__tests__/assets.spec.ts
+++ b/packages/cli/src/commands/__tests__/assets.spec.ts
@@ -70,7 +70,15 @@ function createCommandContext (parsed: unknown) {
     log: vi.fn((msg?: string) => {
       if (msg) logged.push(msg)
     }),
-    style: { outputFormat: undefined, longError: vi.fn() },
+    style: {
+      outputFormat: undefined,
+      actionStart: vi.fn(),
+      actionStatus: vi.fn(),
+      actionSuccess: vi.fn(),
+      actionFailure: vi.fn(),
+      longError: vi.fn(),
+    },
+    fancy: false,
     logged,
   }
 }
@@ -237,6 +245,85 @@ describe('assets commands', () => {
     await expect(readFile(expectedPath, 'utf8')).resolves.toBe('downloaded')
   })
 
+  it('renders single download human output as a full-path detail', async () => {
+    const ctx = createCommandContext({
+      flags: {
+        'check-id': 'check-id',
+        'result-id': 'result-id',
+        'asset': 'page.png',
+        'output': 'table',
+        'force': false,
+        'skip-existing': false,
+        'extract': false,
+      },
+    })
+
+    await AssetsDownload.prototype.run.call(ctx as any)
+
+    const expectedPath = path.join(tempDir, 'checkly-assets', 'check-result-result-id', 'page.png')
+    expect(ctx.logged[0]).toContain('Downloaded screenshot asset')
+    expect(ctx.logged[0]).toContain(`Path: ${expectedPath}`)
+    expect(ctx.logged[0]).not.toContain('ASSET')
+  })
+
+  it('renders multiple download human output with full paths and no repeated asset column', async () => {
+    const ctx = createCommandContext({
+      flags: {
+        'check-id': 'check-id',
+        'result-id': 'result-id',
+        'type': 'file',
+        'output': 'table',
+        'force': false,
+        'skip-existing': false,
+        'extract': false,
+      },
+    })
+
+    await AssetsDownload.prototype.run.call(ctx as any)
+
+    const firstPath = path.join(tempDir, 'checkly-assets', 'check-result-result-id', 'a', 'duplicate.txt')
+    const secondPath = path.join(tempDir, 'checkly-assets', 'check-result-result-id', 'b', 'duplicate.txt')
+    expect(ctx.logged[0]).toContain('2 assets processed (2 downloaded)')
+    expect(ctx.logged[0]).toContain(firstPath)
+    expect(ctx.logged[0]).toContain(secondPath)
+    expect(ctx.logged[0]).toContain('TYPE')
+    expect(ctx.logged[0]).toContain('PATH')
+    expect(ctx.logged[0]).not.toContain('ASSET')
+    expect(ctx.logged[0]).not.toContain('STATUS')
+  })
+
+  it('shows live progress in interactive human output', async () => {
+    const originalIsTTY = process.stdout.isTTY
+    Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: true })
+    vi.mocked(api.api.get).mockResolvedValue({
+      data: Readable.from(['downloaded']),
+      headers: { 'content-length': '10' },
+    } as any)
+    const ctx = createCommandContext({
+      flags: {
+        'check-id': 'check-id',
+        'result-id': 'result-id',
+        'asset': 'page.png',
+        'output': 'table',
+        'force': false,
+        'skip-existing': false,
+        'extract': false,
+      },
+    })
+    ctx.fancy = true
+
+    try {
+      await AssetsDownload.prototype.run.call(ctx as any)
+    } finally {
+      Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: originalIsTTY })
+    }
+
+    expect(ctx.style.actionStart).toHaveBeenCalledWith('Fetching asset manifest')
+    expect(ctx.style.actionStatus).toHaveBeenCalledWith(expect.stringContaining('Downloading 1/1 screenshot page.png'))
+    expect(ctx.style.actionStatus).toHaveBeenCalledWith(expect.stringContaining('10 B / 10 B'))
+    expect(ctx.style.actionSuccess).toHaveBeenCalled()
+  })
+
   it('downloads by glob selector and preserves safe archive entry paths', async () => {
     const ctx = createCommandContext({
       flags: {
@@ -309,7 +396,9 @@ describe('assets commands', () => {
 
     expect(ctx.style.longError).toHaveBeenCalledWith(
       'Failed to download assets.',
-      expect.objectContaining({ message: expect.stringContaining('Refusing to overwrite existing file') }),
+      expect.objectContaining({
+        message: `Refusing to overwrite existing file. Use --force to overwrite or --skip-existing to keep it.\n${existingPath}`,
+      }),
     )
     expect(process.exitCode).toBe(1)
     await expect(readFile(existingPath, 'utf8')).resolves.toBe('existing')

--- a/packages/cli/src/commands/__tests__/command-metadata.spec.ts
+++ b/packages/cli/src/commands/__tests__/command-metadata.spec.ts
@@ -10,6 +10,8 @@ import StatusPagesGet from '../status-pages/get.js'
 import AlertChannelsList from '../alert-channels/list.js'
 import AlertChannelsGet from '../alert-channels/get.js'
 import AlertChannelsLogs from '../alert-channels/logs.js'
+import AssetsList from '../assets/list.js'
+import AssetsDownload from '../assets/download.js'
 import IncidentsList from '../incidents/list.js'
 import IncidentsCreate from '../incidents/create.js'
 import IncidentsUpdate from '../incidents/update.js'
@@ -54,6 +56,8 @@ const commands: Array<[string, typeof BaseCommand]> = [
   ['alert-channels list', AlertChannelsList],
   ['alert-channels get', AlertChannelsGet],
   ['alert-channels logs', AlertChannelsLogs],
+  ['assets list', AssetsList],
+  ['assets download', AssetsDownload],
   ['checks list', ChecksList],
   ['checks get', ChecksGet],
   ['checks stats', ChecksStats],

--- a/packages/cli/src/commands/assets/download.ts
+++ b/packages/cli/src/commands/assets/download.ts
@@ -5,6 +5,8 @@ import { outputFlag } from '../../helpers/flags.js'
 import { assetSelectorValue, formatDownloadedAssets, type DownloadedAssetRow } from '../../formatters/assets.js'
 import {
   assertManifestSupportsDownload,
+  assetManifestFiltersFromSelection,
+  assetTypeSelectionFromFlag,
   assetTypes,
   defaultDownloadDirectory,
   destinationPathForAsset,
@@ -56,6 +58,7 @@ export default class AssetsDownload extends AuthCommand {
     const { flags } = await this.parse(AssetsDownload)
     this.style.outputFormat = flags.output
     const source = resolveAssetSource(flags)
+    const type = assetTypeSelectionFromFlag(flags.type)
     const showProgress = flags.output !== 'json' && this.fancy && process.stdout.isTTY
     let progressStarted = false
 
@@ -90,10 +93,14 @@ export default class AssetsDownload extends AuthCommand {
 
     try {
       startProgress('Fetching asset manifest')
-      const manifest = await fetchAssetManifest(source)
-      assertManifestSupportsDownload(manifest, { asset: flags.asset })
+      const filters = assetManifestFiltersFromSelection({
+        type,
+        asset: flags.asset,
+      })
+      const manifest = await fetchAssetManifest(source, filters)
+      assertManifestSupportsDownload(manifest, filters)
       const assets = selectAssets(manifest.assets, {
-        type: flags.type as any,
+        type,
         asset: flags.asset,
       })
 

--- a/packages/cli/src/commands/assets/download.ts
+++ b/packages/cli/src/commands/assets/download.ts
@@ -2,7 +2,7 @@ import { Flags } from '@oclif/core'
 import path from 'node:path'
 import { AuthCommand } from '../authCommand.js'
 import { outputFlag } from '../../helpers/flags.js'
-import { formatDownloadedAssets, type DownloadedAssetRow } from '../../formatters/assets.js'
+import { assetSelectorValue, formatDownloadedAssets, type DownloadedAssetRow } from '../../formatters/assets.js'
 import {
   assetTypes,
   defaultDownloadDirectory,
@@ -60,6 +60,29 @@ export default class AssetsDownload extends AuthCommand {
     const { flags } = await this.parse(AssetsDownload)
     this.style.outputFormat = flags.output
     const source = resolveAssetSource(flags)
+    const showProgress = flags.output !== 'json' && this.fancy && process.stdout.isTTY
+    let progressStarted = false
+
+    const startProgress = (message: string) => {
+      if (!showProgress) return
+      this.style.actionStart(message)
+      progressStarted = true
+    }
+
+    const setProgress = (message: string) => {
+      if (!showProgress || !progressStarted) return
+      this.style.actionStatus(message)
+    }
+
+    const stopProgress = (success: boolean) => {
+      if (!showProgress || !progressStarted) return
+      if (success) {
+        this.style.actionSuccess()
+      } else {
+        this.style.actionFailure()
+      }
+      progressStarted = false
+    }
 
     if (flags.force && flags['skip-existing']) {
       throw new Error('--force and --skip-existing are mutually exclusive.')
@@ -70,6 +93,7 @@ export default class AssetsDownload extends AuthCommand {
     }
 
     try {
+      startProgress('Fetching asset manifest')
       const manifest = await fetchAssetManifest(source)
       const assets = selectAssets(manifest.assets, {
         type: flags.type as any,
@@ -77,6 +101,7 @@ export default class AssetsDownload extends AuthCommand {
       })
 
       if (assets.length === 0) {
+        stopProgress(true)
         if (flags.output === 'json') {
           this.log(JSON.stringify({ source, directory: null, files: [] }, null, 2))
           return
@@ -98,14 +123,27 @@ export default class AssetsDownload extends AuthCommand {
       const directory = path.resolve(flags.dir ?? defaultDownloadDirectory(source))
       const rows: DownloadedAssetRow[] = []
 
-      for (const asset of assets) {
+      for (const [index, asset] of assets.entries()) {
         const filePath = destinationPathForAsset(directory, asset)
+        const label = `${index + 1}/${assets.length} ${asset.type} ${assetSelectorValue(asset)}`
+        let lastProgressUpdate = 0
+        setProgress(`Downloading ${label}`)
         const status = await downloadAssetToFile(asset, filePath, {
           force: flags.force,
           skipExisting: flags['skip-existing'],
+          onProgress: showProgress
+            ? ({ downloadedBytes, totalBytes }) => {
+                const now = Date.now()
+                if (now - lastProgressUpdate < 250) return
+                lastProgressUpdate = now
+                setProgress(`Downloading ${label} ${formatDownloadBytes(downloadedBytes, totalBytes)}`)
+              }
+            : undefined,
         })
+        setProgress(status === 'skipped' ? `Skipped ${label}` : `Downloaded ${label}`)
         rows.push({ status, path: filePath, asset })
       }
+      stopProgress(true)
 
       if (flags.output === 'json') {
         this.log(JSON.stringify({ source, directory, files: rows }, null, 2))
@@ -114,8 +152,30 @@ export default class AssetsDownload extends AuthCommand {
 
       this.log(formatDownloadedAssets(rows))
     } catch (err: any) {
+      stopProgress(false)
       this.style.longError('Failed to download assets.', err)
       process.exitCode = 1
     }
   }
+}
+
+function formatDownloadBytes (downloadedBytes: number, totalBytes?: number): string {
+  if (totalBytes === undefined) return formatBytes(downloadedBytes)
+  return `${formatBytes(downloadedBytes)} / ${formatBytes(totalBytes)}`
+}
+
+function formatBytes (bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+
+  const units = ['KB', 'MB', 'GB', 'TB']
+  let value = bytes / 1024
+  let unitIndex = 0
+
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024
+    unitIndex += 1
+  }
+
+  const rounded = value >= 10 ? value.toFixed(1) : value.toFixed(2)
+  return `${rounded} ${units[unitIndex]}`
 }

--- a/packages/cli/src/commands/assets/download.ts
+++ b/packages/cli/src/commands/assets/download.ts
@@ -4,6 +4,7 @@ import { AuthCommand } from '../authCommand.js'
 import { outputFlag } from '../../helpers/flags.js'
 import { assetSelectorValue, formatDownloadedAssets, type DownloadedAssetRow } from '../../formatters/assets.js'
 import {
+  assertManifestSupportsDownload,
   assetTypes,
   defaultDownloadDirectory,
   destinationPathForAsset,
@@ -95,6 +96,7 @@ export default class AssetsDownload extends AuthCommand {
     try {
       startProgress('Fetching asset manifest')
       const manifest = await fetchAssetManifest(source)
+      assertManifestSupportsDownload(manifest, { asset: flags.asset })
       const assets = selectAssets(manifest.assets, {
         type: flags.type as any,
         asset: flags.asset,

--- a/packages/cli/src/commands/assets/download.ts
+++ b/packages/cli/src/commands/assets/download.ts
@@ -5,6 +5,7 @@ import { outputFlag } from '../../helpers/flags.js'
 import { assetSelectorValue, formatDownloadedAssets, type DownloadedAssetRow } from '../../formatters/assets.js'
 import {
   assertManifestSupportsDownload,
+  archiveBundleAssets,
   assetManifestFiltersFromSelection,
   assetTypeSelectionFromFlag,
   assetTypes,
@@ -12,6 +13,8 @@ import {
   destinationPathForAsset,
   downloadAssetToFile,
   fetchAssetManifest,
+  hasArchiveEntries,
+  isSingleArchiveBundle,
   resolveAssetSource,
   selectAssets,
 } from '../../helpers/result-assets.js'
@@ -87,10 +90,6 @@ export default class AssetsDownload extends AuthCommand {
       throw new Error('--force and --skip-existing are mutually exclusive.')
     }
 
-    if (!flags.type && !flags.asset) {
-      throw new Error('Pass --type or --asset to select assets. Use --type all to download all assets.')
-    }
-
     try {
       startProgress('Fetching asset manifest')
       const filters = assetManifestFiltersFromSelection({
@@ -103,11 +102,16 @@ export default class AssetsDownload extends AuthCommand {
         type,
         asset: flags.asset,
       })
+      const hasSelector = Boolean(flags.type || flags.asset)
+
+      if (!hasSelector && !isSingleArchiveBundle(assets)) {
+        throw new Error('Pass --type or --asset to select assets. Use --type all to download all assets.')
+      }
 
       if (assets.length === 0) {
         stopProgress(true)
         if (flags.output === 'json') {
-          this.log(JSON.stringify({ source, directory: null, files: [] }, null, 2))
+          this.log(JSON.stringify({ source, directory: null, files: [], warnings: [] }, null, 2))
           return
         }
         this.log('No matching assets found.')
@@ -116,10 +120,24 @@ export default class AssetsDownload extends AuthCommand {
 
       const directory = path.resolve(flags.dir ?? defaultDownloadDirectory(source))
       const rows: DownloadedAssetRow[] = []
+      const directAssets = assets.filter(asset => !asset.archive)
+      const archiveAssets = archiveBundleAssets(assets)
+      const downloadTargets = [
+        ...directAssets.map(asset => ({ asset, displayType: undefined })),
+        ...archiveAssets.map(asset => ({ asset, displayType: 'archive' })),
+      ]
+      const warnings: string[] = []
 
-      for (const [index, asset] of assets.entries()) {
+      if (hasArchiveEntries(assets)) {
+        warnings.push(
+          'Selected assets include archive entries. Downloading the containing archive file; filters narrow the manifest list, not the archive bytes.',
+        )
+      }
+
+      for (const [index, target] of downloadTargets.entries()) {
+        const { asset, displayType } = target
         const filePath = destinationPathForAsset(directory, asset)
-        const label = `${index + 1}/${assets.length} ${asset.type} ${assetSelectorValue(asset)}`
+        const label = `${index + 1}/${downloadTargets.length} ${displayType ?? asset.type} ${assetSelectorValue(asset)}`
         let lastProgressUpdate = 0
         setProgress(`Downloading ${label}`)
         const status = await downloadAssetToFile(asset, filePath, {
@@ -135,16 +153,20 @@ export default class AssetsDownload extends AuthCommand {
             : undefined,
         })
         setProgress(status === 'skipped' ? `Skipped ${label}` : `Downloaded ${label}`)
-        rows.push({ status, path: filePath, asset })
+        rows.push({ status, path: filePath, asset, displayType })
       }
       stopProgress(true)
 
       if (flags.output === 'json') {
-        this.log(JSON.stringify({ source, directory, files: rows }, null, 2))
+        this.log(JSON.stringify({ source, directory, files: rows, warnings }, null, 2))
         return
       }
 
-      this.log(formatDownloadedAssets(rows))
+      const output = [
+        ...warnings.map(warning => `Warning: ${warning}`),
+        formatDownloadedAssets(rows),
+      ].filter(Boolean)
+      this.log(output.join('\n\n'))
     } catch (err: any) {
       stopProgress(false)
       this.style.longError('Failed to download assets.', err)

--- a/packages/cli/src/commands/assets/download.ts
+++ b/packages/cli/src/commands/assets/download.ts
@@ -1,0 +1,121 @@
+import { Flags } from '@oclif/core'
+import path from 'node:path'
+import { AuthCommand } from '../authCommand.js'
+import { outputFlag } from '../../helpers/flags.js'
+import { formatDownloadedAssets, type DownloadedAssetRow } from '../../formatters/assets.js'
+import {
+  assetTypes,
+  defaultDownloadDirectory,
+  destinationPathForAsset,
+  downloadAssetToFile,
+  fetchAssetManifest,
+  isArchiveAsset,
+  resolveAssetSource,
+  selectAssets,
+} from '../../helpers/result-assets.js'
+
+export default class AssetsDownload extends AuthCommand {
+  static hidden = false
+  static readOnly = true
+  static idempotent = true
+  static description = 'Download result assets.'
+
+  static flags = {
+    'check-id': Flags.string({
+      description: 'Check ID for a scheduled check result.',
+    }),
+    'test-session-id': Flags.string({
+      description: 'Test session ID for a test-session result.',
+    }),
+    'result-id': Flags.string({
+      description: 'Check result ID or test-session result ID.',
+      required: true,
+    }),
+    'type': Flags.string({
+      description: 'Select assets by type.',
+      options: assetTypes,
+    }),
+    'asset': Flags.string({
+      description: 'Select an asset by exact Asset/Name value or glob.',
+    }),
+    'dir': Flags.string({
+      description: 'Directory to write assets into.',
+    }),
+    'force': Flags.boolean({
+      description: 'Overwrite existing files.',
+      default: false,
+    }),
+    'skip-existing': Flags.boolean({
+      description: 'Skip files that already exist.',
+      default: false,
+    }),
+    'extract': Flags.boolean({
+      description: 'Extract supported archives instead of writing raw downloads.',
+      default: false,
+    }),
+    'output': outputFlag({ default: 'table', options: ['table', 'json'] }),
+  }
+
+  async run (): Promise<void> {
+    const { flags } = await this.parse(AssetsDownload)
+    this.style.outputFormat = flags.output
+    const source = resolveAssetSource(flags)
+
+    if (flags.force && flags['skip-existing']) {
+      throw new Error('--force and --skip-existing are mutually exclusive.')
+    }
+
+    if (!flags.type && !flags.asset) {
+      throw new Error('Pass --type or --asset to select assets. Use --type all to download all assets.')
+    }
+
+    try {
+      const manifest = await fetchAssetManifest(source)
+      const assets = selectAssets(manifest.assets, {
+        type: flags.type as any,
+        asset: flags.asset,
+      })
+
+      if (assets.length === 0) {
+        if (flags.output === 'json') {
+          this.log(JSON.stringify({ source, directory: null, files: [] }, null, 2))
+          return
+        }
+        this.log('No matching assets found.')
+        return
+      }
+
+      if (flags.extract) {
+        const unsupported = assets.find(isArchiveAsset)
+        if (unsupported) {
+          throw new Error(
+            '--extract is not supported for this asset shape yet. '
+            + 'Download the raw asset without --extract and extract it locally.',
+          )
+        }
+      }
+
+      const directory = path.resolve(flags.dir ?? defaultDownloadDirectory(source))
+      const rows: DownloadedAssetRow[] = []
+
+      for (const asset of assets) {
+        const filePath = destinationPathForAsset(directory, asset)
+        const status = await downloadAssetToFile(asset, filePath, {
+          force: flags.force,
+          skipExisting: flags['skip-existing'],
+        })
+        rows.push({ status, path: filePath, asset })
+      }
+
+      if (flags.output === 'json') {
+        this.log(JSON.stringify({ source, directory, files: rows }, null, 2))
+        return
+      }
+
+      this.log(formatDownloadedAssets(rows))
+    } catch (err: any) {
+      this.style.longError('Failed to download assets.', err)
+      process.exitCode = 1
+    }
+  }
+}

--- a/packages/cli/src/commands/assets/download.ts
+++ b/packages/cli/src/commands/assets/download.ts
@@ -10,7 +10,6 @@ import {
   destinationPathForAsset,
   downloadAssetToFile,
   fetchAssetManifest,
-  isArchiveAsset,
   resolveAssetSource,
   selectAssets,
 } from '../../helpers/result-assets.js'
@@ -48,10 +47,6 @@ export default class AssetsDownload extends AuthCommand {
     }),
     'skip-existing': Flags.boolean({
       description: 'Skip files that already exist.',
-      default: false,
-    }),
-    'extract': Flags.boolean({
-      description: 'Extract supported archives instead of writing raw downloads.',
       default: false,
     }),
     'output': outputFlag({ default: 'table', options: ['table', 'json'] }),
@@ -110,16 +105,6 @@ export default class AssetsDownload extends AuthCommand {
         }
         this.log('No matching assets found.')
         return
-      }
-
-      if (flags.extract) {
-        const unsupported = assets.find(isArchiveAsset)
-        if (unsupported) {
-          throw new Error(
-            '--extract is not supported for this asset shape yet. '
-            + 'Download the raw asset without --extract and extract it locally.',
-          )
-        }
       }
 
       const directory = path.resolve(flags.dir ?? defaultDownloadDirectory(source))

--- a/packages/cli/src/commands/assets/list.ts
+++ b/packages/cli/src/commands/assets/list.ts
@@ -9,6 +9,8 @@ import {
   formatAssetManifestTree,
 } from '../../formatters/assets.js'
 import {
+  assetManifestFiltersFromSelection,
+  assetTypeSelectionFromFlag,
   assetTypes,
   fetchAssetManifest,
   filterAssetsBySelector,
@@ -53,28 +55,24 @@ export default class AssetsList extends AuthCommand {
     const { flags } = await this.parse(AssetsList)
     this.style.outputFormat = flags.output
     const source = resolveAssetSource(flags)
+    const type = assetTypeSelectionFromFlag(flags.type)
 
     try {
-      const manifest = await fetchAssetManifest(source)
+      const filters = assetManifestFiltersFromSelection({
+        type,
+        asset: flags.asset,
+      })
+      const manifest = await fetchAssetManifest(source, filters)
       const assets = filterAssetsBySelector(
-        filterAssetsByType(manifest.assets, flags.type as any),
+        filterAssetsByType(manifest.assets, type),
         flags.asset,
       )
 
       if (flags.output === 'json') {
         this.log(JSON.stringify({
           data: assets,
-          source,
-          metadata: {
-            filter: {
-              type: flags.type,
-              asset: flags.asset,
-            },
-            manifest: {
-              truncated: Boolean(manifest.truncated),
-              entriesReturned: manifest.entriesReturned,
-              entriesTotal: manifest.entriesTotal,
-            },
+          pagination: {
+            length: assets.length,
           },
         }, null, 2))
         return
@@ -88,7 +86,7 @@ export default class AssetsList extends AuthCommand {
         checkId: source.kind === 'check-result' ? source.checkId : undefined,
         testSessionId: source.kind === 'test-session-result' ? source.testSessionId : undefined,
         resultId: source.resultId,
-        type: flags.type,
+        type,
         asset: flags.asset,
       }, assets, fmt))
       output.push('')

--- a/packages/cli/src/commands/assets/list.ts
+++ b/packages/cli/src/commands/assets/list.ts
@@ -38,7 +38,7 @@ export default class AssetsList extends AuthCommand {
       default: 'all',
     }),
     'view': Flags.string({
-      description: 'Human output view.',
+      description: 'Human output view. Ignored with --output json.',
       options: ['table', 'tree'],
       default: 'table',
     }),

--- a/packages/cli/src/commands/assets/list.ts
+++ b/packages/cli/src/commands/assets/list.ts
@@ -5,6 +5,7 @@ import { outputFlag } from '../../helpers/flags.js'
 import type { OutputFormat } from '../../formatters/render.js'
 import {
   formatAssetListHeader,
+  formatAssetListNextSteps,
   formatAssetManifestEntries,
   formatAssetManifestTree,
 } from '../../formatters/assets.js'
@@ -101,8 +102,21 @@ export default class AssetsList extends AuthCommand {
         output.push(formatAssetManifestEntries(assets, fmt))
       }
 
+      const nextSteps = formatAssetListNextSteps({
+        sourceType: source.kind,
+        checkId: source.kind === 'check-result' ? source.checkId : undefined,
+        testSessionId: source.kind === 'test-session-result' ? source.testSessionId : undefined,
+        resultId: source.resultId,
+        type,
+        asset: flags.asset,
+      }, assets, fmt)
+      if (nextSteps) {
+        output.push('')
+        output.push(nextSteps)
+      }
+
       if (manifest.truncated) {
-        const returned = manifest.entriesReturned ?? assets.length
+        const returned = manifest.entriesReturned ?? manifest.assets.length
         const total = manifest.entriesTotal == null ? 'unknown' : String(manifest.entriesTotal)
         output.push('')
         output.push(chalk.yellow(`Warning: asset manifest is truncated (${returned} of ${total} entries returned).`))

--- a/packages/cli/src/commands/assets/list.ts
+++ b/packages/cli/src/commands/assets/list.ts
@@ -1,0 +1,98 @@
+import { Flags } from '@oclif/core'
+import chalk from 'chalk'
+import { AuthCommand } from '../authCommand.js'
+import { outputFlag } from '../../helpers/flags.js'
+import type { OutputFormat } from '../../formatters/render.js'
+import {
+  formatAssetListHeader,
+  formatAssetManifestEntries,
+  formatAssetManifestTree,
+} from '../../formatters/assets.js'
+import {
+  assetTypes,
+  fetchAssetManifest,
+  filterAssetsByType,
+  resolveAssetSource,
+} from '../../helpers/result-assets.js'
+
+export default class AssetsList extends AuthCommand {
+  static hidden = false
+  static readOnly = true
+  static idempotent = true
+  static description = 'List result assets.'
+
+  static flags = {
+    'check-id': Flags.string({
+      description: 'Check ID for a scheduled check result.',
+    }),
+    'test-session-id': Flags.string({
+      description: 'Test session ID for a test-session result.',
+    }),
+    'result-id': Flags.string({
+      description: 'Check result ID or test-session result ID.',
+      required: true,
+    }),
+    'type': Flags.string({
+      description: 'Filter assets by type.',
+      options: assetTypes,
+      default: 'all',
+    }),
+    'view': Flags.string({
+      description: 'Human output view.',
+      options: ['table', 'tree'],
+      default: 'table',
+    }),
+    'output': outputFlag({ default: 'table' }),
+  }
+
+  async run (): Promise<void> {
+    const { flags } = await this.parse(AssetsList)
+    this.style.outputFormat = flags.output
+    const source = resolveAssetSource(flags)
+
+    try {
+      const manifest = await fetchAssetManifest(source)
+      const assets = filterAssetsByType(manifest.assets, flags.type as any)
+      const filteredManifest = { ...manifest, assets }
+
+      if (flags.output === 'json') {
+        this.log(JSON.stringify(filteredManifest, null, 2))
+        return
+      }
+
+      const fmt: OutputFormat = flags.output === 'md' ? 'md' : 'terminal'
+      const output: string[] = []
+
+      output.push(formatAssetListHeader({
+        sourceType: source.kind,
+        checkId: source.kind === 'check-result' ? source.checkId : undefined,
+        testSessionId: source.kind === 'test-session-result' ? source.testSessionId : undefined,
+        resultId: source.resultId,
+        type: flags.type,
+      }, assets, fmt))
+      output.push('')
+
+      if (assets.length === 0) {
+        output.push('No assets found.')
+      } else if (flags.view === 'tree') {
+        output.push(formatAssetManifestTree(assets, fmt))
+        output.push('')
+        output.push(chalk.dim('Tip: use --view table to copy exact Asset values for download.'))
+      } else {
+        output.push(formatAssetManifestEntries(assets, fmt))
+      }
+
+      if (manifest.truncated) {
+        const returned = manifest.entriesReturned ?? assets.length
+        const total = manifest.entriesTotal == null ? 'unknown' : String(manifest.entriesTotal)
+        output.push('')
+        output.push(chalk.yellow(`Warning: asset manifest is truncated (${returned} of ${total} entries returned).`))
+      }
+
+      this.log(output.join('\n'))
+    } catch (err: any) {
+      this.style.longError('Failed to list assets.', err)
+      process.exitCode = 1
+    }
+  }
+}

--- a/packages/cli/src/commands/assets/list.ts
+++ b/packages/cli/src/commands/assets/list.ts
@@ -11,6 +11,7 @@ import {
 import {
   assetTypes,
   fetchAssetManifest,
+  filterAssetsBySelector,
   filterAssetsByType,
   resolveAssetSource,
 } from '../../helpers/result-assets.js'
@@ -37,6 +38,9 @@ export default class AssetsList extends AuthCommand {
       options: assetTypes,
       default: 'all',
     }),
+    'asset': Flags.string({
+      description: 'Filter assets by exact Asset/Name value or glob.',
+    }),
     'view': Flags.string({
       description: 'Human output view. Ignored with --output json.',
       options: ['table', 'tree'],
@@ -52,11 +56,27 @@ export default class AssetsList extends AuthCommand {
 
     try {
       const manifest = await fetchAssetManifest(source)
-      const assets = filterAssetsByType(manifest.assets, flags.type as any)
-      const filteredManifest = { ...manifest, assets }
+      const assets = filterAssetsBySelector(
+        filterAssetsByType(manifest.assets, flags.type as any),
+        flags.asset,
+      )
 
       if (flags.output === 'json') {
-        this.log(JSON.stringify(filteredManifest, null, 2))
+        this.log(JSON.stringify({
+          data: assets,
+          source,
+          metadata: {
+            filter: {
+              type: flags.type,
+              asset: flags.asset,
+            },
+            manifest: {
+              truncated: Boolean(manifest.truncated),
+              entriesReturned: manifest.entriesReturned,
+              entriesTotal: manifest.entriesTotal,
+            },
+          },
+        }, null, 2))
         return
       }
 
@@ -69,6 +89,7 @@ export default class AssetsList extends AuthCommand {
         testSessionId: source.kind === 'test-session-result' ? source.testSessionId : undefined,
         resultId: source.resultId,
         type: flags.type,
+        asset: flags.asset,
       }, assets, fmt))
       output.push('')
 

--- a/packages/cli/src/formatters/assets.ts
+++ b/packages/cli/src/formatters/assets.ts
@@ -63,6 +63,28 @@ export interface AssetListContext {
   asset?: string
 }
 
+function plural (count: number, singular: string, pluralValue = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : pluralValue}`
+}
+
+function summarizeStorage (assets: AssetManifestEntry[]) {
+  const archiveUrls = new Set<string>()
+  let archiveEntries = 0
+
+  for (const asset of assets) {
+    if (asset.archive) {
+      archiveEntries += 1
+      archiveUrls.add(asset.url)
+    }
+  }
+
+  return {
+    directAssets: assets.length - archiveEntries,
+    archiveEntries,
+    archiveUrlCount: archiveUrls.size,
+  }
+}
+
 function formatTypeCounts (assets: AssetManifestEntry[]): string {
   const counts = new Map<string, number>()
   for (const asset of assets) {
@@ -106,7 +128,79 @@ export function formatAssetListHeader (
     ? `- Showing: ${typeCounts ? `${total} (${typeCounts})` : total}`
     : `${chalk.dim('Showing:')} ${typeCounts ? `${total} (${typeCounts})` : total}`)
 
+  const storage = summarizeStorage(assets)
+  if (storage.archiveEntries > 0 && storage.directAssets === 0) {
+    const archiveSummary = `${plural(storage.archiveEntries, 'file')} inside ${plural(storage.archiveUrlCount, 'archive')}`
+    lines.push(format === 'md'
+      ? `- Storage: ${archiveSummary}`
+      : `${chalk.dim('Storage:')} ${archiveSummary}`)
+    lines.push(format === 'md'
+      ? '- Download: archive entries download as the containing archive; filters narrow this list, not the archive bytes.'
+      : `${chalk.dim('Download:')} archive entries download as the containing archive; filters narrow this list, not the archive bytes.`)
+  } else if (storage.archiveEntries > 0) {
+    const storageSummary = [
+      plural(storage.directAssets, 'direct file'),
+      `${plural(storage.archiveEntries, 'file')} inside ${plural(storage.archiveUrlCount, 'archive')}`,
+    ].join(', ')
+    lines.push(format === 'md'
+      ? `- Storage: ${storageSummary}`
+      : `${chalk.dim('Storage:')} ${storageSummary}`)
+    lines.push(format === 'md'
+      ? '- Download: direct files can be downloaded individually; archive entries download as their containing archive.'
+      : `${chalk.dim('Download:')} direct files can be downloaded individually; archive entries download as their containing archive.`)
+  } else if (assets.length > 0) {
+    lines.push(format === 'md'
+      ? '- Download: use --type or --asset to download matching files.'
+      : `${chalk.dim('Download:')} use --type or --asset to download matching files.`)
+  }
+
   return lines.join('\n')
+}
+
+function shellQuote (value: string): string {
+  return `"${value.replace(/(["\\$`])/g, '\\$1')}"`
+}
+
+function sourceFlags (context: AssetListContext): string {
+  const flags = context.sourceType === 'check-result'
+    ? [`--check-id ${context.checkId}`]
+    : [`--test-session-id ${context.testSessionId}`]
+  flags.push(`--result-id ${context.resultId}`)
+  return flags.join(' ')
+}
+
+export function formatAssetListNextSteps (
+  context: AssetListContext,
+  assets: AssetManifestEntry[],
+  format: OutputFormat,
+): string {
+  if (assets.length === 0) return ''
+
+  const commandBase = `checkly assets download ${sourceFlags(context)}`
+  const lines: string[] = []
+
+  const storage = summarizeStorage(assets)
+  if (storage.archiveEntries > 0 && storage.directAssets === 0 && storage.archiveUrlCount === 1) {
+    lines.push('Next:')
+    lines.push(`  Download archive: ${commandBase}`)
+    lines.push(`  Inspect entries:   checkly assets list ${sourceFlags(context)} --asset ${shellQuote('<glob-or-asset>')}`)
+  } else {
+    lines.push('Next:')
+    const selector = context.asset
+      ? ` --asset ${shellQuote(context.asset)}`
+      : context.type && context.type !== 'all'
+        ? ` --type ${context.type}`
+        : ' --asset <Asset>'
+    lines.push(`  Download files: ${commandBase}${selector}`)
+  }
+
+  if (format === 'md') {
+    return lines.join('\n')
+  }
+
+  return lines
+    .map(line => chalk.dim(line))
+    .join('\n')
 }
 
 interface AssetTreeNode {
@@ -183,6 +277,7 @@ export interface DownloadedAssetRow {
   status: 'written' | 'skipped'
   path: string
   asset: AssetManifestEntry
+  displayType?: string
 }
 
 function buildDownloadedAssetColumns (): ColumnDef<DownloadedAssetRow>[] {
@@ -190,7 +285,7 @@ function buildDownloadedAssetColumns (): ColumnDef<DownloadedAssetRow>[] {
     {
       header: 'Type',
       width: 12,
-      value: row => row.asset.type,
+      value: row => row.displayType ?? row.asset.type,
     },
     {
       header: 'Path',
@@ -211,7 +306,7 @@ function buildDownloadedAssetStatusColumns (): ColumnDef<DownloadedAssetRow>[] {
     {
       header: 'Type',
       width: 12,
-      value: row => row.asset.type,
+      value: row => row.displayType ?? row.asset.type,
     },
     {
       header: 'Path',
@@ -229,7 +324,7 @@ export function formatDownloadedAssets (rows: DownloadedAssetRow[]): string {
     const [row] = rows
     const action = row.status === 'written' ? 'Downloaded' : 'Skipped existing'
     return [
-      chalk.bold(`${action} ${row.asset.type} asset`),
+      chalk.bold(`${action} ${row.displayType ?? row.asset.type} asset`),
       `${chalk.dim('Path:')} ${row.path}`,
     ].join('\n')
   }

--- a/packages/cli/src/formatters/assets.ts
+++ b/packages/cli/src/formatters/assets.ts
@@ -5,7 +5,6 @@ import {
   type OutputFormat,
   escapeMdCell,
   renderAdaptiveTable,
-  truncateToWidth,
 } from './render.js'
 
 export function assetSelectorValue (asset: AssetManifestEntry): string {
@@ -182,10 +181,22 @@ export interface DownloadedAssetRow {
 }
 
 function buildDownloadedAssetColumns (): ColumnDef<DownloadedAssetRow>[] {
-  const termWidth = process.stdout.columns || 120
-  const pathWidth = Math.min(58, Math.floor(termWidth * 0.48))
-  const assetWidth = Math.min(42, Math.floor(termWidth * 0.34))
+  return [
+    {
+      header: 'Type',
+      width: 12,
+      value: row => row.asset.type,
+    },
+    {
+      header: 'Path',
+      minWidth: 24,
+      truncate: false,
+      value: row => row.path,
+    },
+  ]
+}
 
+function buildDownloadedAssetStatusColumns (): ColumnDef<DownloadedAssetRow>[] {
   return [
     {
       header: 'Status',
@@ -193,22 +204,44 @@ function buildDownloadedAssetColumns (): ColumnDef<DownloadedAssetRow>[] {
       value: row => row.status === 'written' ? chalk.green('written') : chalk.yellow('skipped'),
     },
     {
-      header: 'Path',
-      width: pathWidth,
-      value: row => truncateToWidth(row.path, pathWidth - 2),
-    },
-    {
       header: 'Type',
       width: 12,
       value: row => row.asset.type,
     },
     {
-      header: 'Asset',
-      value: row => truncateToWidth(assetSelectorValue(row.asset), assetWidth),
+      header: 'Path',
+      minWidth: 24,
+      truncate: false,
+      value: row => row.path,
     },
   ]
 }
 
 export function formatDownloadedAssets (rows: DownloadedAssetRow[]): string {
-  return renderAdaptiveTable(buildDownloadedAssetColumns(), rows, 'terminal')
+  if (rows.length === 0) return ''
+
+  if (rows.length === 1) {
+    const [row] = rows
+    const action = row.status === 'written' ? 'Downloaded' : 'Skipped existing'
+    return [
+      chalk.bold(`${action} ${row.asset.type} asset`),
+      `${chalk.dim('Path:')} ${row.path}`,
+    ].join('\n')
+  }
+
+  const written = rows.filter(row => row.status === 'written').length
+  const skipped = rows.length - written
+  const summary = [
+    written > 0 ? `${written} downloaded` : undefined,
+    skipped > 0 ? `${skipped} skipped` : undefined,
+  ].filter(Boolean).join(', ')
+
+  const columns = skipped > 0
+    ? buildDownloadedAssetStatusColumns()
+    : buildDownloadedAssetColumns()
+
+  return [
+    chalk.bold(`${rows.length} assets processed (${summary})`),
+    renderAdaptiveTable(columns, rows, 'terminal'),
+  ].join('\n')
 }

--- a/packages/cli/src/formatters/assets.ts
+++ b/packages/cli/src/formatters/assets.ts
@@ -60,6 +60,7 @@ export interface AssetListContext {
   testSessionId?: string
   resultId: string
   type?: string
+  asset?: string
 }
 
 function formatTypeCounts (assets: AssetManifestEntry[]): string {
@@ -93,7 +94,11 @@ export function formatAssetListHeader (
       : `${chalk.dim('Test session ID:')} ${context.testSessionId}`)
   }
   lines.push(format === 'md' ? `- Result ID: ${context.resultId}` : `${chalk.dim('Result ID:')} ${context.resultId}`)
-  lines.push(format === 'md' ? `- Filter: type=${context.type ?? 'all'}` : `${chalk.dim('Filter:')} type=${context.type ?? 'all'}`)
+  const filters = [`type=${context.type ?? 'all'}`]
+  if (context.asset) {
+    filters.push(`asset=${context.asset}`)
+  }
+  lines.push(format === 'md' ? `- Filter: ${filters.join(', ')}` : `${chalk.dim('Filter:')} ${filters.join(', ')}`)
 
   const typeCounts = formatTypeCounts(assets)
   const total = `${assets.length} asset${assets.length !== 1 ? 's' : ''}`

--- a/packages/cli/src/formatters/assets.ts
+++ b/packages/cli/src/formatters/assets.ts
@@ -1,0 +1,214 @@
+import chalk from 'chalk'
+import type { AssetManifestEntry } from '../rest/asset-manifests.js'
+import {
+  type ColumnDef,
+  type OutputFormat,
+  escapeMdCell,
+  renderAdaptiveTable,
+  truncateToWidth,
+} from './render.js'
+
+export function assetSelectorValue (asset: AssetManifestEntry): string {
+  return asset.archive?.entryName ?? asset.name
+}
+
+function buildAssetColumns (format: OutputFormat): ColumnDef<AssetManifestEntry>[] {
+  if (format === 'md') {
+    return [
+      { header: 'Type', value: asset => asset.type },
+      { header: 'Name', value: asset => asset.name },
+      { header: 'Asset', value: asset => assetSelectorValue(asset) },
+      { header: 'Content Type', value: asset => asset.contentType ?? '-' },
+    ]
+  }
+
+  return [
+    {
+      header: 'Type',
+      width: 12,
+      value: asset => asset.type,
+    },
+    {
+      header: 'Name',
+      minWidth: 16,
+      maxWidth: 34,
+      value: asset => asset.name,
+    },
+    {
+      header: 'Asset',
+      minWidth: 28,
+      value: asset => assetSelectorValue(asset),
+    },
+    {
+      header: 'Content Type',
+      minWidth: 14,
+      maxWidth: 28,
+      value: asset => {
+        const contentType = asset.contentType ?? '-'
+        return asset.contentType ? contentType : chalk.dim(contentType)
+      },
+    },
+  ]
+}
+
+export function formatAssetManifestEntries (assets: AssetManifestEntry[], format: OutputFormat): string {
+  return renderAdaptiveTable(buildAssetColumns(format), assets, format)
+}
+
+export interface AssetListContext {
+  sourceType: 'check-result' | 'test-session-result'
+  checkId?: string
+  testSessionId?: string
+  resultId: string
+  type?: string
+}
+
+function formatTypeCounts (assets: AssetManifestEntry[]): string {
+  const counts = new Map<string, number>()
+  for (const asset of assets) {
+    counts.set(asset.type, (counts.get(asset.type) ?? 0) + 1)
+  }
+  return [...counts.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([type, count]) => `${type} ${count}`)
+    .join(', ')
+}
+
+export function formatAssetListHeader (
+  context: AssetListContext,
+  assets: AssetManifestEntry[],
+  format: OutputFormat,
+): string {
+  const lines: string[] = []
+  const title = context.sourceType === 'check-result'
+    ? 'Assets for check result'
+    : 'Assets for test-session result'
+
+  lines.push(format === 'md' ? `## ${title}` : chalk.bold(title))
+  if (context.checkId) {
+    lines.push(format === 'md' ? `- Check ID: ${context.checkId}` : `${chalk.dim('Check ID:')} ${context.checkId}`)
+  }
+  if (context.testSessionId) {
+    lines.push(format === 'md'
+      ? `- Test session ID: ${context.testSessionId}`
+      : `${chalk.dim('Test session ID:')} ${context.testSessionId}`)
+  }
+  lines.push(format === 'md' ? `- Result ID: ${context.resultId}` : `${chalk.dim('Result ID:')} ${context.resultId}`)
+  lines.push(format === 'md' ? `- Filter: type=${context.type ?? 'all'}` : `${chalk.dim('Filter:')} type=${context.type ?? 'all'}`)
+
+  const typeCounts = formatTypeCounts(assets)
+  const total = `${assets.length} asset${assets.length !== 1 ? 's' : ''}`
+  lines.push(format === 'md'
+    ? `- Showing: ${typeCounts ? `${total} (${typeCounts})` : total}`
+    : `${chalk.dim('Showing:')} ${typeCounts ? `${total} (${typeCounts})` : total}`)
+
+  return lines.join('\n')
+}
+
+interface AssetTreeNode {
+  children: Map<string, AssetTreeNode>
+  assets: AssetManifestEntry[]
+}
+
+function createTreeNode (): AssetTreeNode {
+  return { children: new Map(), assets: [] }
+}
+
+function assetPathSegments (asset: AssetManifestEntry): string[] {
+  const selector = assetSelectorValue(asset)
+  const segments = selector.split(/[\\/]+/).filter(Boolean)
+  return segments.length > 0 ? segments : [asset.name]
+}
+
+function insertAsset (root: AssetTreeNode, asset: AssetManifestEntry): void {
+  let node = root
+  const segments = assetPathSegments(asset)
+  for (const segment of segments) {
+    let child = node.children.get(segment)
+    if (!child) {
+      child = createTreeNode()
+      node.children.set(segment, child)
+    }
+    node = child
+  }
+  node.assets.push(asset)
+}
+
+function leafLabel (segment: string, assets: AssetManifestEntry[], format: OutputFormat): string {
+  if (assets.length === 0) return `${segment}/`
+
+  const labels = assets
+    .map(asset => {
+      const contentType = asset.contentType ? ` ${asset.contentType}` : ''
+      return `${asset.type}${contentType}`
+    })
+    .join('; ')
+
+  return format === 'md'
+    ? `${segment} (${labels})`
+    : `${segment} ${chalk.dim(`(${labels})`)}`
+}
+
+function renderTreeNode (node: AssetTreeNode, format: OutputFormat, depth = 0): string[] {
+  const lines: string[] = []
+  const entries = [...node.children.entries()].sort(([a], [b]) => a.localeCompare(b))
+
+  for (const [segment, child] of entries) {
+    const indent = '  '.repeat(depth)
+    lines.push(`${indent}${leafLabel(segment, child.assets, format)}`)
+    lines.push(...renderTreeNode(child, format, depth + 1))
+  }
+
+  return lines
+}
+
+export function formatAssetManifestTree (assets: AssetManifestEntry[], format: OutputFormat): string {
+  const root = createTreeNode()
+  for (const asset of assets) {
+    insertAsset(root, asset)
+  }
+
+  const tree = renderTreeNode(root, format)
+  if (format === 'md') {
+    return ['```text', ...tree.map(line => escapeMdCell(line)), '```'].join('\n')
+  }
+  return tree.join('\n')
+}
+
+export interface DownloadedAssetRow {
+  status: 'written' | 'skipped'
+  path: string
+  asset: AssetManifestEntry
+}
+
+function buildDownloadedAssetColumns (): ColumnDef<DownloadedAssetRow>[] {
+  const termWidth = process.stdout.columns || 120
+  const pathWidth = Math.min(58, Math.floor(termWidth * 0.48))
+  const assetWidth = Math.min(42, Math.floor(termWidth * 0.34))
+
+  return [
+    {
+      header: 'Status',
+      width: 10,
+      value: row => row.status === 'written' ? chalk.green('written') : chalk.yellow('skipped'),
+    },
+    {
+      header: 'Path',
+      width: pathWidth,
+      value: row => truncateToWidth(row.path, pathWidth - 2),
+    },
+    {
+      header: 'Type',
+      width: 12,
+      value: row => row.asset.type,
+    },
+    {
+      header: 'Asset',
+      value: row => truncateToWidth(assetSelectorValue(row.asset), assetWidth),
+    },
+  ]
+}
+
+export function formatDownloadedAssets (rows: DownloadedAssetRow[]): string {
+  return renderAdaptiveTable(buildDownloadedAssetColumns(), rows, 'terminal')
+}

--- a/packages/cli/src/helpers/command-style.ts
+++ b/packages/cli/src/helpers/command-style.ts
@@ -29,6 +29,12 @@ export class CommandStyle {
     }
   }
 
+  actionStatus (message: string) {
+    if (this.c.fancy) {
+      ux.action.status = message
+    }
+  }
+
   actionSuccess () {
     if (this.c.fancy) {
       ux.action.stop(`✅`)

--- a/packages/cli/src/helpers/result-assets.ts
+++ b/packages/cli/src/helpers/result-assets.ts
@@ -1,10 +1,12 @@
 import path from 'node:path'
+import axios, { type AxiosRequestConfig, type AxiosResponse } from 'axios'
 import { constants, createWriteStream } from 'node:fs'
 import { access, mkdir, rm } from 'node:fs/promises'
 import { Transform } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
 import { minimatch } from 'minimatch'
 import * as api from '../rest/api.js'
+import { assignProxy } from '../services/proxy.js'
 import type {
   AssetManifest,
   AssetManifestEntry,
@@ -72,8 +74,27 @@ export function filterAssetsByType (
   return assets.filter(asset => asset.type === type)
 }
 
-function hasGlobCharacters (selector: string): boolean {
+export function hasGlobCharacters (selector: string): boolean {
   return /[*?[\]{}]/.test(selector)
+}
+
+export function filterAssetsBySelector (
+  assets: AssetManifestEntry[],
+  selector?: string,
+): AssetManifestEntry[] {
+  if (!selector) return assets
+
+  if (hasGlobCharacters(selector)) {
+    return assets.filter(asset =>
+      minimatch(asset.archive?.entryName ?? '', selector, { dot: true })
+      || minimatch(asset.name, selector, { dot: true }),
+    )
+  }
+
+  return assets.filter(asset =>
+    asset.archive?.entryName === selector
+    || asset.name === selector,
+  )
 }
 
 export function selectAssets (
@@ -85,16 +106,10 @@ export function selectAssets (
   if (!selector) return byType
 
   if (hasGlobCharacters(selector)) {
-    return byType.filter(asset =>
-      minimatch(asset.archive?.entryName ?? '', selector, { dot: true })
-      || minimatch(asset.name, selector, { dot: true }),
-    )
+    return filterAssetsBySelector(byType, selector)
   }
 
-  const exactMatches = byType.filter(asset =>
-    asset.archive?.entryName === selector
-    || asset.name === selector,
-  )
+  const exactMatches = filterAssetsBySelector(byType, selector)
 
   if (exactMatches.length > 1) {
     const values = [...new Set(exactMatches.map(assetSelectorValue))]
@@ -154,6 +169,30 @@ export function isArchiveAsset (asset: AssetManifestEntry): boolean {
     || name.endsWith('.tgz')
 }
 
+export function formatTruncatedManifestMessage (manifest: AssetManifest): string {
+  const returned = manifest.entriesReturned ?? manifest.assets.length
+  const total = manifest.entriesTotal == null ? 'unknown' : String(manifest.entriesTotal)
+  return `Asset manifest is truncated (${returned} of ${total} entries returned).`
+}
+
+export function assertManifestSupportsDownload (
+  manifest: AssetManifest,
+  options: { asset?: string },
+): void {
+  if (!manifest.truncated) return
+
+  const selector = options.asset
+  const isExactCopiedAsset = selector && !hasGlobCharacters(selector)
+    && manifest.assets.some(asset => asset.archive?.entryName === selector)
+
+  if (isExactCopiedAsset) return
+
+  throw new Error(
+    `${formatTruncatedManifestMessage(manifest)} Refusing to download from an incomplete manifest because the selector may miss assets.\n`
+    + 'Use `checkly assets list --view table` and pass an exact Asset value from the list.',
+  )
+}
+
 export interface AssetDownloadProgress {
   downloadedBytes: number
   totalBytes?: number
@@ -203,6 +242,30 @@ function progressTransform (
   })
 }
 
+function shouldUseAuthenticatedApiClient (url: string): boolean {
+  try {
+    const apiBaseUrl = api.api.defaults.baseURL
+    if (!apiBaseUrl) return !URL.canParse(url)
+    const resolvedUrl = new URL(url, apiBaseUrl)
+    const resolvedApiUrl = new URL(apiBaseUrl)
+    return resolvedUrl.origin === resolvedApiUrl.origin
+  } catch {
+    return !URL.canParse(url)
+  }
+}
+
+function fetchAssetStream (assetUrl: string): Promise<AxiosResponse<NodeJS.ReadableStream>> {
+  if (shouldUseAuthenticatedApiClient(assetUrl)) {
+    return api.api.get<NodeJS.ReadableStream>(assetUrl, { responseType: 'stream' })
+  }
+
+  const config = assignProxy(assetUrl, { responseType: 'stream' }) as AxiosRequestConfig
+  return axios.get<NodeJS.ReadableStream>(
+    assetUrl,
+    config,
+  )
+}
+
 export async function downloadAssetToFile (
   asset: AssetManifestEntry,
   filePath: string,
@@ -219,7 +282,7 @@ export async function downloadAssetToFile (
   await mkdir(path.dirname(filePath), { recursive: true })
 
   try {
-    const response = await api.api.get<NodeJS.ReadableStream>(asset.url, { responseType: 'stream' })
+    const response = await fetchAssetStream(asset.url)
     const transform = progressTransform(parseContentLength(response.headers), options.onProgress)
     if (transform) {
       await pipeline(response.data, transform, createWriteStream(filePath))

--- a/packages/cli/src/helpers/result-assets.ts
+++ b/packages/cli/src/helpers/result-assets.ts
@@ -1,7 +1,8 @@
 import path from 'node:path'
 import axios, { type AxiosRequestConfig, type AxiosResponse } from 'axios'
+import { randomUUID } from 'node:crypto'
 import { constants, createWriteStream } from 'node:fs'
-import { access, mkdir, rm } from 'node:fs/promises'
+import { access, mkdir, rename, rm } from 'node:fs/promises'
 import { Transform } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
 import { minimatch } from 'minimatch'
@@ -156,19 +157,6 @@ async function pathExists (filePath: string): Promise<boolean> {
   }
 }
 
-export function isArchiveAsset (asset: AssetManifestEntry): boolean {
-  if (asset.archive?.entryName) return true
-
-  const contentType = asset.contentType?.toLowerCase() ?? ''
-  const name = asset.name.toLowerCase()
-  return contentType.includes('zip')
-    || contentType.includes('tar')
-    || name.endsWith('.zip')
-    || name.endsWith('.tar')
-    || name.endsWith('.tar.gz')
-    || name.endsWith('.tgz')
-}
-
 export function formatTruncatedManifestMessage (manifest: AssetManifest): string {
   const returned = manifest.entriesReturned ?? manifest.assets.length
   const total = manifest.entriesTotal == null ? 'unknown' : String(manifest.entriesTotal)
@@ -183,7 +171,7 @@ export function assertManifestSupportsDownload (
 
   const selector = options.asset
   const isExactCopiedAsset = selector && !hasGlobCharacters(selector)
-    && manifest.assets.some(asset => asset.archive?.entryName === selector)
+    && manifest.assets.some(asset => assetSelectorValue(asset) === selector)
 
   if (isExactCopiedAsset) return
 
@@ -266,6 +254,10 @@ function fetchAssetStream (assetUrl: string): Promise<AxiosResponse<NodeJS.Reada
   )
 }
 
+function temporaryDownloadPath (filePath: string): string {
+  return path.join(path.dirname(filePath), `.${path.basename(filePath)}.${process.pid}.${randomUUID()}.tmp`)
+}
+
 export async function downloadAssetToFile (
   asset: AssetManifestEntry,
   filePath: string,
@@ -280,19 +272,19 @@ export async function downloadAssetToFile (
   }
 
   await mkdir(path.dirname(filePath), { recursive: true })
+  const tempPath = temporaryDownloadPath(filePath)
 
   try {
     const response = await fetchAssetStream(asset.url)
     const transform = progressTransform(parseContentLength(response.headers), options.onProgress)
     if (transform) {
-      await pipeline(response.data, transform, createWriteStream(filePath))
+      await pipeline(response.data, transform, createWriteStream(tempPath))
     } else {
-      await pipeline(response.data, createWriteStream(filePath))
+      await pipeline(response.data, createWriteStream(tempPath))
     }
+    await rename(tempPath, filePath)
   } catch (err) {
-    if (!exists) {
-      await rm(filePath, { force: true })
-    }
+    await rm(tempPath, { force: true })
     throw err
   }
 

--- a/packages/cli/src/helpers/result-assets.ts
+++ b/packages/cli/src/helpers/result-assets.ts
@@ -9,13 +9,13 @@ import { minimatch } from 'minimatch'
 import * as api from '../rest/api.js'
 import { assignProxy } from '../services/proxy.js'
 import type {
+  AssetManifestFilters,
   AssetManifest,
   AssetManifestEntry,
-  AssetManifestEntryType,
 } from '../rest/asset-manifests.js'
 import { assetSelectorValue } from '../formatters/assets.js'
 
-export const assetTypes: Array<AssetManifestEntryType | 'all'> = [
+export const assetTypes = [
   'log',
   'trace',
   'video',
@@ -24,7 +24,25 @@ export const assetTypes: Array<AssetManifestEntryType | 'all'> = [
   'report',
   'file',
   'all',
-]
+] as const
+
+export type AssetTypeSelection = typeof assetTypes[number]
+
+const assetTypeValues: readonly string[] = assetTypes
+
+function isAssetTypeSelection (type: string): type is AssetTypeSelection {
+  return assetTypeValues.includes(type)
+}
+
+export function assetTypeSelectionFromFlag (type?: string): AssetTypeSelection | undefined {
+  if (!type) return
+
+  if (isAssetTypeSelection(type)) {
+    return type
+  }
+
+  throw new Error(`Unsupported asset type "${type}".`)
+}
 
 export interface AssetSourceFlags {
   'check-id'?: string
@@ -59,17 +77,41 @@ export function resolveAssetSource (flags: AssetSourceFlags): AssetSource {
   return { kind: 'test-session-result', testSessionId: flags['test-session-id']!, resultId: flags['result-id'] }
 }
 
-export function fetchAssetManifest (source: AssetSource): Promise<AssetManifest> {
-  if (source.kind === 'check-result') {
-    return api.assetManifests.getForCheckResult(source.checkId, source.resultId)
+export function assetManifestFiltersFromSelection (
+  options: { type?: AssetTypeSelection, asset?: string },
+): AssetManifestFilters | undefined {
+  const filters: AssetManifestFilters = {}
+
+  if (options.type && options.type !== 'all') {
+    filters.type = options.type
   }
 
-  return api.assetManifests.getForTestSessionResult(source.testSessionId, source.resultId)
+  const name = options.asset?.trim()
+  if (name) {
+    filters.name = name
+  }
+
+  return Object.keys(filters).length > 0 ? filters : undefined
+}
+
+export function fetchAssetManifest (
+  source: AssetSource,
+  filters?: AssetManifestFilters,
+): Promise<AssetManifest> {
+  if (source.kind === 'check-result') {
+    return filters
+      ? api.assetManifests.getForCheckResult(source.checkId, source.resultId, filters)
+      : api.assetManifests.getForCheckResult(source.checkId, source.resultId)
+  }
+
+  return filters
+    ? api.assetManifests.getForTestSessionResult(source.testSessionId, source.resultId, filters)
+    : api.assetManifests.getForTestSessionResult(source.testSessionId, source.resultId)
 }
 
 export function filterAssetsByType (
   assets: AssetManifestEntry[],
-  type?: AssetManifestEntryType | 'all',
+  type?: AssetTypeSelection,
 ): AssetManifestEntry[] {
   if (!type || type === 'all') return assets
   return assets.filter(asset => asset.type === type)
@@ -77,6 +119,14 @@ export function filterAssetsByType (
 
 export function hasGlobCharacters (selector: string): boolean {
   return /[*?[\]{}]/.test(selector)
+}
+
+const assetNameGlobOptions = {
+  nocase: true,
+  dot: true,
+  matchBase: true,
+  nobrace: true,
+  noext: true,
 }
 
 export function filterAssetsBySelector (
@@ -87,20 +137,21 @@ export function filterAssetsBySelector (
 
   if (hasGlobCharacters(selector)) {
     return assets.filter(asset =>
-      minimatch(asset.archive?.entryName ?? '', selector, { dot: true })
-      || minimatch(asset.name, selector, { dot: true }),
+      minimatch(asset.archive?.entryName ?? '', selector, assetNameGlobOptions)
+      || minimatch(asset.name, selector, assetNameGlobOptions),
     )
   }
 
+  const normalizedSelector = selector.toLowerCase()
   return assets.filter(asset =>
-    asset.archive?.entryName === selector
-    || asset.name === selector,
+    asset.archive?.entryName.toLowerCase() === normalizedSelector
+    || asset.name.toLowerCase() === normalizedSelector,
   )
 }
 
 export function selectAssets (
   assets: AssetManifestEntry[],
-  options: { type?: AssetManifestEntryType | 'all', asset?: string },
+  options: { type?: AssetTypeSelection, asset?: string },
 ): AssetManifestEntry[] {
   const byType = filterAssetsByType(assets, options.type)
   const selector = options.asset
@@ -165,20 +216,27 @@ export function formatTruncatedManifestMessage (manifest: AssetManifest): string
 
 export function assertManifestSupportsDownload (
   manifest: AssetManifest,
-  options: { asset?: string },
+  filters?: AssetManifestFilters,
 ): void {
   if (!manifest.truncated) return
 
-  const selector = options.asset
-  const isExactCopiedAsset = selector && !hasGlobCharacters(selector)
-    && manifest.assets.some(asset => assetSelectorValue(asset) === selector)
-
-  if (isExactCopiedAsset) return
-
   throw new Error(
-    `${formatTruncatedManifestMessage(manifest)} Refusing to download from an incomplete manifest because the selector may miss assets.\n`
-    + 'Use `checkly assets list --view table` and pass an exact Asset value from the list.',
+    `${formatTruncatedManifestMessage(manifest)} Refusing to download because ${formatFilterScope(filters)}.\n`
+    + 'Use a more specific --type and/or --asset filter, then retry the download.',
   )
+}
+
+function formatFilterScope (filters?: AssetManifestFilters): string {
+  const parts = [
+    filters?.type ? `--type ${filters.type}` : undefined,
+    filters?.name ? `--asset ${filters.name}` : undefined,
+  ].filter(Boolean)
+
+  if (parts.length === 0) {
+    return 'the manifest is incomplete'
+  }
+
+  return `the filtered manifest is still incomplete after applying ${parts.join(' and ')}`
 }
 
 export interface AssetDownloadProgress {

--- a/packages/cli/src/helpers/result-assets.ts
+++ b/packages/cli/src/helpers/result-assets.ts
@@ -1,0 +1,182 @@
+import path from 'node:path'
+import { constants, createWriteStream } from 'node:fs'
+import { access, mkdir, rm } from 'node:fs/promises'
+import { pipeline } from 'node:stream/promises'
+import { minimatch } from 'minimatch'
+import * as api from '../rest/api.js'
+import type {
+  AssetManifest,
+  AssetManifestEntry,
+  AssetManifestEntryType,
+} from '../rest/asset-manifests.js'
+import { assetSelectorValue } from '../formatters/assets.js'
+
+export const assetTypes: Array<AssetManifestEntryType | 'all'> = [
+  'log',
+  'trace',
+  'video',
+  'screenshot',
+  'pcap',
+  'report',
+  'file',
+  'all',
+]
+
+export interface AssetSourceFlags {
+  'check-id'?: string
+  'test-session-id'?: string
+  'result-id'?: string
+}
+
+export type AssetSource =
+  | { kind: 'check-result', checkId: string, resultId: string }
+  | { kind: 'test-session-result', testSessionId: string, resultId: string }
+
+export function resolveAssetSource (flags: AssetSourceFlags): AssetSource {
+  if (!flags['result-id']) {
+    throw new Error('--result-id is required.')
+  }
+
+  const hasCheckId = Boolean(flags['check-id'])
+  const hasTestSessionId = Boolean(flags['test-session-id'])
+
+  if (hasCheckId && hasTestSessionId) {
+    throw new Error('Use exactly one of --check-id or --test-session-id, not both.')
+  }
+
+  if (!hasCheckId && !hasTestSessionId) {
+    throw new Error('Use exactly one of --check-id or --test-session-id.')
+  }
+
+  if (flags['check-id']) {
+    return { kind: 'check-result', checkId: flags['check-id'], resultId: flags['result-id'] }
+  }
+
+  return { kind: 'test-session-result', testSessionId: flags['test-session-id']!, resultId: flags['result-id'] }
+}
+
+export function fetchAssetManifest (source: AssetSource): Promise<AssetManifest> {
+  if (source.kind === 'check-result') {
+    return api.assetManifests.getForCheckResult(source.checkId, source.resultId)
+  }
+
+  return api.assetManifests.getForTestSessionResult(source.testSessionId, source.resultId)
+}
+
+export function filterAssetsByType (
+  assets: AssetManifestEntry[],
+  type?: AssetManifestEntryType | 'all',
+): AssetManifestEntry[] {
+  if (!type || type === 'all') return assets
+  return assets.filter(asset => asset.type === type)
+}
+
+function hasGlobCharacters (selector: string): boolean {
+  return /[*?[\]{}]/.test(selector)
+}
+
+export function selectAssets (
+  assets: AssetManifestEntry[],
+  options: { type?: AssetManifestEntryType | 'all', asset?: string },
+): AssetManifestEntry[] {
+  const byType = filterAssetsByType(assets, options.type)
+  const selector = options.asset
+  if (!selector) return byType
+
+  if (hasGlobCharacters(selector)) {
+    return byType.filter(asset =>
+      minimatch(asset.archive?.entryName ?? '', selector, { dot: true })
+      || minimatch(asset.name, selector, { dot: true }),
+    )
+  }
+
+  const exactMatches = byType.filter(asset =>
+    asset.archive?.entryName === selector
+    || asset.name === selector,
+  )
+
+  if (exactMatches.length > 1) {
+    const values = [...new Set(exactMatches.map(assetSelectorValue))]
+    throw new Error(
+      `--asset "${selector}" matches multiple assets:\n`
+      + values.map(value => `  ${value}`).join('\n')
+      + '\nCopy one Asset value from `checkly assets list` and pass it to --asset.',
+    )
+  }
+
+  return exactMatches
+}
+
+export function defaultDownloadDirectory (source: AssetSource): string {
+  const prefix = source.kind === 'check-result' ? 'check-result' : 'test-session-result'
+  return path.join('.', 'checkly-assets', `${prefix}-${source.resultId}`)
+}
+
+function sanitizePathSegment (segment: string): string {
+  return segment
+    // eslint-disable-next-line no-control-regex
+    .replace(/[<>:"|?*\u0000-\u001F]/g, '_')
+    .replace(/^\.+$/, '_')
+    .trim()
+}
+
+export function destinationPathForAsset (directory: string, asset: AssetManifestEntry): string {
+  const selector = assetSelectorValue(asset)
+  const rawSegments = selector.split(/[\\/]+/)
+  const safeSegments = rawSegments
+    .map(sanitizePathSegment)
+    .filter(segment => segment && segment !== '.' && segment !== '..')
+
+  const relativePath = safeSegments.length > 0 ? path.join(...safeSegments) : 'asset'
+  return path.join(directory, relativePath)
+}
+
+async function pathExists (filePath: string): Promise<boolean> {
+  try {
+    await access(filePath, constants.F_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function isArchiveAsset (asset: AssetManifestEntry): boolean {
+  if (asset.archive?.entryName) return true
+
+  const contentType = asset.contentType?.toLowerCase() ?? ''
+  const name = asset.name.toLowerCase()
+  return contentType.includes('zip')
+    || contentType.includes('tar')
+    || name.endsWith('.zip')
+    || name.endsWith('.tar')
+    || name.endsWith('.tar.gz')
+    || name.endsWith('.tgz')
+}
+
+export async function downloadAssetToFile (
+  asset: AssetManifestEntry,
+  filePath: string,
+  options: { force?: boolean, skipExisting?: boolean },
+): Promise<'written' | 'skipped'> {
+  const exists = await pathExists(filePath)
+  if (exists) {
+    if (options.skipExisting) return 'skipped'
+    if (!options.force) {
+      throw new Error(`Refusing to overwrite existing file: ${filePath}. Use --force or --skip-existing.`)
+    }
+  }
+
+  await mkdir(path.dirname(filePath), { recursive: true })
+
+  try {
+    const response = await api.api.get<NodeJS.ReadableStream>(asset.url, { responseType: 'stream' })
+    await pipeline(response.data, createWriteStream(filePath))
+  } catch (err) {
+    if (!exists) {
+      await rm(filePath, { force: true })
+    }
+    throw err
+  }
+
+  return 'written'
+}

--- a/packages/cli/src/helpers/result-assets.ts
+++ b/packages/cli/src/helpers/result-assets.ts
@@ -1,6 +1,7 @@
 import path from 'node:path'
 import { constants, createWriteStream } from 'node:fs'
 import { access, mkdir, rm } from 'node:fs/promises'
+import { Transform } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
 import { minimatch } from 'minimatch'
 import * as api from '../rest/api.js'
@@ -153,16 +154,65 @@ export function isArchiveAsset (asset: AssetManifestEntry): boolean {
     || name.endsWith('.tgz')
 }
 
+export interface AssetDownloadProgress {
+  downloadedBytes: number
+  totalBytes?: number
+}
+
+export interface AssetDownloadOptions {
+  force?: boolean
+  skipExisting?: boolean
+  onProgress?: (progress: AssetDownloadProgress) => void
+}
+
+function headerValue (headers: unknown, name: string): unknown {
+  if (!headers || typeof headers !== 'object') return
+
+  if ('get' in headers && typeof headers.get === 'function') {
+    return headers.get(name)
+  }
+
+  const record = headers as Record<string, unknown>
+  return record[name] ?? record[name.toLowerCase()]
+}
+
+function parseContentLength (headers: unknown): number | undefined {
+  const value = headerValue(headers, 'content-length')
+  if (Array.isArray(value)) return parseContentLength({ 'content-length': value[0] })
+  if (typeof value !== 'string' && typeof value !== 'number') return
+
+  const parsed = Number(value)
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined
+}
+
+function progressTransform (
+  totalBytes: number | undefined,
+  onProgress: AssetDownloadOptions['onProgress'],
+): Transform | undefined {
+  if (!onProgress) return
+
+  let downloadedBytes = 0
+  return new Transform({
+    transform (chunk, _encoding, callback) {
+      downloadedBytes += Buffer.isBuffer(chunk)
+        ? chunk.length
+        : Buffer.byteLength(chunk)
+      onProgress({ downloadedBytes, totalBytes })
+      callback(null, chunk)
+    },
+  })
+}
+
 export async function downloadAssetToFile (
   asset: AssetManifestEntry,
   filePath: string,
-  options: { force?: boolean, skipExisting?: boolean },
+  options: AssetDownloadOptions,
 ): Promise<'written' | 'skipped'> {
   const exists = await pathExists(filePath)
   if (exists) {
     if (options.skipExisting) return 'skipped'
     if (!options.force) {
-      throw new Error(`Refusing to overwrite existing file: ${filePath}. Use --force or --skip-existing.`)
+      throw new Error(`Refusing to overwrite existing file. Use --force to overwrite or --skip-existing to keep it.\n${filePath}`)
     }
   }
 
@@ -170,7 +220,12 @@ export async function downloadAssetToFile (
 
   try {
     const response = await api.api.get<NodeJS.ReadableStream>(asset.url, { responseType: 'stream' })
-    await pipeline(response.data, createWriteStream(filePath))
+    const transform = progressTransform(parseContentLength(response.headers), options.onProgress)
+    if (transform) {
+      await pipeline(response.data, transform, createWriteStream(filePath))
+    } else {
+      await pipeline(response.data, createWriteStream(filePath))
+    }
   } catch (err) {
     if (!exists) {
       await rm(filePath, { force: true })

--- a/packages/cli/src/helpers/result-assets.ts
+++ b/packages/cli/src/helpers/result-assets.ts
@@ -175,6 +175,78 @@ export function selectAssets (
   return exactMatches
 }
 
+export interface AssetStorageSummary {
+  directAssets: number
+  archiveEntries: number
+  archiveUrls: string[]
+}
+
+export function summarizeAssetStorage (assets: AssetManifestEntry[]): AssetStorageSummary {
+  const archiveUrls = new Set<string>()
+  let archiveEntries = 0
+
+  for (const asset of assets) {
+    if (asset.archive) {
+      archiveEntries += 1
+      archiveUrls.add(asset.url)
+    }
+  }
+
+  return {
+    directAssets: assets.length - archiveEntries,
+    archiveEntries,
+    archiveUrls: [...archiveUrls],
+  }
+}
+
+export function isSingleArchiveBundle (assets: AssetManifestEntry[]): boolean {
+  const summary = summarizeAssetStorage(assets)
+  return summary.archiveEntries > 0 && summary.directAssets === 0 && summary.archiveUrls.length === 1
+}
+
+export function hasArchiveEntries (assets: AssetManifestEntry[]): boolean {
+  return assets.some(asset => asset.archive)
+}
+
+function archiveFileNameFromUrl (url: string): string {
+  try {
+    const parsed = new URL(url, api.api.defaults?.baseURL)
+    const segments = parsed.pathname.split('/').filter(Boolean)
+    const redirectIndex = segments.lastIndexOf('redirect')
+    const keySegment = redirectIndex > 0 ? segments[redirectIndex - 1] : segments.at(-1)
+    if (keySegment) {
+      return path.posix.basename(decodeURIComponent(keySegment)) || 'assets.zip'
+    }
+  } catch {
+    // Fall through to the deterministic default.
+  }
+
+  return 'assets.zip'
+}
+
+export function archiveBundleAssets (assets: AssetManifestEntry[]): AssetManifestEntry[] {
+  const byUrl = new Map<string, AssetManifestEntry[]>()
+
+  for (const asset of assets) {
+    if (!asset.archive) continue
+    byUrl.set(asset.url, [...(byUrl.get(asset.url) ?? []), asset])
+  }
+
+  return [...byUrl.entries()].map(([url, entries], index) => {
+    const first = entries[0]
+    const fileName = archiveFileNameFromUrl(url)
+    const name = byUrl.size === 1 ? fileName : `${index + 1}-${fileName}`
+
+    return {
+      type: 'file',
+      name,
+      url,
+      contentType: 'application/zip',
+      source: first.source,
+    }
+  })
+}
+
 export function defaultDownloadDirectory (source: AssetSource): string {
   const prefix = source.kind === 'check-result' ? 'check-result' : 'test-session-result'
   return path.join('.', 'checkly-assets', `${prefix}-${source.resultId}`)

--- a/packages/cli/src/rest/__tests__/asset-manifests.spec.ts
+++ b/packages/cli/src/rest/__tests__/asset-manifests.spec.ts
@@ -14,6 +14,26 @@ describe('AssetManifests REST client', () => {
     expect(api.get).toHaveBeenCalledWith('/v1/check-results/check-id/result-id/assets')
   })
 
+  it('gets a filtered check result asset manifest', async () => {
+    const api = {
+      get: vi.fn().mockResolvedValue({ data: { assets: [] } }),
+    }
+    const assetManifests = new AssetManifests(api as any)
+
+    const result = await assetManifests.getForCheckResult('check-id', 'result-id', {
+      type: 'trace',
+      name: 'test-results/**/trace.zip',
+    })
+
+    expect(result).toEqual({ assets: [] })
+    expect(api.get).toHaveBeenCalledWith('/v1/check-results/check-id/result-id/assets', {
+      params: {
+        type: 'trace',
+        name: 'test-results/**/trace.zip',
+      },
+    })
+  })
+
   it('gets a test-session result asset manifest', async () => {
     const api = {
       get: vi.fn().mockResolvedValue({ data: { assets: [] } }),
@@ -24,5 +44,25 @@ describe('AssetManifests REST client', () => {
 
     expect(result).toEqual({ assets: [] })
     expect(api.get).toHaveBeenCalledWith('/v1/test-sessions/session-id/results/result-id/assets')
+  })
+
+  it('gets a filtered test-session result asset manifest', async () => {
+    const api = {
+      get: vi.fn().mockResolvedValue({ data: { assets: [] } }),
+    }
+    const assetManifests = new AssetManifests(api as any)
+
+    const result = await assetManifests.getForTestSessionResult('session-id', 'result-id', {
+      type: 'screenshot',
+      name: '*.png',
+    })
+
+    expect(result).toEqual({ assets: [] })
+    expect(api.get).toHaveBeenCalledWith('/v1/test-sessions/session-id/results/result-id/assets', {
+      params: {
+        type: 'screenshot',
+        name: '*.png',
+      },
+    })
   })
 })

--- a/packages/cli/src/rest/__tests__/asset-manifests.spec.ts
+++ b/packages/cli/src/rest/__tests__/asset-manifests.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest'
+import AssetManifests from '../asset-manifests.js'
+
+describe('AssetManifests REST client', () => {
+  it('gets a check result asset manifest', async () => {
+    const api = {
+      get: vi.fn().mockResolvedValue({ data: { assets: [] } }),
+    }
+    const assetManifests = new AssetManifests(api as any)
+
+    const result = await assetManifests.getForCheckResult('check-id', 'result-id')
+
+    expect(result).toEqual({ assets: [] })
+    expect(api.get).toHaveBeenCalledWith('/v1/check-results/check-id/result-id/assets')
+  })
+
+  it('gets a test-session result asset manifest', async () => {
+    const api = {
+      get: vi.fn().mockResolvedValue({ data: { assets: [] } }),
+    }
+    const assetManifests = new AssetManifests(api as any)
+
+    const result = await assetManifests.getForTestSessionResult('session-id', 'result-id')
+
+    expect(result).toEqual({ assets: [] })
+    expect(api.get).toHaveBeenCalledWith('/v1/test-sessions/session-id/results/result-id/assets')
+  })
+})

--- a/packages/cli/src/rest/api.ts
+++ b/packages/cli/src/rest/api.ts
@@ -6,6 +6,7 @@ import Accounts, { Account } from './accounts.js'
 import Users from './users.js'
 import Projects from './projects.js'
 import Assets from './assets.js'
+import AssetManifests from './asset-manifests.js'
 import Runtimes from './runtimes.js'
 import PrivateLocations from './private-locations.js'
 import Locations from './locations.js'
@@ -114,6 +115,7 @@ export const accounts = new Accounts(api)
 export const user = new Users(api)
 export const projects = new Projects(api)
 export const assets = new Assets(api)
+export const assetManifests = new AssetManifests(api)
 export const runtimes = new Runtimes(api)
 export const locations = new Locations(api)
 export const privateLocations = new PrivateLocations(api)

--- a/packages/cli/src/rest/asset-manifests.ts
+++ b/packages/cli/src/rest/asset-manifests.ts
@@ -2,6 +2,11 @@ import type { AxiosInstance } from 'axios'
 
 export type AssetManifestEntryType = 'log' | 'trace' | 'video' | 'screenshot' | 'pcap' | 'report' | 'file'
 
+export interface AssetManifestFilters {
+  type?: AssetManifestEntryType
+  name?: string
+}
+
 export interface AssetManifestArchiveEntry {
   entryName: string
 }
@@ -28,17 +33,36 @@ class AssetManifests {
     this.api = api
   }
 
-  async getForCheckResult (checkId: string, checkResultId: string): Promise<AssetManifest> {
-    const response = await this.api.get<AssetManifest>(`/v1/check-results/${checkId}/${checkResultId}/assets`)
+  async getForCheckResult (
+    checkId: string,
+    checkResultId: string,
+    filters?: AssetManifestFilters,
+  ): Promise<AssetManifest> {
+    const url = `/v1/check-results/${checkId}/${checkResultId}/assets`
+    const config = requestConfig(filters)
+    const response = config
+      ? await this.api.get<AssetManifest>(url, config)
+      : await this.api.get<AssetManifest>(url)
     return response.data
   }
 
-  async getForTestSessionResult (testSessionId: string, testSessionResultId: string): Promise<AssetManifest> {
-    const response = await this.api.get<AssetManifest>(
-      `/v1/test-sessions/${testSessionId}/results/${testSessionResultId}/assets`,
-    )
+  async getForTestSessionResult (
+    testSessionId: string,
+    testSessionResultId: string,
+    filters?: AssetManifestFilters,
+  ): Promise<AssetManifest> {
+    const url = `/v1/test-sessions/${testSessionId}/results/${testSessionResultId}/assets`
+    const config = requestConfig(filters)
+    const response = config
+      ? await this.api.get<AssetManifest>(url, config)
+      : await this.api.get<AssetManifest>(url)
     return response.data
   }
+}
+
+function requestConfig (filters?: AssetManifestFilters) {
+  if (!filters || Object.keys(filters).length === 0) return undefined
+  return { params: filters }
 }
 
 export default AssetManifests

--- a/packages/cli/src/rest/asset-manifests.ts
+++ b/packages/cli/src/rest/asset-manifests.ts
@@ -1,0 +1,44 @@
+import type { AxiosInstance } from 'axios'
+
+export type AssetManifestEntryType = 'log' | 'trace' | 'video' | 'screenshot' | 'pcap' | 'report' | 'file'
+
+export interface AssetManifestArchiveEntry {
+  entryName: string
+}
+
+export interface AssetManifestEntry {
+  type: AssetManifestEntryType
+  name: string
+  url: string
+  contentType?: string
+  source: string
+  archive?: AssetManifestArchiveEntry
+}
+
+export interface AssetManifest {
+  assets: AssetManifestEntry[]
+  truncated?: boolean
+  entriesReturned?: number
+  entriesTotal?: number
+}
+
+class AssetManifests {
+  api: AxiosInstance
+  constructor (api: AxiosInstance) {
+    this.api = api
+  }
+
+  async getForCheckResult (checkId: string, checkResultId: string): Promise<AssetManifest> {
+    const response = await this.api.get<AssetManifest>(`/v1/check-results/${checkId}/${checkResultId}/assets`)
+    return response.data
+  }
+
+  async getForTestSessionResult (testSessionId: string, testSessionResultId: string): Promise<AssetManifest> {
+    const response = await this.api.get<AssetManifest>(
+      `/v1/test-sessions/${testSessionId}/results/${testSessionResultId}/assets`,
+    )
+    return response.data
+  }
+}
+
+export default AssetManifests


### PR DESCRIPTION
## Summary
- Add a new `checkly assets` command group for check-result and test-session result asset manifests
- Support listing and downloading assets with shared source validation and unified REST models
- Improve terminal UX with source recap, adaptive tables, and an optional tree view for nested asset paths

## Demo
https://www.loom.com/share/b63dd3dcb8e446bc96e1637117d6037a

## Testing
- Added unit coverage for REST endpoint selection, list rendering, asset selection, overwrite behavior, and download summaries
- Updated help coverage for the new top-level topic