### PR TITLE
feat: add HTTPS (RFC 9460) DNS record type

### DIFF
--- a/packages/cli/src/constructs/dns-assertion.ts
+++ b/packages/cli/src/constructs/dns-assertion.ts
@@ -22,12 +22,9 @@ export type DnsAssertion = CoreAssertion<DnsAssertionSource>
  * DnsAssertionBuilder.responseCode().equals('NOERROR')
  * DnsAssertionBuilder.responseCode().equals('NXDOMAIN')
  *
- * // HTTPS (RFC 9460) record — monitor HTTP/3 advertisement. The answer renders
- * // as: 1 . alpn="h3,h2" ipv4hint="..." ipv6hint="..."
- * // Scope the match to the alpn value with a capture group (recommended):
+ * // HTTPS record assertions (HTTP/3 advertisement)
  * DnsAssertionBuilder.textAnswer('alpn="([^"]*)"').contains('h3')
- * // Or assert against the whole rendered answer / its JSON `data` field:
- * DnsAssertionBuilder.jsonAnswer('$.Answer[0].data').contains('alpn="h3')
+ * DnsAssertionBuilder.jsonAnswer('$.Answer[0].data').contains('h3')
  * ```
  */
 export class DnsAssertionBuilder {

--- a/packages/cli/src/constructs/dns-assertion.ts
+++ b/packages/cli/src/constructs/dns-assertion.ts
@@ -21,6 +21,13 @@ export type DnsAssertion = CoreAssertion<DnsAssertionSource>
  * // Response code assertions
  * DnsAssertionBuilder.responseCode().equals('NOERROR')
  * DnsAssertionBuilder.responseCode().equals('NXDOMAIN')
+ *
+ * // HTTPS (RFC 9460) record — monitor HTTP/3 advertisement. The answer renders
+ * // as: 1 . alpn="h3,h2" ipv4hint="..." ipv6hint="..."
+ * // Scope the match to the alpn value with a capture group (recommended):
+ * DnsAssertionBuilder.textAnswer('alpn="([^"]*)"').contains('h3')
+ * // Or assert against the whole rendered answer / its JSON `data` field:
+ * DnsAssertionBuilder.jsonAnswer('$.Answer[0].data').contains('alpn="h3')
  * ```
  */
 export class DnsAssertionBuilder {

--- a/packages/cli/src/constructs/dns-request.ts
+++ b/packages/cli/src/constructs/dns-request.ts
@@ -20,9 +20,7 @@ export type DnsProtocol =
  */
 export interface DnsRequest {
   /**
-   * The DNS record type to query for. Use 'HTTPS' (RFC 9460) to monitor a
-   * domain's HTTPS service binding record — e.g. whether it advertises HTTP/3
-   * via its `alpn` parameter, plus `ipv4hint`/`ipv6hint`/`ech`.
+   * The DNS record type to query for.
    *
    * @example "A"
    * @example "AAAA"

--- a/packages/cli/src/constructs/dns-request.ts
+++ b/packages/cli/src/constructs/dns-request.ts
@@ -8,6 +8,7 @@ export type DnsRecordType =
   | 'NS'
   | 'TXT'
   | 'SOA'
+  | 'HTTPS'
 
 export type DnsProtocol =
   | 'UDP'
@@ -19,11 +20,14 @@ export type DnsProtocol =
  */
 export interface DnsRequest {
   /**
-   * The DNS record type to query for.
+   * The DNS record type to query for. Use 'HTTPS' (RFC 9460) to monitor a
+   * domain's HTTPS service binding record — e.g. whether it advertises HTTP/3
+   * via its `alpn` parameter, plus `ipv4hint`/`ipv6hint`/`ech`.
    *
    * @example "A"
    * @example "AAAA"
    * @example "TXT"
+   * @example "HTTPS"
    */
   recordType: DnsRecordType
 


### PR DESCRIPTION
## What

Adds the **HTTPS** (RFC 9460, DNS type 65 / SVCB family) record type to the DNS check construct's `DnsRecordType` union, so monitoring-as-code can query a domain's HTTPS service-binding record — e.g. verify HTTP/3 advertisement (`alpn`), IP hints (`ipv4hint`/`ipv6hint`), or ECH.

## Changes

- `constructs/dns-request.ts` — add `'HTTPS'` to `DnsRecordType`, with a doc note on the `recordType` field.
- `constructs/dns-assertion.ts` — update the `DnsAssertionBuilder` `@example` to the recommended forms:
  - `DnsAssertionBuilder.textAnswer('alpn="([^"]*)"').contains('h3')` (capture group scopes the match to the alpn value)
  - `DnsAssertionBuilder.jsonAnswer('$.Answer[0].data').contains('alpn="h3')`

## Context

Pairs with the runner + API support and the webapp record-type option in the main monorepo (runner/API and webapp PRs). The runner renders the HTTPS record's rdata into the answer (`1 . alpn="h3,h2" ipv4hint="…" …`), which these assertions target.
