### PR TITLE
feat(cli): surface env-var credentials in logout and whoami

### DIFF
--- a/packages/cli/e2e/__tests__/logout.spec.ts
+++ b/packages/cli/e2e/__tests__/logout.spec.ts
@@ -24,6 +24,5 @@ describe('logout', () => {
     // The e2e env has CHECKLY_API_KEY/CHECKLY_ACCOUNT_ID set, so clearing the
     // local session does not actually log us out — logout warns about that.
     expect(stderr).toContain('are configured (via shell or .env file)')
-    expect(stderr).toContain('authenticated')
   })
 })

--- a/packages/cli/e2e/__tests__/logout.spec.ts
+++ b/packages/cli/e2e/__tests__/logout.spec.ts
@@ -21,8 +21,7 @@ describe('logout', () => {
     })
 
     expect(stdout).toContain('See you soon! 👋')
-    // The e2e env has CHECKLY_API_KEY/CHECKLY_ACCOUNT_ID set, so clearing the
-    // local session does not actually log us out — logout warns about that.
+    // env credentials are set, so logout warns the session clear didn't log us out
     expect(stderr).toContain('are configured (via shell or .env file)')
   })
 })

--- a/packages/cli/e2e/__tests__/logout.spec.ts
+++ b/packages/cli/e2e/__tests__/logout.spec.ts
@@ -21,6 +21,9 @@ describe('logout', () => {
     })
 
     expect(stdout).toContain('See you soon! 👋')
-    expect(stderr).toBe('')
+    // The e2e env has CHECKLY_API_KEY/CHECKLY_ACCOUNT_ID set, so clearing the
+    // local session does not actually log us out — logout warns about that.
+    expect(stderr).toContain('are configured (via shell or .env file)')
+    expect(stderr).toContain('still authenticated through them')
   })
 })

--- a/packages/cli/e2e/__tests__/logout.spec.ts
+++ b/packages/cli/e2e/__tests__/logout.spec.ts
@@ -23,7 +23,10 @@ describe('logout', () => {
     expect(stdout).toContain('See you soon! 👋')
     // The e2e env has CHECKLY_API_KEY/CHECKLY_ACCOUNT_ID set, so clearing the
     // local session does not actually log us out — logout warns about that.
-    expect(stderr).toContain('are configured (via shell or .env file)')
-    expect(stderr).toContain('still authenticated through them')
+    // oclif wraps the warning and prefixes continuation lines with ` › `, so
+    // strip those markers and collapse whitespace before matching.
+    const warning = stderr.replace(/›/g, '').replace(/\s+/g, ' ')
+    expect(warning).toContain('are configured (via shell or .env file)')
+    expect(warning).toContain('still authenticated through them')
   })
 })

--- a/packages/cli/e2e/__tests__/logout.spec.ts
+++ b/packages/cli/e2e/__tests__/logout.spec.ts
@@ -23,10 +23,7 @@ describe('logout', () => {
     expect(stdout).toContain('See you soon! 👋')
     // The e2e env has CHECKLY_API_KEY/CHECKLY_ACCOUNT_ID set, so clearing the
     // local session does not actually log us out — logout warns about that.
-    // oclif wraps the warning and prefixes continuation lines with ` › `, so
-    // strip those markers and collapse whitespace before matching.
-    const warning = stderr.replace(/›/g, '').replace(/\s+/g, ' ')
-    expect(warning).toContain('are configured (via shell or .env file)')
-    expect(warning).toContain('still authenticated through them')
+    expect(stderr).toContain('are configured (via shell or .env file)')
+    expect(stderr).toContain('authenticated')
   })
 })

--- a/packages/cli/e2e/__tests__/whoami.spec.ts
+++ b/packages/cli/e2e/__tests__/whoami.spec.ts
@@ -19,8 +19,7 @@ describe('whomai', () => {
     const { stdout } = await runCheckly(fixt, ['whoami'])
     expect(stdout).toContain(config.get('accountName'))
     expect(stdout).toContain('Plan:')
-    // The e2e env authenticates via CHECKLY_API_KEY/CHECKLY_ACCOUNT_ID, so
-    // whoami notes that the account comes from the environment.
+    // env credentials are set, so whoami notes the account comes from the environment
     expect(stdout).toContain('resolved from your environment')
   })
 })

--- a/packages/cli/e2e/__tests__/whoami.spec.ts
+++ b/packages/cli/e2e/__tests__/whoami.spec.ts
@@ -19,5 +19,8 @@ describe('whomai', () => {
     const { stdout } = await runCheckly(fixt, ['whoami'])
     expect(stdout).toContain(config.get('accountName'))
     expect(stdout).toContain('Plan:')
+    // The e2e env authenticates via CHECKLY_API_KEY/CHECKLY_ACCOUNT_ID, so
+    // whoami notes that the account comes from the environment.
+    expect(stdout).toContain('resolved from your environment')
   })
 })

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -6,6 +6,7 @@ import config from '../services/config.js'
 import * as api from '../rest/api.js'
 import type { Account } from '../rest/accounts.js'
 import { AuthContext } from '../auth/index.js'
