### PR TITLE
feat(cli): add early diagnostics to Construct [RED-641]

### DIFF
--- a/packages/cli/e2e/__tests__/test.spec.ts
+++ b/packages/cli/e2e/__tests__/test.spec.ts
@@ -174,8 +174,10 @@ describe('test', { timeout: 45000 }, () => {
         await runTest(fixt, [])
       } catch (err) {
         if (err instanceof ExecaError) {
-          expect((err.stderr as unknown as string).replace(/(\n {4})/gm, ''))
-            .toContain('Error: Resource of type \'check-group\' with logical id \'my-check-group\' already exists.')
+          // A duplicate logicalId is now reported as a fatal validation
+          // diagnostic (printed to stdout) rather than a thrown error.
+          expect((err.stdout as unknown as string).replace(/(\n {4})/gm, ''))
+            .toContain('A check-group with logicalId "my-check-group" already exists.')
           expect(err.exitCode).toBe(1)
         } else {
           throw err

--- a/packages/cli/src/constructs/__tests__/alert-channel.spec.ts
+++ b/packages/cli/src/constructs/__tests__/alert-channel.spec.ts
@@ -19,19 +19,24 @@ class TestAlertChannel extends AlertChannel {
 }
 
 describe('AlertChannel', () => {
-  it('should throw if the same logicalId is used twice', () => {
-    Session.project = new Project('project-id', {
+  it('should produce a diagnostic if the same logicalId is used twice', async () => {
+    const project = new Project('project-id', {
       name: 'Test Project',
       repoUrl: 'https://github.com/checkly/checkly-cli',
     })
+    Session.project = project
 
-    const add = () => {
-      new TestAlertChannel('foo', {
-      })
-    }
+    new TestAlertChannel('foo', {})
+    new TestAlertChannel('foo', {})
 
-    expect(add).not.toThrow()
-    expect(add).toThrow('already exists')
+    const diagnostics = new Diagnostics()
+    await project.validate(diagnostics)
+    expect(diagnostics.isFatal()).toBe(true)
+    expect(diagnostics.observations).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        message: expect.stringContaining('already exists'),
+      }),
+    ]))
   })
 
   it('should not throw if the same fromId() is used twice', () => {

--- a/packages/cli/src/constructs/__tests__/check-group.spec.ts
+++ b/packages/cli/src/constructs/__tests__/check-group.spec.ts
@@ -11,20 +11,28 @@ describe('CheckGroup', () => {
       expect(CheckGroupV1).toBe(CheckGroup)
     })
 
-    it('should throw if the same logicalId is used twice', () => {
-      Session.project = new Project('project-id', {
+    it('should produce a diagnostic if the same logicalId is used twice', async () => {
+      const project = new Project('project-id', {
         name: 'Test Project',
         repoUrl: 'https://github.com/checkly/checkly-cli',
       })
+      Session.project = project
 
-      const add = () => {
-        new CheckGroupV1('foo', {
-          name: 'Test',
-        })
-      }
+      new CheckGroupV1('foo', {
+        name: 'Test',
+      })
+      new CheckGroupV1('foo', {
+        name: 'Test',
+      })
 
-      expect(add).not.toThrow()
-      expect(add).toThrow('already exists')
+      const diagnostics = new Diagnostics()
+      await project.validate(diagnostics)
+      expect(diagnostics.isFatal()).toBe(true)
+      expect(diagnostics.observations).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          message: expect.stringContaining('already exists'),
+        }),
+      ]))
     })
 
     it('should not throw if the same fromId() is used twice', () => {
@@ -84,20 +92,28 @@ describe('CheckGroup', () => {
   })
 
   describe('v2', () => {
-    it('should throw if the same logicalId is used twice', () => {
-      Session.project = new Project('project-id', {
+    it('should produce a diagnostic if the same logicalId is used twice', async () => {
+      const project = new Project('project-id', {
         name: 'Test Project',
         repoUrl: 'https://github.com/checkly/checkly-cli',
       })
+      Session.project = project
 
-      const add = () => {
-        new CheckGroupV2('foo', {
-          name: 'Test',
-        })
-      }
+      new CheckGroupV2('foo', {
+        name: 'Test',
+      })
+      new CheckGroupV2('foo', {
+        name: 'Test',
+      })
 
-      expect(add).not.toThrow()
-      expect(add).toThrow('already exists')
+      const diagnostics = new Diagnostics()
+      await project.validate(diagnostics)
+      expect(diagnostics.isFatal()).toBe(true)
+      expect(diagnostics.observations).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          message: expect.stringContaining('already exists'),
+        }),
+      ]))
     })
 
     it('should not throw if the same fromId() is used twice', () => {

--- a/packages/cli/src/constructs/__tests__/early-diagnostics.spec.ts
+++ b/packages/cli/src/constructs/__tests__/early-diagnostics.spec.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+
+import { Session } from '../session.js'
+import { Construct } from '../construct.js'
+import { Diagnostics, ErrorDiagnostic } from '../diagnostics.js'
+import { ConstructDiagnostics } from '../construct-diagnostics.js'
+
+class EarlyConstruct extends Construct {
+  constructor (logicalId: string) {
+    super('test', logicalId)
+    this.earlyDiagnostics.add(new ErrorDiagnostic({
+      title: 'Early problem',
+      message: 'Something the constructor noticed.',
+      error: new Error('Something the constructor noticed.'),
+    }))
+  }
+
+  describe (): string {
+    return `Test:${this.logicalId}`
+  }
+
+  synthesize () {
+    return null
+  }
+}
+
+describe('Construct early diagnostics', () => {
+  beforeEach(() => {
+    Session.reset()
+    Session.project = { addResource: () => {} } as any
+  })
+
+  it('surfaces diagnostics recorded in the constructor via validate()', async () => {
+    const construct = new EarlyConstruct('my-check')
+    const diagnostics = new Diagnostics()
+    await construct.validate(diagnostics)
+    expect(diagnostics.isFatal()).toBe(true)
+    expect(diagnostics.observations).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        message: expect.stringContaining('Something the constructor noticed.'),
+      }),
+    ]))
+  })
+
+  it('attributes early diagnostics to the construct when validated via ConstructDiagnostics', async () => {
+    const construct = new EarlyConstruct('my-check')
+    const diagnostics = new ConstructDiagnostics(construct)
+    await construct.validate(diagnostics)
+    expect(diagnostics.observations).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        title: expect.stringContaining('[Test:my-check]'),
+      }),
+    ]))
+  })
+
+  it('does not record any diagnostics when the constructor adds none', async () => {
+    class QuietConstruct extends Construct {
+      constructor (logicalId: string) {
+        super('test', logicalId)
+      }
+
+      describe (): string {
+        return `Quiet:${this.logicalId}`
+      }
+
+      synthesize () {
+        return null
+      }
+    }
+
+    const construct = new QuietConstruct('my-check')
+    const diagnostics = new Diagnostics()
+    await construct.validate(diagnostics)
+    expect(diagnostics.isFatal()).toBe(false)
+    expect(diagnostics.observations).toHaveLength(0)
+  })
+})

