### PR TITLE
test: remove flaky badssl.com e2e check

### DIFF
--- a/packages/cli/e2e/__tests__/fixtures/test-project/src/services/api/api.check.ts
+++ b/packages/cli/e2e/__tests__/fixtures/test-project/src/services/api/api.check.ts
@@ -21,20 +21,3 @@ const apiCheck = new ApiCheck('homepage-api-check-1', {
     ],
   },
 })
-
-const skipSslApiCheck = new ApiCheck('ssl-api-check-1', {
-  name: 'Skip SSL Check',
-  activated: false,
-  alertChannels: [slackChannel, webhookChannel],
-  degradedResponseTime: 10000,
-  maxResponseTime: 20000,
-  request: {
-    url: 'https://self-signed.badssl.com/',
-    method: 'GET',
-    followRedirects: true,
-    skipSSL: true,
-    assertions: [
-      AssertionBuilder.statusCode().equals(200),
-    ],
-  },
-})

--- a/packages/cli/e2e/__tests__/fixtures/test-project/src/services/api/api.check.ts
+++ b/packages/cli/e2e/__tests__/fixtures/test-project/src/services/api/api.check.ts
@@ -24,6 +24,7 @@ const apiCheck = new ApiCheck('homepage-api-check-1', {
 
 const skipSslApiCheck = new ApiCheck('ssl-api-check-1', {
   name: 'Skip SSL Check',
+  activated: false,
   alertChannels: [slackChannel, webhookChannel],
   degradedResponseTime: 10000,
   maxResponseTime: 20000,

--- a/packages/cli/e2e/__tests__/test.spec.ts
+++ b/packages/cli/e2e/__tests__/test.spec.ts
@@ -51,7 +51,13 @@ describe('test', { timeout: 45000 }, () => {
 
     it('Test project should run successfully', async () => {
       const secretEnv = uuid.v4()
-      const result = await runTest(fixt, ['-e', `SECRET_ENV=${secretEnv}`, '--verbose'])
+      const result = await runTest(fixt, [
+        '-e',
+        `SECRET_ENV=${secretEnv}`,
+        '--verbose',
+        '--grep',
+        '^(?!Skip SSL Check$).*',
+      ])
       expect(result.stdout).not.toContain('File extension type example')
       expect(result.stdout).toContain(secretEnv)
     }, 130_000)
@@ -98,7 +104,9 @@ describe('test', { timeout: 45000 }, () => {
       } catch {
         // No-op
       }
-      const result = await runTest(fixt, ['--record', '--reporter', 'github'], {
+      // Keep this reporter test scoped to one stable check. The GitHub assertions below do not
+      // need the whole fixture project, and unrelated remote checks can make this fail first.
+      const result = await runTest(fixt, ['secret.check.ts', '--record', '--reporter', 'github'], {
         env: {
           CHECKLY_REPORTER_GITHUB_OUTPUT: reportFilename,
         },

--- a/packages/cli/e2e/__tests__/test.spec.ts
+++ b/packages/cli/e2e/__tests__/test.spec.ts
@@ -51,13 +51,7 @@ describe('test', { timeout: 45000 }, () => {
 
     it('Test project should run successfully', async () => {
       const secretEnv = uuid.v4()
-      const result = await runTest(fixt, [
-        '-e',
-        `SECRET_ENV=${secretEnv}`,
-        '--verbose',
-        '--grep',
-        '^(?!Skip SSL Check$).*',
-      ])
+      const result = await runTest(fixt, ['-e', `SECRET_ENV=${secretEnv}`, '--verbose'])
       expect(result.stdout).not.toContain('File extension type example')
       expect(result.stdout).toContain(secretEnv)
     }, 130_000)

--- a/packages/cli/src/constructs/__tests__/api-check.spec.ts
+++ b/packages/cli/src/constructs/__tests__/api-check.spec.ts
@@ -272,6 +272,34 @@ describe('ApiCheck', () => {
     }))
   }, DEFAULT_TEST_TIMEOUT)
 
+  it('should synthesize skipSSL requests', async () => {
+    const output = await parseProject(
+      fixt,
+      '--config',
+      fixt.abspath('test-cases/test-skip-ssl/checkly.config.js'),
+    )
+
+    expect(output).toEqual(expect.objectContaining({
+      diagnostics: expect.objectContaining({
+        fatal: false,
+      }),
+      payload: expect.objectContaining({
+        resources: expect.arrayContaining([
+          expect.objectContaining({
+            logicalId: 'check',
+            type: 'check',
+            member: true,
+            payload: expect.objectContaining({
+              request: expect.objectContaining({
+                skipSSL: true,
+              }),
+            }),
+          }),
+        ]),
+      }),
+    }))
+  }, DEFAULT_TEST_TIMEOUT)
+
   describe('retryStrategy', () => {
     it('should synthesize `onlyOn`', async () => {
       const output = await parseProject(

--- a/packages/cli/src/constructs/__tests__/fixtures/api-check/test-cases/test-skip-ssl/checkly.config.js
+++ b/packages/cli/src/constructs/__tests__/fixtures/api-check/test-cases/test-skip-ssl/checkly.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'checkly'
+
+const config = defineConfig({
+  projectName: 'Check Fixture',
+  logicalId: 'check-fixture',
+  checks: {
+    checkMatch: '**/*.check.js',
+  },
+})
+
+export default config

--- a/packages/cli/src/constructs/__tests__/fixtures/api-check/test-cases/test-skip-ssl/test.check.js
+++ b/packages/cli/src/constructs/__tests__/fixtures/api-check/test-cases/test-skip-ssl/test.check.js
@@ -1,0 +1,11 @@
+import { ApiCheck } from 'checkly/constructs'
+
+new ApiCheck('check', {
+  name: 'Skip SSL Check',
+  request: {
+    method: 'GET',
+    // This fixture is parsed and synthesized only; it must never perform a network request.
+    url: 'https://self-signed.example.test',
+    skipSSL: true,
+  },
+})


### PR DESCRIPTION
## What changed

- Removed the `Skip SSL Check` fixture API check, which depended on `https://self-signed.badssl.com/`.
- Added a parse/synthesize-only ApiCheck fixture and unit test that assert `skipSSL: true` is synthesized correctly, without performing a network request.
- Narrowed the GitHub reporter E2E to `secret.check.ts` so reporter assertions are not coupled to unrelated fixture checks.

## Why

The E2E suite depended on `https://self-signed.badssl.com/`, which resets connections from Checkly cloud runners. That made the broad CLI smoke test and the GitHub reporter test fail for reasons unrelated to the behavior they are intended to cover. `skipSSL` synthesis is now covered locally by a fixture that never reaches the network.

## Validation

- `pnpm exec vitest --run ./src/constructs/__tests__/api-check.spec.ts`
- `pnpm exec eslint e2e/__tests__/test.spec.ts src/constructs/__tests__/api-check.spec.ts`
- Commit hook ran `pnpm run lint` on staged files

I did not run the remote E2E suite locally because this shell does not have `CHECKLY_API_KEY` / `CHECKLY_ACCOUNT_ID` configured.