### PR TITLE
feat(check-parser): support tsconfig/jsconfig extends [SIM-132]

### DIFF
--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-array/from-a/thing.ts
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-array/from-a/thing.ts
@@ -1,0 +1,3 @@
+// Present so that a wrongly-applied precedence (config A winning over B) would
+// resolve here instead of from-b, making the precedence bug observable.
+export const thing = 'from-a'

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-array/from-b/thing.ts
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-array/from-b/thing.ts
@@ -1,0 +1,1 @@
+export const thing = 'from-b'

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-array/package.json
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-array/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "tsconfig-extends-array"
+}

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-array/src/entrypoint.ts
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-array/src/entrypoint.ts
@@ -1,0 +1,3 @@
+import { thing } from '@/thing'
+
+export const entrypoint = thing

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-array/tsconfig.a.json
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-array/tsconfig.a.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./from-a/*"
+      ]
+    }
+  }
+}

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-array/tsconfig.b.json
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-array/tsconfig.b.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "@/*": [
+        "./from-b/*"
+      ]
+    }
+  }
+}

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-array/tsconfig.json
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-array/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": [
+    "./tsconfig.a.json",
+    "./tsconfig.b.json"
+  ]
+}

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-jsconfig/jsconfig.base.json
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-jsconfig/jsconfig.base.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./src/lib/*"
+      ]
+    }
+  }
+}

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-jsconfig/jsconfig.json
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-jsconfig/jsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./jsconfig.base.json"
+}

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-jsconfig/package.json
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-jsconfig/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "tsconfig-extends-jsconfig"
+}

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-jsconfig/src/entrypoint.js
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-jsconfig/src/entrypoint.js
@@ -1,0 +1,3 @@
+import { foo } from '@/foo'
+
+export const entrypoint = foo

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-jsconfig/src/lib/foo.js
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-jsconfig/src/lib/foo.js
@@ -1,0 +1,1 @@
+export const foo = 'foo'

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-node-modules/node_modules/@fake/tsconfig/lib/util.ts
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-node-modules/node_modules/@fake/tsconfig/lib/util.ts
@@ -1,0 +1,1 @@
+export const util = 'util'

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-node-modules/node_modules/@fake/tsconfig/package.json
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-node-modules/node_modules/@fake/tsconfig/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@fake/tsconfig",
+  "version": "1.0.0"
+}

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-node-modules/node_modules/@fake/tsconfig/tsconfig.json
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-node-modules/node_modules/@fake/tsconfig/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@ext/*": [
+        "./lib/*"
+      ]
+    }
+  }
+}

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-node-modules/package.json
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-node-modules/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "tsconfig-extends-node-modules",
+  "dependencies": {
+    "@fake/tsconfig": "*"
+  }
+}

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-node-modules/src/entrypoint.ts
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-node-modules/src/entrypoint.ts
@@ -1,0 +1,3 @@
+import { util } from '@ext/util'
+
+export const entrypoint = util

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-node-modules/tsconfig.json
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-node-modules/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@fake/tsconfig"
+}

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-relative/package.json
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-relative/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "tsconfig-extends-relative"
+}

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-relative/src/entrypoint.ts
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-relative/src/entrypoint.ts
@@ -1,0 +1,3 @@
+import { foo } from '@/foo'
+
+export const entrypoint = foo

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-relative/src/lib/foo.ts
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-relative/src/lib/foo.ts
@@ -1,0 +1,1 @@
+export const foo = 'foo'

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-relative/tsconfig.base.json
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-relative/tsconfig.base.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./src/lib/*"
+      ]
+    }
+  }
+}

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-relative/tsconfig.json
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-relative/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./tsconfig.base.json"
+}

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-workspace/package-lock.json
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-workspace/package-lock.json
@@ -1,0 +1,23 @@
+{
+  "name": "tsconfig-extends-workspace",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tsconfig-extends-workspace",
+      "version": "1.0.0",
+      "workspaces": [
+        "packages/*"
+      ]
+    },
+    "packages/config": {
+      "name": "@scope/config",
+      "version": "1.0.0"
+    },
+    "node_modules/@scope/config": {
+      "resolved": "packages/config",
+      "link": true
+    }
+  }
+}

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-workspace/package.json
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-workspace/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "tsconfig-extends-workspace",
+  "version": "1.0.0",
+  "workspaces": [
+    "packages/*"
+  ]
+}

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-workspace/packages/config/package.json
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-workspace/packages/config/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@scope/config",
+  "version": "1.0.0"
+}

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-workspace/packages/config/tsconfig.json
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-workspace/packages/config/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
+    "strict": true
+  }
+}

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-workspace/src/entrypoint.ts
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-workspace/src/entrypoint.ts
@@ -1,0 +1,3 @@
+import { thing } from '@/thing'
+
+export const entrypoint = thing

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-workspace/src/lib/thing.ts
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-workspace/src/lib/thing.ts
@@ -1,0 +1,1 @@
+export const thing = 'thing'

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-workspace/tsconfig.json
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/tsconfig-extends-workspace/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@scope/config/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./src/lib/*"
+      ]
+    }
+  }
+}

--- a/packages/cli/src/services/check-parser/__tests__/check-parser.spec.ts
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser.spec.ts
@@ -399,6 +399,92 @@ describe('dependency-parser - parser()', () => {
       ])
     })
 
+    it('should resolve tsconfig paths inherited through a relative extends', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('tsconfig-extends-relative', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: false,
+      })
+      const { dependencies } = await parser.parse(toAbsolutePath('src', 'entrypoint.ts'))
+      expect(dependencies.map(d => d.filePath).sort()).toEqual([
+        toAbsolutePath('package.json'),
+        toAbsolutePath('src', 'lib', 'foo.ts'),
+        toAbsolutePath('tsconfig.base.json'),
+        toAbsolutePath('tsconfig.json'),
+      ])
+    })
+
+    it('should apply the last extends entry when extends is an array', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('tsconfig-extends-array', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: false,
+      })
+      const { dependencies } = await parser.parse(toAbsolutePath('src', 'entrypoint.ts'))
+      expect(dependencies.map(d => d.filePath).sort()).toEqual([
+        toAbsolutePath('from-b', 'thing.ts'),
+        toAbsolutePath('package.json'),
+        toAbsolutePath('tsconfig.a.json'),
+        toAbsolutePath('tsconfig.b.json'),
+        toAbsolutePath('tsconfig.json'),
+      ])
+    })
+
+    it('should bundle a workspace-member config reached through extends', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('tsconfig-extends-workspace', ...filepath)
+      const workspace = await new NpmDetector().lookupWorkspace(toAbsolutePath('.'))
+      expect(workspace).toBeDefined()
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: false,
+        workspace,
+      })
+      const { dependencies } = await parser.parse(toAbsolutePath('src', 'entrypoint.ts'))
+      expect(dependencies.map(d => d.filePath).sort()).toEqual([
+        toAbsolutePath('package-lock.json'),
+        toAbsolutePath('package.json'),
+        toAbsolutePath('packages', 'config', 'package.json'),
+        toAbsolutePath('packages', 'config', 'tsconfig.json'),
+        toAbsolutePath('src', 'lib', 'thing.ts'),
+        toAbsolutePath('tsconfig.json'),
+      ])
+    })
+
+    it('should read options from an external node_modules config without bundling it', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('tsconfig-extends-node-modules', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: false,
+      })
+      const { dependencies } = await parser.parse(toAbsolutePath('src', 'entrypoint.ts'))
+      // The `@ext/*` alias is defined only in the external config, so its
+      // presence proves the inherited options were read. The external config
+      // and its package.json appear only as the nearest config of the resolved
+      // in-package file, not because the extends chain bundled them.
+      expect(dependencies.map(d => d.filePath).sort()).toEqual([
+        toAbsolutePath('node_modules', '@fake', 'tsconfig', 'lib', 'util.ts'),
+        toAbsolutePath('node_modules', '@fake', 'tsconfig', 'package.json'),
+        toAbsolutePath('node_modules', '@fake', 'tsconfig', 'tsconfig.json'),
+        toAbsolutePath('package.json'),
+        toAbsolutePath('tsconfig.json'),
+      ])
+    })
+
+    it('should resolve jsconfig paths inherited through extends', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('tsconfig-extends-jsconfig', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: false,
+      })
+      const { dependencies } = await parser.parse(toAbsolutePath('src', 'entrypoint.js'))
+      expect(dependencies.map(d => d.filePath).sort()).toEqual([
+        toAbsolutePath('jsconfig.base.json'),
+        toAbsolutePath('jsconfig.json'),
+        toAbsolutePath('package.json'),
+        toAbsolutePath('src', 'lib', 'foo.js'),
+      ])
+    })
+
     it('should not import TS files from a JS file', async () => {
       const toAbsolutePath = (...filepath: string[]) => fixt.abspath('no-import-ts-from-js', ...filepath)
       const parser = new Parser({
@@ -750,6 +836,38 @@ describe('dependency-parser - parser()', () => {
         toAbsolutePath('src', 'dep1.ts'),
         toAbsolutePath('src', 'dep2.ts'),
         toAbsolutePath('src', 'dep3.ts'),
+      ])
+    })
+
+    it('should bundle a relative extends base needed for path resolution', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('tsconfig-extends-relative', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: true,
+      })
+      const { dependencies } = await parser.parse(toAbsolutePath('src', 'entrypoint.ts'))
+      // The nearest package.json/tsconfig are not bundled in restricted mode, but
+      // the extends base is still pulled in via the supporting-config path
+      // because it is needed to resolve the `@/foo` alias.
+      expect(dependencies.map(d => d.filePath).sort()).toEqual([
+        toAbsolutePath('src', 'lib', 'foo.ts'),
+        toAbsolutePath('tsconfig.base.json'),
+        toAbsolutePath('tsconfig.json'),
+      ])
+    })
+
+    it('should not bundle an external node_modules config in restricted mode', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('tsconfig-extends-node-modules', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: true,
+      })
+      const { dependencies } = await parser.parse(toAbsolutePath('src', 'entrypoint.ts'))
+      // The inherited `@ext/*` alias still resolves, but the external config is
+      // never bundled — only the leaf config and the resolved source remain.
+      expect(dependencies.map(d => d.filePath).sort()).toEqual([
+        toAbsolutePath('node_modules', '@fake', 'tsconfig', 'lib', 'util.ts'),
+        toAbsolutePath('tsconfig.json'),
       ])
     })
 

--- a/packages/cli/src/services/check-parser/package-files/__tests__/tsconfig-json-file.spec.ts
+++ b/packages/cli/src/services/check-parser/package-files/__tests__/tsconfig-json-file.spec.ts
@@ -1,0 +1,76 @@
+import path from 'node:path'
+
+import { describe, it, expect } from 'vitest'
+
+import { TSConfigFile, Schema, ResolveExtends, ExtendedConfig } from '../tsconfig-json-file.js'
+import { JsonTextSourceFile } from '../json-text-source-file.js'
+import { SourceFile, FileMeta } from '../source-file.js'
+
+const ROOT = path.resolve('/proj')
+
+function configFile (filePath: string, data: Schema): JsonTextSourceFile<Schema> {
+  const sourceFile = new SourceFile(FileMeta.fromFilePath(filePath), JSON.stringify(data))
+  return new JsonTextSourceFile<Schema>(sourceFile, data)
+}
+
+// Builds a resolveExtends that maps specifiers to pre-built configs, so the
+// chain can be exercised without touching the filesystem.
+function resolverFor (configs: Record<string, ExtendedConfig>): ResolveExtends {
+  // eslint-disable-next-line require-await
+  return async specifier => configs[specifier]
+}
+
+describe('TSConfigFile extends', () => {
+  it('terminates on a circular extends chain', async () => {
+    const a = configFile(path.join(ROOT, 'a.json'), {
+      extends: './b.json',
+      compilerOptions: { baseUrl: './from-a' },
+    })
+    const b = configFile(path.join(ROOT, 'b.json'), {
+      extends: './a.json',
+    })
+
+    const tsconfig = await TSConfigFile.loadFromJsonTextSourceFile(a, resolverFor({
+      './b.json': { jsonFile: b, bundle: true },
+      './a.json': { jsonFile: a, bundle: true },
+    }))
+
+    // Resolves at all (no infinite recursion) and keeps the leaf's baseUrl.
+    expect(tsconfig?.baseUrl).toBe(path.join(ROOT, 'from-a'))
+  })
+
+  it('resolves inherited outDir/rootDir against the base config directory', async () => {
+    const baseDir = path.join(ROOT, 'config')
+    const base = configFile(path.join(baseDir, 'tsconfig.base.json'), {
+      compilerOptions: { outDir: 'dist', rootDir: 'src' },
+    })
+    const leaf = configFile(path.join(ROOT, 'tsconfig.json'), {
+      extends: './config/tsconfig.base.json',
+    })
+
+    const tsconfig = await TSConfigFile.loadFromJsonTextSourceFile(leaf, resolverFor({
+      './config/tsconfig.base.json': { jsonFile: base, bundle: true },
+    }))
+
+    // A compiled file under the base's outDir maps back to the base's rootDir,
+    // both relative to the base config directory rather than the leaf's.
+    const lookupPaths = tsconfig!.collectLookupPaths(path.join(baseDir, 'dist', 'foo.js'))
+    expect(lookupPaths).toContain(path.join(baseDir, 'src', 'foo.js'))
+  })
+
+  it('bundles only the local bases reached through extends', async () => {
+    const local = configFile(path.join(ROOT, 'local.json'), {})
+    const external = configFile(path.join(ROOT, 'node_modules', 'pkg', 'tsconfig.json'), {})
+    const leaf = configFile(path.join(ROOT, 'tsconfig.json'), {
+      extends: ['./local.json', 'pkg/tsconfig.json'],
+    })
+
+    const tsconfig = await TSConfigFile.loadFromJsonTextSourceFile(leaf, resolverFor({
+      './local.json': { jsonFile: local, bundle: true },
+      'pkg/tsconfig.json': { jsonFile: external, bundle: false },
+    }))
+
+    const bundled = tsconfig!.bundledExtendsSourceFiles.map(file => file.meta.filePath)
+    expect(bundled).toEqual([local.sourceFile.meta.filePath])
+  })
+})

--- a/packages/cli/src/services/check-parser/package-files/jsconfig-json-file.ts
+++ b/packages/cli/src/services/check-parser/package-files/jsconfig-json-file.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 
-import { TSConfigFile, Schema } from './tsconfig-json-file.js'
+import { TSConfigFile, Schema, ResolveExtends } from './tsconfig-json-file.js'
 import { JsonSourceFile } from './json-source-file.js'
 
 /**
@@ -21,8 +21,11 @@ export class JSConfigFile extends TSConfigFile {
     return path.join(dirPath, JSConfigFile.FILENAME)
   }
 
-  // eslint-disable-next-line require-await
-  static async loadFromJsonSourceFile (jsonFile: JsonSourceFile<Schema>): Promise<JSConfigFile | undefined> {
-    return new JSConfigFile(jsonFile)
+  static async loadFromJsonSourceFile (
+    jsonFile: JsonSourceFile<Schema>,
+    resolveExtends: ResolveExtends,
+  ): Promise<JSConfigFile | undefined> {
+    const chain = await JSConfigFile.buildChain(jsonFile, false, resolveExtends, new Set())
+    return new JSConfigFile(jsonFile, chain)
   }
 }

--- a/packages/cli/src/services/check-parser/package-files/resolver.ts
+++ b/packages/cli/src/services/check-parser/package-files/resolver.ts
@@ -1,10 +1,11 @@
+import { createRequire } from 'node:module'
 import path from 'node:path'
 
 import Debug from 'debug'
 
 import { SourceFile } from './source-file.js'
 import { PackageJsonFile } from './package-json-file.js'
-import { TSConfigFile } from './tsconfig-json-file.js'
+import { TSConfigFile, Schema, ResolveExtends, ExtendedConfig } from './tsconfig-json-file.js'
 import { JSConfigFile } from './jsconfig-json-file.js'
 import { isBuiltinPath, isImportsPath, isLocalPath, isNativeBinaryPath, PathResult, splitExternalPath } from './paths.js'
 import { FileLoader, LoadFile } from './loader.js'
@@ -16,7 +17,21 @@ import { Package, Workspace } from './workspace.js'
 
 const debug = Debug('checkly:cli:services:check-parser:resolver')
 
+/**
+ * Candidate file paths for an `extends` target. TypeScript appends `.json` when
+ * the specifier has no extension and falls back to `<dir>/tsconfig.json` when it
+ * points at a directory.
+ */
+function configFileCandidates (base: string): string[] {
+  if (base.endsWith('.json')) {
+    return [base]
+  }
+  return [`${base}.json`, path.join(base, TSConfigFile.FILENAME)]
+}
+
 class PackageFilesCache {
+  #workspace?: Workspace
+
   #sourceFileCache = new FileLoader(SourceFile.loadFromFilePath)
 
   #fileLoader<T> (load: (sourceFile: SourceFile) => Promise<T | undefined>): LoadFile<T> {
@@ -52,9 +67,79 @@ class PackageFilesCache {
     })
   }
 