--- a/packages/cli/src/constructs/__tests__/private-location.spec.ts
+++ b/packages/cli/src/constructs/__tests__/private-location.spec.ts
@@ -5,21 +5,30 @@ import { Project } from '../project.js'
 import { Session } from '../session.js'
 
 describe('PrivateLocation', () => {
-  it('should throw if the same logicalId is used twice', () => {
-    Session.project = new Project('project-id', {
+  it('should produce a diagnostic if the same logicalId is used twice', async () => {
+    const project = new Project('project-id', {
       name: 'Test Project',
       repoUrl: 'https://github.com/checkly/checkly-cli',
     })
+    Session.project = project
 
-    const add = () => {
-      new PrivateLocation('foo', {
-        name: 'Test',
-        slugName: 'test',
-      })
-    }
+    new PrivateLocation('foo', {
+      name: 'Test',
+      slugName: 'test',
+    })
+    new PrivateLocation('foo', {
+      name: 'Test',
+      slugName: 'test',
+    })
 
-    expect(add).not.toThrow()
-    expect(add).toThrow('already exists')
+    const diagnostics = new Diagnostics()
+    await project.validate(diagnostics)
+    expect(diagnostics.isFatal()).toBe(true)
+    expect(diagnostics.observations).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        message: expect.stringContaining('already exists'),
+      }),
+    ]))
   })
 
   it('should not throw if the same fromId() is used twice', () => {

--- a/packages/cli/src/constructs/__tests__/project.spec.ts
+++ b/packages/cli/src/constructs/__tests__/project.spec.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 
+import { Project } from '../project.js'
 import { Session } from '../session.js'
 import { Construct } from '../construct.js'
 import { Diagnostics } from '../diagnostics.js'
 
 class TestConstruct extends Construct {
-  constructor (logicalId: string) {
+  constructor (logicalId: any) {
     super('test', logicalId)
   }
 
@@ -71,6 +72,38 @@ describe('Construct logicalId validation', () => {
     expect(diagnostics.observations).toEqual(expect.arrayContaining([
       expect.objectContaining({
         message: expect.stringContaining('contains invalid characters'),
+      }),
+    ]))
+  })
+
+  it('should produce a diagnostic for a non-string logicalId instead of throwing', async () => {
+    const construct = new TestConstruct(123)
+    expect(construct.logicalId).toBe('123')
+    const diagnostics = new Diagnostics()
+    await construct.validate(diagnostics)
+    expect(diagnostics.isFatal()).toBe(true)
+    expect(diagnostics.observations).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        message: expect.stringContaining('Expected a string but received type "number"'),
+      }),
+    ]))
+  })
+
+  it('should produce a diagnostic for a duplicate logicalId instead of throwing', async () => {
+    Session.reset()
+    const project = new Project('test-project', { name: 'Test' })
+    Session.project = project
+
+    project.addResource('check', 'duplicate-id', new TestConstruct('duplicate-id'))
+    project.addResource('check', 'duplicate-id', new TestConstruct('duplicate-id'))
+
+    const diagnostics = new Diagnostics()
+    await project.validate(diagnostics)
+    expect(diagnostics.isFatal()).toBe(true)
+    expect(diagnostics.observations).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        title: expect.stringContaining('[Test:duplicate-id]'),
+        message: expect.stringContaining('A check with logicalId "duplicate-id" already exists'),
       }),
     ]))
   })

