### PR TITLE
docs(cli): remove jiti install step from init skill

### DIFF
--- a/packages/cli/src/ai-context/references/initialize.md
+++ b/packages/cli/src/ai-context/references/initialize.md
@@ -35,18 +35,9 @@ Continue with the following steps:
 
 #### Step 1: Install dependencies
 
-1. **Install the Checkly dependency**
+**Install the Checkly dependency**
 
 Check if `npx checkly --version` works. If not, run `npm install --save-dev checkly`.
-
-2. **Do you want to use TypeScript? (recommended)**
-   - If **yes** → install `jiti`:
-
-     ```bash
-     npm i --save-dev jiti
-     ```
-
-   - If **no** → there's nothing to do
 
 #### Step 2: Gather the project requirements
 


### PR DESCRIPTION
## Summary

Removes the optional `jiti` install step from the `init` skill's `initialize.md` reference. TypeScript check files no longer require `jiti`, so the "Do you want to use TypeScript? → install jiti" prompt is obsolete and only adds friction to the setup flow.

## Changes

- Drop the `jiti` install step from Step 1 of `packages/cli/src/ai-context/references/initialize.md`
- Flatten the remaining "Install the Checkly dependency" instruction (no longer a numbered list of one)

## Notes

Docs/reference-only change — no code or dependency changes.