+  // Loads any file path as a raw tsconfig/jsconfig schema, tolerating JSONC
+  // (comments and trailing commas). Used to pull in the configs referenced by a
+  // config's `extends` property, whatever their filename.
+  #tsconfigSchemaCache = new FileLoader<JsonTextSourceFile<Schema>>(async filePath => {
+    const sourceFile = await this.#sourceFileCache.load(filePath)
+    if (sourceFile === undefined) {
+      return
+    }
+
+    return JsonTextSourceFile.loadFromSourceFile<Schema>(sourceFile)
+  })
+
+  // Resolves a config referenced by another config's `extends` property. A
+  // relative/absolute path or a workspace-member package is bundled; an external
+  // node_modules package is read for its options but left to the runner to
+  // restore from package.json (so it is not bundled).
+  #resolveExtends: ResolveExtends = async (specifier, fromDir) => {
+    if (isLocalPath(specifier) || path.isAbsolute(specifier)) {
+      const base = path.resolve(fromDir, specifier)
+      return this.#loadExtendedConfig(configFileCandidates(base), true)
+    }
+
+    const { name, path: subPath } = splitExternalPath(specifier)
+    const member = this.#workspace?.memberByName(name)
+    if (member !== undefined) {
+      const base = path.resolve(member.path, subPath === '' ? TSConfigFile.FILENAME : subPath)
+      const resolved = await this.#loadExtendedConfig(configFileCandidates(base), true)
+      if (resolved !== undefined) {
+        return resolved
+      }
+    }
+
+    // External node_modules package. Let Node resolve it the way tsc does,
+    // falling back to `<package>/tsconfig.json` for the common case of a package
+    // that exposes a config but no main entry point.
+    try {
+      const require = createRequire(path.join(fromDir, TSConfigFile.FILENAME))
+      let resolvedPath: string
+      try {
+        resolvedPath = require.resolve(specifier)
+      } catch {
+        resolvedPath = require.resolve(path.posix.join(specifier, TSConfigFile.FILENAME))
+      }
+      return await this.#loadExtendedConfig([resolvedPath], false)
+    } catch {
+      // Could not resolve the extended config; behave as if `extends` were
+      // absent, matching the behavior before `extends` was supported.
+    }
+  }
+
+  async #loadExtendedConfig (candidates: string[], bundle: boolean): Promise<ExtendedConfig | undefined> {
+    for (const candidate of candidates) {
+      const jsonFile = await this.#tsconfigSchemaCache.load(candidate)
+      if (jsonFile !== undefined) {
+        return { jsonFile, bundle }
+      }
+    }
+  }
+
   #packageJsonCache = new FileLoader(this.#jsonFileLoader(PackageJsonFile.loadFromJsonSourceFile))