--- a/packages/cli/src/constructs/__tests__/status-page-service.spec.ts
+++ b/packages/cli/src/constructs/__tests__/status-page-service.spec.ts
@@ -5,20 +5,28 @@ import { Project } from '../project.js'
 import { Session } from '../session.js'
 
 describe('StatusPageService', () => {
-  it('should throw if the same logicalId is used twice', () => {
-    Session.project = new Project('project-id', {
+  it('should produce a diagnostic if the same logicalId is used twice', async () => {
+    const project = new Project('project-id', {
       name: 'Test Project',
       repoUrl: 'https://github.com/checkly/checkly-cli',
     })
+    Session.project = project
 
-    const add = () => {
-      new StatusPageService('foo', {
-        name: 'foo',
-      })
-    }
+    new StatusPageService('foo', {
+      name: 'foo',
+    })
+    new StatusPageService('foo', {
+      name: 'foo',
+    })
 
-    expect(add).not.toThrow()
-    expect(add).toThrow('already exists')
+    const diagnostics = new Diagnostics()
+    await project.validate(diagnostics)
+    expect(diagnostics.isFatal()).toBe(true)
+    expect(diagnostics.observations).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        message: expect.stringContaining('already exists'),
+      }),
+    ]))
   })
 
   it('should not throw if the same fromId() is used twice', () => {

--- a/packages/cli/src/constructs/construct.ts
+++ b/packages/cli/src/constructs/construct.ts
@@ -57,6 +57,13 @@ export abstract class Construct implements Validate, Bundle {
   member: boolean
   /** Absolute path to the check file that created this construct */
   checkFileAbsolutePath?: string
+  /**
+   * Diagnostics recorded during construction. A constructor cannot perform the
+   * async work that validate() can, so any issue it notices (e.g. an argument
+   * of the wrong type) can be added here and is merged into the caller's
+   * Diagnostics by validate().
+   */
+  readonly earlyDiagnostics = new Diagnostics()
 
   /**
    * Creates a new construct instance.
@@ -128,6 +135,8 @@ export abstract class Construct implements Validate, Bundle {
    */
   // eslint-disable-next-line require-await
   async validate (diagnostics: Diagnostics): Promise<void> {
+    diagnostics.extend(this.earlyDiagnostics)
+
     if (!LOGICAL_ID_PATTERN.test(this.logicalId)) {
       diagnostics.add(new InvalidPropertyValueDiagnostic(
         'logicalId',

--- a/packages/cli/src/constructs/construct.ts
+++ b/packages/cli/src/constructs/construct.ts
@@ -74,6 +74,13 @@ export abstract class Construct implements Validate, Bundle {
    * @param member Whether this construct is a member of the project
    */
   constructor (type: string, logicalId: string, physicalId?: string | number, member?: boolean) {
+    if (typeof logicalId !== 'string') {
+      this.earlyDiagnostics.add(new InvalidPropertyValueDiagnostic(
+        'logicalId',
+        new Error(`Expected a string but received type "${typeof logicalId}".`),
+      ))
+      logicalId = String(logicalId)
+    }
     this.logicalId = logicalId
     this.type = type
     this.physicalId = physicalId

--- a/packages/cli/src/constructs/project.ts
+++ b/packages/cli/src/constructs/project.ts
@@ -9,7 +9,7 @@ import {
   StatusPage, StatusPageService,
 } from './/index.js'
 import { Diagnostics } from './diagnostics.js'
-import { ConstructDiagnostics, InvalidPropertyValueDiagnostic } from './construct-diagnostics.js'
+import { ConstructDiagnostic, ConstructDiagnostics, InvalidPropertyValueDiagnostic } from './construct-diagnostics.js'
 import { ProjectBundle, ProjectDataBundle } from './project-bundle.js'
 import { Bundler } from '../services/check-parser/bundler.js'
 import { Session } from './session.js'
@@ -126,7 +126,19 @@ export class Project extends Construct {
         return
       }
 
-      throw new Error(`Resource of type '${type}' with logical id '${logicalId}' already exists.`)
+      // The duplicate resource is intentionally not stored, so it is never
+      // visited by the validate() fan-out over project data. Record the
+      // diagnostic on the project itself so it surfaces during validation,
+      // wrapping it in a ConstructDiagnostic so the output names the
+      // offending construct.
+      this.earlyDiagnostics.add(new ConstructDiagnostic(
+        resource,
+        new InvalidPropertyValueDiagnostic(
+          'logicalId',
+          new Error(`A ${type} with logicalId "${logicalId}" already exists.`),
+        ),
+      ))
+      return
     }
 
     this.data[type as keyof ProjectData][logicalId] = resource

--- a/packages/cli/src/constructs/session.ts
+++ b/packages/cli/src/constructs/session.ts
@@ -5,7 +5,6 @@ import { CheckConfigDefaults } from '../services/checkly-config-loader.js'
 import { type EngineDetectionResult } from '../services/engine-detector.js'
 import { Parser } from '../services/check-parser/parser.js'
 import { Construct } from './construct.js'
-import { ValidationError } from './validator-error.js'
 import { PrivateLocationApi } from '../rest/private-locations.js'
 import {
   FileLoader,
@@ -158,10 +157,6 @@ export class Session {
   }
 
   static validateCreateConstruct (construct: Construct) {
-    if (typeof construct.logicalId !== 'string') {
-      throw new ValidationError(`The "logicalId" of a ${construct.type} construct must be a string (logicalId=${construct.logicalId} [${typeof construct.logicalId}])`)
-    }
-
     if (construct.type === PROJECT_CONSTRUCT_TYPE) {
       // Creating the construct is allowed - We're creating the project.
     } else if (Session.project) {

--- a/packages/cli/src/constructs/validator-error.ts
+++ b/packages/cli/src/constructs/validator-error.ts
@@ -1,1 +1,0 @@
-export class ValidationError extends Error {}


### PR DESCRIPTION
## Why

Constructs validate via `async validate(diagnostics)`, but they're built through a synchronous constructor that can't do async work and, by convention, never throws for user-facing validation issues. Anything a constructor *notices* at construction time (e.g. an argument of the wrong type) currently has to either throw a hard error or be stashed in a single-purpose instance field solely so `validate()` can re-inspect it later.

This adds a first-class way for a constructor to record diagnostics at construction time, then reimplements the invalid/duplicate `logicalId` validation on top of it.

## What

**Commit 1 — infrastructure.** Adds a `readonly earlyDiagnostics = new Diagnostics()` collector on the base `Construct`. A constructor records issues into it; base `validate()` merges them into the caller's `Diagnostics` via `diagnostics.extend(this.earlyDiagnostics)`. Because every subclass `validate()` starts with `await super.validate(diagnostics)`, and `Project.validate()` already wraps each member in `ConstructDiagnostics`, early diagnostics flow through the existing per-construct collection and reporting path with no changes to subclasses or commands.

**Commit 2 — example.** Turns two construction-time hard errors into soft validation diagnostics using the new mechanism (no holder fields):
- **Non-string `logicalId`** is recorded as a diagnostic in the `Construct` constructor and the value is coerced to a string; the matching throw in `Session.validateCreateConstruct` is removed.
- **Duplicate `logicalId`** is recorded on the `Project` in `addResource` instead of throwing. The duplicate resource is intentionally not stored, so the diagnostic is attached to the project to ensure it surfaces during validation, and is wrapped in a `ConstructDiagnostic` so the reported title names the offending construct (e.g. `[CheckGroup:my-check-group]`).
- Removes the now-unused `ValidationError` class.

These now surface as fatal validation diagnostics (non-zero exit) under `checkly validate` / `checkly deploy` / `checkly test` rather than aborting with an unhandled exception.

## Tests

- New `early-diagnostics.spec.ts` covers the plain path, the `ConstructDiagnostics` attribution-prefix path, and the empty case.
- `project.spec.ts` gains non-string and duplicate `logicalId` cases; the duplicate case asserts the construct-attributed title prefix.
- The throw-based unit tests (alert-channel, check-group v1+v2, private-location, status-page-service) are converted to assert diagnostics.
- The duplicate-`logicalId` e2e test now asserts the soft diagnostic on stdout with exit 1.

`tsc --build` clean; full constructs unit suite green.

Resolves RED-641.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Example

Given the following constructs:

```typescript
new ApiCheck('api-example-1', {
  name: 'API Check Example #1',
  request: {
    url: 'https://welcome.checklyhq.com',
    method: 'GET',
  },
})

new ApiCheck('api-example-1', {
  name: 'API Check Example #1',
  request: {
    url: 'https://welcome.checklyhq.com',
    method: 'GET',
  },
})

new ApiCheck(undefined, {
  name: 'API Check Example #1',
  request: {
    url: 'https://welcome.checklyhq.com',
    method: 'GET',
  },
})
```

The following output is returned:

```
➜ pnpm checkly validate
Parsing your project... ✅

✖ [ApiCheck:api-example-1] Invalid property value

  The value provided for property "logicalId" is not valid.

  Reason: A check with logicalId "api-example-1" already exists.

✖ [ApiCheck:undefined] Invalid property value

  The value provided for property "logicalId" is not valid.

  Reason: Expected a string but received type "undefined".

Validating project resources... ❌

✖ Your project is not valid.
```

And here's what it used to look like:

```
➜ pnpm checkly validate
Parsing your project... !
    Error: Error loading file '/private/var/folders/r_/l7c0j9wd7ngg5hhgthl52j9w0000gn/T/tmp.jE0hmom8nq/__checks__/api.check.ts'
    Error: Resource of type 'check' with logical id 'api-example-1' already exists.
        at Project.addResource (file:///redacted/packages/cli/dist/constructs/project.js:74:19)
        at Session.registerConstruct (file:///redacted/packages/cli/dist/constructs/session.js:99:29)
        at new ApiCheck (file:///redacted/packages/cli/dist/constructs/api-check.js:91:17)
        at /private/var/folders/r_/l7c0j9wd7ngg5hhgthl52j9w0000gn/T/tmp.jE0hmom8nq/__checks__/api.check.ts:11:1
        at async Function.import (/redacted/node_modules/.pnpm/jiti@2.7.0/node_modules/jiti/dist/jiti.cjs:1:187718)
        at async InitializedJitiFileLoaderState.loadFile (file:///redacted/packages/cli/dist/loader/jiti.js:53:35)
        at async JitiFileLoader.loadFile (file:///redacted/packages/cli/dist/loader/jiti.js:73:16)
        at async MixedFileLoader.loadFile (file:///redacted/packages/cli/dist/loader/mixed.js:20:28)
        at async Session.loadFile (file:///redacted/packages/cli/dist/constructs/session.js:72:35)
        at async loadAllCheckFiles (file:///redacted/packages/cli/dist/services/project-parser.js:161:13)
        at async parseProject (file:///redacted/packages/cli/dist/services/project-parser.js:96:9)
        at async Validate.run (file:///redacted/packages/cli/dist/commands/validate.js:35:25)
        at async Validate._run (/redacted/node_modules/.pnpm/@oclif+core@4.11.4/node_modules/@oclif/core/lib/command.js:183:22)
        at async Config.runCommand
    (/redacted/node_modules/.pnpm/@oclif+core@4.11.4/node_modules/@oclif/core/lib/config/config.js:445:25)
        at async run (/redacted/node_modules/.pnpm/@oclif+core@4.11.4/node_modules/@oclif/core/lib/main.js:97:16)
        at async file:///redacted/packages/cli/bin/run:8:1
```
