### PR TITLE
test(e2e): fix slow Windows e2e (oclif PowerShell spawn) and add per-OS CI gates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,13 +33,13 @@ jobs:
       # Test that the packaging works as well
       - run: pnpm -r pack
       - run: pnpm run lint
-  test:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest-x64]
-    name: test - ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+
+  # ---------------------------------------------------------------------------
+  # Unit tests
+  # ---------------------------------------------------------------------------
+  test-ubuntu:
+    name: test - ubuntu
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v5
@@ -55,20 +55,41 @@ jobs:
       - name: Save LLM rules as an artifact
         uses: actions/upload-artifact@v4
         with:
-          name: llm-rules-test-${{ matrix.os }}
+          name: llm-rules-test-ubuntu
           if-no-files-found: error
           path: packages/cli/dist/ai-context/*
           retention-days: 1
-  test-e2e-checkly:
-    # Only on PRs — these hit the live Checkly API. The push-to-main run exists
-    # solely to seed the dependency cache, which lint + test already cover.
+  test-windows:
+    name: test - windows
+    runs-on: blacksmith-4vcpu-windows-2025
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v5
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run prepack
+      - run: pnpm run test
+      - name: Save LLM rules as an artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: llm-rules-test-windows
+          if-no-files-found: error
+          path: packages/cli/dist/ai-context/*
+          retention-days: 1
+
+  # ---------------------------------------------------------------------------
+  # checkly e2e — hits the live Checkly API (PRs only). Windows is sharded
+  # because it is the slow leg; Ubuntu runs the whole suite in one job.
+  # ---------------------------------------------------------------------------
+  test-e2e-checkly-ubuntu:
+    name: e2e - checkly - ubuntu
     if: github.event_name == 'pull_request'
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest-x64]
-    name: e2e - checkly - ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v5
@@ -87,15 +108,40 @@ jobs:
           CHECKLY_API_KEY: ${{ secrets.E2E_CHECKLY_API_KEY }}
           CHECKLY_EMPTY_ACCOUNT_ID: ${{ secrets.E2E_EMPTY_CHECKLY_ACCOUNT_ID }}
           CHECKLY_EMPTY_API_KEY: ${{ secrets.E2E_EMPTY_CHECKLY_API_KEY }}
-  test-e2e-create-checkly:
-    # Only on PRs — see test-e2e-checkly above.
+  test-e2e-checkly-windows:
+    name: e2e - checkly - windows (${{ matrix.shard }})
     if: github.event_name == 'pull_request'
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest-x64]
-    name: e2e - create-checkly - ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+        shard: ['1/4', '2/4', '3/4', '4/4']
+    runs-on: blacksmith-4vcpu-windows-2025
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v5
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run prepack
+      - run: pnpm --filter checkly run test:e2e -- --shard=${{ matrix.shard }}
+        env:
+          CHECKLY_ACCOUNT_NAME: ${{ secrets.E2E_CHECKLY_ACCOUNT_NAME }}
+          CHECKLY_ACCOUNT_ID: ${{ secrets.E2E_CHECKLY_ACCOUNT_ID }}
+          CHECKLY_API_KEY: ${{ secrets.E2E_CHECKLY_API_KEY }}
+          CHECKLY_EMPTY_ACCOUNT_ID: ${{ secrets.E2E_EMPTY_CHECKLY_ACCOUNT_ID }}
+          CHECKLY_EMPTY_API_KEY: ${{ secrets.E2E_EMPTY_CHECKLY_API_KEY }}
+
+  # ---------------------------------------------------------------------------
+  # create-checkly e2e (PRs only)
+  # ---------------------------------------------------------------------------
+  test-e2e-create-checkly-ubuntu:
+    name: e2e - create-checkly - ubuntu
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v5
@@ -107,3 +153,62 @@ jobs:
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter create-checkly run test:e2e
+  test-e2e-create-checkly-windows:
+    name: e2e - create-checkly - windows
+    if: github.event_name == 'pull_request'
+    runs-on: blacksmith-4vcpu-windows-2025
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v5
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter create-checkly run test:e2e
+
+  # ---------------------------------------------------------------------------
+  # Gates — one aggregate status check per OS. These are the jobs to require in
+  # branch protection: a single check for Windows (which fans out into 4 e2e
+  # shards) and a single check for Ubuntu, so Windows can be made non-required
+  # independently of Ubuntu without touching individual job names.
+  # ---------------------------------------------------------------------------
+  gate-ubuntu:
+    name: CI gate - ubuntu
+    if: always()
+    needs:
+      - lint
+      - test-ubuntu
+      - test-e2e-checkly-ubuntu
+      - test-e2e-create-checkly-ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all Ubuntu jobs succeeded
+        run: |
+          results="${{ join(needs.*.result, ', ') }}"
+          echo "Ubuntu job results: $results"
+          # 'skipped' is allowed (e2e jobs are skipped on push-to-main); only
+          # 'failure'/'cancelled' should fail the gate.
+          if [[ "$results" == *failure* || "$results" == *cancelled* ]]; then
+            echo "::error::One or more Ubuntu jobs did not succeed"
+            exit 1
+          fi
+  gate-windows:
+    name: CI gate - windows
+    if: always()
+    needs:
+      - test-windows
+      - test-e2e-checkly-windows
+      - test-e2e-create-checkly-windows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all Windows jobs succeeded
+        run: |
+          results="${{ join(needs.*.result, ', ') }}"
+          echo "Windows job results: $results"
+          if [[ "$results" == *failure* || "$results" == *cancelled* ]]; then
+            echo "::error::One or more Windows jobs did not succeed"
+            exit 1
+          fi

--- a/packages/cli/e2e/run-checkly.ts
+++ b/packages/cli/e2e/run-checkly.ts
@@ -29,6 +29,12 @@ export function checklyEnv (overrides?: {
     CHECKLY_CLI_VERSION: cliVersion,
     CHECKLY_E2E_PROMPTS_INJECTIONS: promptsInjection?.length ? JSON.stringify(promptsInjection) : undefined,
     CHECKLY_E2E_DISABLE_FANCY_OUTPUT: '1',
+    // Set SHELL so @oclif/core's getShell() short-circuits instead of running
+    // determineWindowsShell(), which spawns `powershell.exe -Command Get-CimInstance`
+    // on every command. That spawn costs seconds per command on Windows and is the
+    // dominant cost of the Windows e2e suite. On Linux SHELL is already set, so this
+    // only changes behaviour on Windows where it would otherwise be unset.
+    SHELL: process.env.SHELL ?? 'powershell.exe',
     ...env,
   }
 }


### PR DESCRIPTION
## Context

The Windows `e2e - checkly` job had become excruciatingly slow and timed out (~600s, ~80 failures) while Ubuntu passed in ~170s. Diagnosed empirically: move Windows to `blacksmith-4vcpu-windows-2025` → observe CI → CPU-profile the slow commands → fix.

Linear: RED-645

## Root cause

`@oclif/core` resolves the shell during `Config.load()` — on **every command** — via `getShell()`. In **4.11.5** that gained `determineWindowsShell()` (upstream [oclif/core#1614](https://github.com/oclif/core/pull/1614) "windows shell identification is more reliable", merged/published 2026-06-15), which on Windows runs:

```
execSync(`powershell.exe -NoProfile -Command "(Get-CimInstance Win32_Process -Filter 'ProcessID = <ppid>').Name"`)
```

Spawning PowerShell + a WMI query (plus Defender scanning `powershell.exe` and its assemblies) costs ~2.6s **per command** under suite load — CPU profiling showed this `spawn` dominating every slow command. Linux never takes this path (`$SHELL` / `userInfo().shell`), so Ubuntu was unaffected — exactly the OS split we saw.

**Why it started with no CLI change:** the CLI declares `@oclif/core: ^4.11.4` (unpinned). Its own lockfile pins 4.11.4, but the e2e `FixtureTemplate` installs the packed CLI with a lockfile-less `pnpm install`, so it resolves `^4.11.4` to the latest 4.11.x. When 4.11.5 published on 2026-06-15, the Windows e2e silently picked it up and every command began paying the spawn.

## Fix

Set `SHELL` in the e2e harness (`run-checkly.ts`). `getShell()` short-circuits when `SHELL` is set, skipping `determineWindowsShell()` entirely. On Linux `SHELL` is already set so behaviour is unchanged; on Windows it supplies a value so the spawn never runs.

Chose this over pinning `@oclif/core` to avoid the daily npm-audit churn of pinning a transitive dependency.

**Impact:** CI Windows e2e timeouts **268 → 0**; the `account-plan` spec went **80s → 43s** in an A/B on the runner.

## CI restructure

- Windows legs moved to `blacksmith-4vcpu-windows-2025`.
- The three mixed-OS matrix jobs are split into per-OS jobs; Windows `e2e - checkly` is **sharded into 4** (the slow leg), Ubuntu runs the suite in one job.
- Added aggregate gate jobs **`CI gate - ubuntu`** and **`CI gate - windows`** — a single status check per OS, so the 4 Windows shards gate as one and Ubuntu can be made the only required check later. `skipped` passes, so push-to-main stays green.

⚠️ **Branch protection:** the old per-job check names no longer exist. Require **`CI gate - ubuntu`** and **`CI gate - windows`** instead.

## Out of scope / follow-up

- **Real Windows users** who resolve `@oclif/core` ≥ 4.11.5 pay the same ~2.6s/command. The harness `SHELL` fix is e2e-only; a CLI-side guard, or an upstream fix to [oclif/core#1614](https://github.com/oclif/core/pull/1614) (cache the result / avoid the per-command `Get-CimInstance` spawn), is the durable user-facing fix.
- **API rate-limiting (429):** with the suite now fast and Windows sharded into 4 concurrent jobs, the e2e brushes the E2E account's 600 req/min limit. Separate fix — enable `DISABLE_RATE_LIMITING` on the E2E account and/or add 429 retry-with-backoff to the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)