-  #tsconfigJsonCache = new FileLoader(this.#jsonTextFileLoader(TSConfigFile.loadFromJsonTextSourceFile))
-  #jsconfigJsonCache = new FileLoader(this.#jsonFileLoader(JSConfigFile.loadFromJsonSourceFile))
+  #tsconfigJsonCache = new FileLoader(this.#jsonTextFileLoader(
+    (jsonFile: JsonTextSourceFile<Schema>) =>
+      TSConfigFile.loadFromJsonTextSourceFile(jsonFile, this.#resolveExtends),
+  ))
+
+  #jsconfigJsonCache = new FileLoader(this.#jsonFileLoader(
+    (jsonFile: JsonSourceFile<Schema>) =>
+      JSConfigFile.loadFromJsonSourceFile(jsonFile, this.#resolveExtends),
+  ))
+
+  constructor (workspace?: Workspace) {
+    this.#workspace = workspace
+  }
 
   async exactSourceFile (filePath: string): Promise<SourceFile | undefined> {
     return await this.#sourceFileCache.load(filePath)
@@ -175,6 +260,13 @@ type SupportingTSConfigFileLocalDependency = {
   configFile: TSConfigFile
 }
 
+type ExtendedTSConfigFileLocalDependency = {
+  kind: 'extended-tsconfig-file'
+  importPath: string
+  sourceFile: SourceFile
+  configFile: TSConfigFile
+}
+
 type SupportingTSConfigResolvedPathLocalDependency = {
   kind: 'supporting-tsconfig-resolved-path'
   importPath: string
@@ -211,6 +303,7 @@ type LocalDependency =
   | NearestPackageJsonFileLocalDependency
   | NearestTSConfigFileLocalDependency
   | SupportingTSConfigFileLocalDependency
+  | ExtendedTSConfigFileLocalDependency
   | SupportingTSConfigResolvedPathLocalDependency
   | SupportingTSConfigBaseUrlRelativePathLocalDependency
   | RelativePathLocalDependency
@@ -248,13 +341,14 @@ export interface PackageFilesResolverOptions {
 }
 
 export class PackageFilesResolver {
-  cache = new PackageFilesCache()
+  cache: PackageFilesCache
   workspace?: Workspace
   restricted: boolean
 
   constructor (options?: PackageFilesResolverOptions) {
     this.workspace = options?.workspace
     this.restricted = options?.restricted ?? false
+    this.cache = new PackageFilesCache(options?.workspace)
   }
 
   async loadPackageFiles (filePath: string, options?: LineageOptions): Promise<PackageFiles> {
@@ -332,7 +426,12 @@ export class PackageFilesResolver {
 
             configJson.registerRelatedSourceFile(mainSourceFile)
 
-            return [sourceFile, mainSourceFile, configJson.jsonFile.sourceFile]
+            return [
+              sourceFile,
+              mainSourceFile,
+              configJson.jsonFile.sourceFile,
+              ...configJson.bundledExtendsSourceFiles,
+            ]
           }
         }
 
@@ -365,6 +464,20 @@ export class PackageFilesResolver {
         depends: [],
         references: [],
       },
+    }
+
+    // Whenever a config is included as a dependency, the local configs it
+    // reaches through `extends` must be included too, so that path resolution
+    // still works at runtime.
+    const pushExtendedConfigs = (importPath: string, configFile: TSConfigFile) => {
+      for (const sourceFile of configFile.bundledExtendsSourceFiles) {
+        resolved.local.push({
+          kind: 'extended-tsconfig-file',
+          importPath,
+          sourceFile,
+          configFile,
+        })
+      }
     }
 
     const dirname = path.dirname(filePath)
@@ -415,6 +528,7 @@ export class PackageFilesResolver {
           sourceFile: tsconfigJson.jsonFile.sourceFile,
           configFile: tsconfigJson,
         })
+        pushExtendedConfigs(filePath, tsconfigJson)
       }
 
       if (jsconfigJson) {
@@ -427,6 +541,7 @@ export class PackageFilesResolver {
           sourceFile: jsconfigJson.jsonFile.sourceFile,
           configFile: jsconfigJson,
         })