+import commonMessages from '../messages/common-messages.js'
 
 export const selectAccount = async (
   accounts: Array<Account>, { onCancel }: { onCancel: () => void }): Promise<Account> => {
@@ -30,8 +31,7 @@ export default class Login extends BaseCommand {
 
   private _checkExistingCredentials = async () => {
     if (config.hasEnvVarsConfigured()) {
-      this.warn('`CHECKLY_API_KEY` '
-        + 'or `CHECKLY_ACCOUNT_ID` environment variables are configured (via shell or .env file). You must delete them to use `npx checkly login`.')
+      this.warn(`${commonMessages.envCredentialsConfigured} You must delete them to use \`npx checkly login\`.`)
       this.exit(0)
     }
 

--- a/packages/cli/src/commands/logout.ts
+++ b/packages/cli/src/commands/logout.ts
@@ -39,5 +39,9 @@ export default class Logout extends BaseCommand {
 
     config.clear()
     this.log('See you soon! 👋')
+
+    if (config.hasEnvVarsConfigured()) {
+      this.warn(`${commonMessages.envCredentialsConfigured} You are still authenticated through them until you remove them.`)
+    }
   }
 }

--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -1,4 +1,6 @@
 import * as api from '../rest/api.js'
+import config from '../services/config.js'
+import commonMessages from '../messages/common-messages.js'
 import { AuthCommand } from './authCommand.js'
 
 export default class Whoami extends AuthCommand {
@@ -17,6 +19,10 @@ export default class Whoami extends AuthCommand {
     const addonNames = Object.values(addons).map(a => a.tierDisplayName)
     if (addonNames.length > 0) {
       this.log(`Add-ons: ${addonNames.join(', ')}`)
+    }
+    if (config.hasEnvVarsConfigured()) {
+      this.log()
+      this.log(`This account is resolved from your environment, not a \`checkly login\` session. ${commonMessages.envCredentialsConfigured}`)
     }
   }
 }

--- a/packages/cli/src/messages/common-messages.ts
+++ b/packages/cli/src/messages/common-messages.ts
@@ -2,6 +2,8 @@ const commonMessages = {
   forceMode: 'Force mode. Skips the confirmation dialog.',
   configFile: 'The Checkly CLI configuration file. If not passed, uses the checkly.config.ts|js file in the current'
     + ' directory.',
+  envCredentialsConfigured: '`CHECKLY_API_KEY` or `CHECKLY_ACCOUNT_ID` environment variables are configured'
+    + ' (via shell or .env file).',
 }
 
 export default commonMessages


### PR DESCRIPTION
## Affected Components
* [x] CLI

## Notes for the Reviewer

### Problem

Credentials are resolved from two sources, with env vars winning over the persisted login session (`config.ts`):

```ts
getApiKey ()    { return process.env.CHECKLY_API_KEY    || this.auth.get('apiKey') || '' }
getAccountId () { return process.env.CHECKLY_ACCOUNT_ID || this.data.get('accountId') || '' }
```

`logout` only clears the persisted session (`config.clear()`) — it can't touch your shell or `.env`. So when `CHECKLY_API_KEY`/`CHECKLY_ACCOUNT_ID` are set, `logout` cheerfully says goodbye while you stay fully authenticated, and `whoami` keeps reporting a logged-in account afterward with no explanation. Because `.env` is loaded from the current working directory, the *same* `whoami` can even resolve a different account depending on which directory you run it in.

### Why this shape

**`login` already handles this** — it warns and exits when those env vars are set, because they override any login session:

```
Warning: `CHECKLY_API_KEY` or `CHECKLY_ACCOUNT_ID` environment variables are configured
(via shell or .env file). You must delete them to use `npx checkly login`.
```

So the precedent and the wording already exist in one command. This PR simply extends that same transparency to the other two auth commands rather than inventing anything new. The shared sentence is extracted into `common-messages.ts` so all three stay in sync; `login`'s output is unchanged.

### Behavior (with env-var credentials set)

**`whoami`** — appends a note on stdout:

```
You are currently on account "Monitoring as Code" (b2f06fc6-…) as stefan@checklyhq.com.
Plan: Enterprise
Add-ons: Resolve Hobby, Communicate Hobby

This account is resolved from your environment, not a `checkly login` session. `CHECKLY_API_KEY` or `CHECKLY_ACCOUNT_ID` environment variables are configured (via shell or .env file).
```

**`logout`** — still clears the local session, then warns on stderr that you're not actually logged out:

```
See you soon! 👋
 ›   Warning: `CHECKLY_API_KEY` or `CHECKLY_ACCOUNT_ID` environment variables
 ›   are configured (via shell or .env file). You are still authenticated
 ›   through them until you remove them.
```

**`login`** — unchanged, now sourced from the shared message:

```
 ›   Warning: `CHECKLY_API_KEY` or `CHECKLY_ACCOUNT_ID` environment variables
 ›   are configured (via shell or .env file). You must delete them to use `npx
 ›   checkly login`.
```

### Testing

- `lint` and `tsc --noEmit` pass.
- Updated the `logout` e2e (it asserted `stderr === ''`, the old silent behavior) and the `whoami` e2e to assert the new note. The e2e env already authenticates via `CHECKLY_API_KEY`/`CHECKLY_ACCOUNT_ID`, so both paths exercise the env-var branch.
- Manually verified all three commands against a real project with both env vars set; the outputs above are the actual results.