+        pushExtendedConfigs(filePath, jsconfigJson)
       }
 
       if (this.workspace.lockfile.isOk()) {
@@ -495,6 +610,7 @@ export class PackageFilesResolver {
           sourceFile: tsconfigJson.jsonFile.sourceFile,
           configFile: tsconfigJson,
         })
+        pushExtendedConfigs(filePath, tsconfigJson)
       }
 
       if (jsconfigJson) {
@@ -507,6 +623,7 @@ export class PackageFilesResolver {
           sourceFile: jsconfigJson.jsonFile.sourceFile,
           configFile: jsconfigJson,
         })
+        pushExtendedConfigs(filePath, jsconfigJson)
       }
     }
 
@@ -597,6 +714,7 @@ export class PackageFilesResolver {
                   sourceFile: configJson.jsonFile.sourceFile,
                   configFile: configJson,
                 })
+                pushExtendedConfigs(importPath, configJson)
                 found = true
               }
               if (found) {
@@ -637,6 +755,7 @@ export class PackageFilesResolver {
                 sourceFile: configJson.jsonFile.sourceFile,
                 configFile: configJson,
               })
+              pushExtendedConfigs(importPath, configJson)
               found = true
             }
             if (found) {

--- a/packages/cli/src/services/check-parser/package-files/tsconfig-json-file.ts
+++ b/packages/cli/src/services/check-parser/package-files/tsconfig-json-file.ts
@@ -1,6 +1,7 @@
 import path from 'node:path'
 
 import { SourceFile } from './source-file.js'
+import { JsonSourceFile } from './json-source-file.js'
 import { JsonTextSourceFile } from './json-text-source-file.js'
 import { PathResolver, ResolveResult } from './paths.js'
 
@@ -57,7 +58,70 @@ interface CompilerOptions {
 }
 
 export interface Schema {
+  /**
+   * Path(s) to one or more configuration files this config inherits from. May
+   * be a single specifier or, since TypeScript 5.0, an array. Later array
+   * entries override earlier ones and this config overrides all of them.
+   *
+   * @see https://www.typescriptlang.org/tsconfig/#extends
+   */
+  extends?: string | string[]
   compilerOptions?: CompilerOptions
+}
+
+/**
+ * A configuration file reached through another config's `extends` property.
+ *
+ * `bundle` indicates whether the config is a local project file that must be
+ * included in the deployment bundle (a relative/absolute path or a
+ * workspace-member package) as opposed to an external `node_modules` package
+ * that the runner restores from `package.json` and therefore does not need to
+ * be bundled.
+ */
+export type ExtendedConfig = {
+  jsonFile: JsonSourceFile<Schema>
+  bundle: boolean
+}
+
+/**
+ * Resolves a config referenced by another config's `extends` property. The
+ * resolver supplies this so that config loading can pull in the chain of
+ * extended configs without the file-loading machinery leaking into this module.
+ */
+export type ResolveExtends =
+  (specifier: string, fromDir: string) => Promise<ExtendedConfig | undefined>
+
+/**
+ * A value together with the directory of the config file that declared it.
+ * Relative paths in `extends`'d configs resolve relative to the file they
+ * originated in, so the origin directory must travel with each value.
+ */
+type Origin<T> = {
+  value: T
+  dir: string
+}
+
+/**
+ * The effective compiler options after merging an `extends` chain. For each
+ * option the leaf-most config that declares it wins (options are replaced, not
+ * deep-merged), and each path-bearing option remembers its origin directory.
+ */
+interface EffectiveOptions {
+  baseUrl?: Origin<string>
+  paths?: Origin<Paths>
+  outDir?: Origin<string>
+  rootDir?: Origin<string>
+  rootDirs?: Origin<string[]>
+  moduleResolution?: string
+}
+
+/**
+ * One link in a flattened `extends` chain, ordered from lowest to highest
+ * precedence. `bundle` carries whether the link's source file must be bundled.
+ */
+export type ChainLink = {
+  jsonFile: JsonSourceFile<Schema>
+  bundle: boolean
 }
 
 export class TSConfigFile {
@@ -66,39 +130,168 @@ export class TSConfigFile {
   static #id = 0
   readonly id = ++TSConfigFile.#id
 
-  jsonFile: JsonTextSourceFile<Schema>
+  jsonFile: JsonSourceFile<Schema>
   basePath: string
   moduleResolution: string
   baseUrl: string
   pathResolver: PathResolver
 
+  /**
+   * Source files of the configs reached through `extends` that must be bundled
+   * alongside this config (relative/absolute paths and workspace-member
+   * packages). External `node_modules` configs are excluded — they only
+   * contribute their compiler options, not a bundled file.
+   */
+  bundledExtendsSourceFiles: SourceFile[]
+
+  // Effective output/root directories, resolved to absolute paths against the
+  // directory of the config that declared each one.
+  #outDir?: string
+  #rootDir?: string
+  #rootDirs?: string[]
+
   relatedSourceFiles: SourceFile[] = []
 
-  protected constructor (jsonFile: JsonTextSourceFile<Schema>) {
+  protected constructor (
+    jsonFile: JsonSourceFile<Schema>,
+    chain: ChainLink[],
+  ) {
     this.jsonFile = jsonFile
 
     this.basePath = jsonFile.meta.dirname
 
-    this.moduleResolution = jsonFile.data.compilerOptions?.moduleResolution?.toLocaleLowerCase() ?? 'unspecified'
+    // The leaf config (the last link) is bundled by the resolver; only its
+    // bundlable bases need to be carried here.
+    this.bundledExtendsSourceFiles = chain
+      .slice(0, -1)
+      .filter(link => link.bundle)
+      .map(link => link.jsonFile.sourceFile)
 
-    this.baseUrl = jsonFile.data.compilerOptions?.baseUrl !== undefined
-      ? path.resolve(this.basePath, jsonFile.data.compilerOptions.baseUrl)
-      : this.basePath
+    const effective = TSConfigFile.#computeEffectiveOptions(chain)
 
-    this.pathResolver = PathResolver.createFromPaths(this.baseUrl, jsonFile.data.compilerOptions?.paths ?? {})
+    this.moduleResolution = effective.moduleResolution?.toLocaleLowerCase() ?? 'unspecified'
+
+    const baseUrlAbs = effective.baseUrl !== undefined
+      ? path.resolve(effective.baseUrl.dir, effective.baseUrl.value)
+      : undefined
+
+    this.baseUrl = baseUrlAbs ?? this.basePath
+
+    // Paths resolve relative to baseUrl when it is set anywhere in the chain,
+    // otherwise relative to the directory of the config that declared paths.
+    const pathsRoot = baseUrlAbs ?? effective.paths?.dir ?? this.basePath
+    this.pathResolver = PathResolver.createFromPaths(pathsRoot, effective.paths?.value ?? {})
+
+    this.#outDir = effective.outDir !== undefined
+      ? path.resolve(effective.outDir.dir, effective.outDir.value)
+      : undefined
+
+    this.#rootDir = effective.rootDir !== undefined
+      ? path.resolve(effective.rootDir.dir, effective.rootDir.value)
+      : undefined
+
+    const rootDirs = effective.rootDirs
+    this.#rootDirs = rootDirs !== undefined
+      ? rootDirs.value.map(dir => path.resolve(rootDirs.dir, dir))
+      : undefined
   }
 
   public get meta () {
     return this.jsonFile.meta
   }
 
-  // eslint-disable-next-line require-await
-  static async loadFromJsonTextSourceFile (jsonFile: JsonTextSourceFile<Schema>): Promise<TSConfigFile | undefined> {
-    return new TSConfigFile(jsonFile)
+  static async loadFromJsonTextSourceFile (
+    jsonFile: JsonTextSourceFile<Schema>,
+    resolveExtends: ResolveExtends,
+  ): Promise<TSConfigFile | undefined> {
+    const chain = await TSConfigFile.buildChain(jsonFile, false, resolveExtends, new Set())
+    return new TSConfigFile(jsonFile, chain)
   }
 
   static filePath (dirPath: string) {
     return path.join(dirPath, TSConfigFile.FILENAME)
+  }
+
+  /**
+   * Depth-first expands the `extends` chain into links ordered from lowest to
+   * highest precedence (this config last). A config that `extends` an array
+   * inherits later entries with higher precedence than earlier ones. Cycles are
+   * terminated by tracking visited config paths.
+   */
+  protected static async buildChain (
+    jsonFile: JsonSourceFile<Schema>,
+    bundle: boolean,
+    resolveExtends: ResolveExtends,
+    visited: Set<string>,
+  ): Promise<ChainLink[]> {
+    const filePath = jsonFile.meta.filePath
+    if (visited.has(filePath)) {
+      return []
+    }
+    visited.add(filePath)
+
+    const chain: ChainLink[] = []
+
+    const { extends: extendsValue } = jsonFile.data
+    const specifiers = extendsValue === undefined
+      ? []
+      : Array.isArray(extendsValue) ? extendsValue : [extendsValue]
+
+    for (const specifier of specifiers) {
+      const resolved = await resolveExtends(specifier, jsonFile.meta.dirname)
+      if (resolved === undefined) {
+        continue
+      }
+      chain.push(...await TSConfigFile.buildChain(
+        resolved.jsonFile,
+        resolved.bundle,
+        resolveExtends,
+        visited,
+      ))
+    }
+
+    chain.push({ jsonFile, bundle })
+
+    return chain
+  }
+
+  static #computeEffectiveOptions (chain: ChainLink[]): EffectiveOptions {
+    const effective: EffectiveOptions = {}
+
+    for (const { jsonFile } of chain) {
+      const compilerOptions = jsonFile.data.compilerOptions
+      if (compilerOptions === undefined) {
+        continue
+      }
+
+      const dir = jsonFile.meta.dirname
+
+      if (compilerOptions.baseUrl !== undefined) {
+        effective.baseUrl = { value: compilerOptions.baseUrl, dir }
+      }
+
+      if (compilerOptions.paths !== undefined) {
+        effective.paths = { value: compilerOptions.paths, dir }
+      }
+
+      if (compilerOptions.outDir !== undefined) {
+        effective.outDir = { value: compilerOptions.outDir, dir }
+      }
+
+      if (compilerOptions.rootDir !== undefined) {
+        effective.rootDir = { value: compilerOptions.rootDir, dir }
+      }
+
+      if (compilerOptions.rootDirs !== undefined) {
+        effective.rootDirs = { value: compilerOptions.rootDirs, dir }
+      }
+
+      if (compilerOptions.moduleResolution !== undefined) {
+        effective.moduleResolution = compilerOptions.moduleResolution
+      }
+    }
+
+    return effective
   }
 
   resolvePath (importPath: string): ResolveResult {
@@ -106,40 +299,21 @@ export class TSConfigFile {
   }
 
   collectLookupPaths (filePath: string): string[] {
-    let {
-      // eslint-disable-next-line prefer-const
-      outDir,
-      rootDir,
-      // eslint-disable-next-line prefer-const
-      rootDirs,
-      composite,
-    } = this.jsonFile.data.compilerOptions ?? {}
-
     const candidates = []
+
+    const outDir = this.#outDir
 
     if (outDir === undefined) {
       candidates.push(path.resolve(this.basePath, filePath))
       return candidates // Nothing more we can do.
     }
 
-    if (composite === undefined) {
-      composite = false
-    }
+    // Inferred rootDir is the config directory when not explicitly set. (This is
+    // also the inferred value when composite is true; computing the true longest
+    // common path of all input files would be far more effort than it's worth.)
+    const rootDir = this.#rootDir ?? this.basePath
 
-    // Inferred rootDir is tsconfig directory if composite === true.
-    if (rootDir === undefined && composite) {
-      rootDir = '.'
-    }
-
-    // If we still don't have a root, we should calculate the longest common
-    // path among input files, but that's a lot of effort. Assume tsconfig
-    // directory and hope for the best.
-    if (rootDir === undefined) {
-      rootDir = '.'
-    }
-
-    const absoluteOutDir = path.resolve(this.basePath, outDir)
-    const relativePath = path.relative(absoluteOutDir, filePath)
+    const relativePath = path.relative(outDir, filePath)
 
     // If the file is outside outDir, then assume we're looking for
     // something that wasn't compiled using this tsconfig (or at all), and
@@ -149,13 +323,13 @@ export class TSConfigFile {
       return candidates
     }
 
-    candidates.push(path.resolve(this.basePath, rootDir, relativePath))
+    candidates.push(path.resolve(rootDir, relativePath))
 
     // Assume that our inferred (or user specified) rootDir is enough to cover
     // the same conditions we'd have to infer rootDirs, and only add rootDirs
     // if they're actually set.
-    for (const multiRootDir of rootDirs ?? []) {
-      candidates.push(path.resolve(this.basePath, multiRootDir, relativePath))
+    for (const multiRootDir of this.#rootDirs ?? []) {
+      candidates.push(path.resolve(multiRootDir, relativePath))
     }
 
     return candidates


### PR DESCRIPTION
## Summary

The check-parser dependency resolver previously read only the **leaf** `tsconfig.json` / `jsconfig.json`, ignoring `extends` entirely. Projects that keep shared compiler options (`baseUrl`/`paths`) in a base config — a common monorepo pattern — lost those aliases, so alias imports failed to resolve and the referenced files were silently dropped from the bundle.

This change makes the resolver honor `extends`:

- **Resolution:** the effective `compilerOptions` are merged across the whole `extends` chain (string or array; leaf wins; later array entries override earlier ones), with each path option resolved relative to the config that declared it.
- **Bundling:** local base configs (relative/absolute paths and workspace-member packages) are added to the bundle so resolution still works at runtime. External `node_modules` base configs are read for their options but **not** bundled — the runner restores them from `package.json`. Browser/API ("restricted") checks already skip tsconfig bundling, so nothing regresses there.

Resolves SIM-132.

## No impact when `extends` is not used

Projects that don't use `extends` are unaffected. Every new code path is gated on an `extends` key being present: with no `extends`, the chain is just the leaf config, so the merged options and `collectLookupPaths` output are identical to before, `#resolveExtends` is never called (no extra file I/O), and `bundledExtendsSourceFiles` is empty so the new bundling calls are no-ops. The leaf is parsed exactly as before. The full pre-existing test suite — whose tsconfig fixtures are all no-`extends` cases — passes unchanged.

## Implementation

All under `packages/cli/src/services/check-parser/package-files/`:

- `tsconfig-json-file.ts` — flattens the `extends` chain and folds it into origin-aware effective options; `collectLookupPaths` refactored to use precomputed absolute paths (behavior-preserving for the no-extends case).
- `jsconfig-json-file.ts` — threads the extends resolver through `JSConfigFile`.
- `resolver.ts` — workspace-aware config cache, `#resolveExtends` (relative/absolute paths, workspace members via `memberByName`, external packages via `createRequire`), and bundling of the local chain at every config-push site.

## Tests

Fixtures + tests covering relative, array, workspace-member, external `node_modules` (read but not bundled), and jsconfig `extends`, in both unrestricted and restricted modes, plus a unit spec for circular-extends termination, origin-aware `outDir`/`rootDir`, and bundle exclusion of external bases.

## Other changes

- Dropped the `composite` handling in `collectLookupPaths`. It was a no-op: when `rootDir` was unset, the `composite` branch set it to `'.'`, but the next unconditional line set the same `'.'` default regardless of `composite`, so it never affected the result. The refactor preserves the exact behavior (default `rootDir` = the config directory). `composite` only matters for TypeScript's `rootDir` *inference*, and the original code already approximated both the composite and non-composite cases as the config directory rather than implementing longest-common-path inference, so there was nothing for the flag to influence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)