### PR TITLE
feat(destroy): delete projects via the async backend endpoint [RED-666] [show]

### DIFF
--- a/packages/cli/src/commands/__tests__/confirm-flow-destroy.spec.ts
+++ b/packages/cli/src/commands/__tests__/confirm-flow-destroy.spec.ts
@@ -155,6 +155,17 @@ describe('destroy confirmation flow', () => {
     expect(ctx.logged[0]).toContain('preserved as account-level resources')
   })
 
+  it('passes cancel-in-progress-deployment flag to deleteProject', async () => {
+    vi.mocked(detectCliMode).mockReturnValue('agent')
+    const ctx = createCommandContext({
+      flags: { 'force': true, 'cancel-in-progress-deployment': true },
+    })
+
+    await Destroy.prototype.run.call(ctx as any)
+
+    expect(api.projects.deleteProject).toHaveBeenCalledWith('my-project', expect.objectContaining({ cancelInProgress: true }))
+  })
+
   it('has correct metadata', () => {
     expect(Destroy.destructive).toBe(true)
     expect(Destroy.readOnly).toBe(false)

--- a/packages/cli/src/commands/__tests__/confirm-flow-destroy.spec.ts
+++ b/packages/cli/src/commands/__tests__/confirm-flow-destroy.spec.ts
@@ -45,7 +45,14 @@ function createCommandContext (parsed: unknown) {
       throw new Error(`EXIT_${code}`)
     }),
     confirmOrAbort: AuthCommand.prototype.confirmOrAbort,
-    style: { outputFormat: undefined, longError: vi.fn() },
+    style: {
+      outputFormat: undefined,
+      longError: vi.fn(),
+      actionStart: vi.fn(),
+      actionStatus: vi.fn(),
+      actionSuccess: vi.fn(),
+      actionFailure: vi.fn(),
+    },
     constructor: Destroy,
     account: { name: 'Test Account' },
     logged,
@@ -86,7 +93,7 @@ describe('destroy confirmation flow', () => {
 
     await Destroy.prototype.run.call(ctx as any)
 
-    expect(api.projects.deleteProject).toHaveBeenCalledWith('my-project', { preserveResources: false })
+    expect(api.projects.deleteProject).toHaveBeenCalledWith('my-project', expect.objectContaining({ preserveResources: false }))
   })
 
   it('prompts for project name in interactive mode', async () => {
@@ -99,7 +106,7 @@ describe('destroy confirmation flow', () => {
     await Destroy.prototype.run.call(ctx as any)
 
     expect(prompts).toHaveBeenCalledTimes(1)
-    expect(api.projects.deleteProject).toHaveBeenCalledWith('my-project', { preserveResources: false })
+    expect(api.projects.deleteProject).toHaveBeenCalledWith('my-project', expect.objectContaining({ preserveResources: false }))
   })
 
   it('aborts when project name does not match in interactive mode', async () => {
@@ -144,7 +151,7 @@ describe('destroy confirmation flow', () => {
 
     await Destroy.prototype.run.call(ctx as any)
 
-    expect(api.projects.deleteProject).toHaveBeenCalledWith('my-project', { preserveResources: true })
+    expect(api.projects.deleteProject).toHaveBeenCalledWith('my-project', expect.objectContaining({ preserveResources: true }))
     expect(ctx.logged[0]).toContain('preserved as account-level resources')
   })
 

--- a/packages/cli/src/commands/destroy.ts
+++ b/packages/cli/src/commands/destroy.ts
@@ -24,6 +24,10 @@ export default class Destroy extends AuthCommand {
       description: 'Preserve all project resources (checks, groups, dashboards, etc.) when destroying the project. Resources become normal account-level resources.',
       default: false,
     }),
+    'cancel-in-progress-deployment': Flags.boolean({
+      description: 'If a deployment for this project is already in progress, cancel it instead of waiting for it to finish.',
+      default: false,
+    }),
   }
 
   async run (): Promise<void> {
@@ -31,6 +35,7 @@ export default class Destroy extends AuthCommand {
     const {
       config: configFilename,
       'preserve-resources': preserveResources,
+      'cancel-in-progress-deployment': cancelInProgress,
     } = flags
     const { configDirectory, configFilenames } = splitConfigFilePath(configFilename)
     const { config: checklyConfig } = await loadChecklyConfig(configDirectory, configFilenames)
@@ -77,6 +82,7 @@ export default class Destroy extends AuthCommand {
       // completion, so large projects are no longer bound by the request timeout.
       await api.projects.deleteProject(checklyConfig.logicalId, {
         preserveResources,
+        cancelInProgress,
         onProgress: progress => this.style.actionStatus(`${progress}% complete`),
         onStatus: message => this.style.actionStatus(message),
       })
@@ -93,7 +99,8 @@ export default class Destroy extends AuthCommand {
         // 409 only reaches here once that wait exceeded its deadline.
         this.style.longError(
           'An operation for this project is still in progress.',
-          'Try again once it has finished.',
+          'Try again later, or re-run with `--cancel-in-progress-deployment` to '
+          + 'cancel the running operation and destroy now.',
         )
       } else {
         this.style.longError('Your project could not be destroyed.', err)

--- a/packages/cli/src/commands/destroy.ts
+++ b/packages/cli/src/commands/destroy.ts
@@ -6,6 +6,8 @@ import { AuthCommand } from './authCommand.js'
 import { splitConfigFilePath } from '../services/util.js'
 import commonMessages from '../messages/common-messages.js'
 import { forceFlag } from '../helpers/flags.js'
+import { ProjectDeployCancelledError } from '../rest/projects.js'
+import { ConflictError } from '../rest/errors.js'
 
 export default class Destroy extends AuthCommand {
   static hidden = false
@@ -70,12 +72,32 @@ export default class Destroy extends AuthCommand {
     })
 
     try {
-      await api.projects.deleteProject(checklyConfig.logicalId, { preserveResources })
+      this.style.actionStart('Destroying project')
+      // The deletion runs asynchronously on the backend and is followed to
+      // completion, so large projects are no longer bound by the request timeout.
+      await api.projects.deleteProject(checklyConfig.logicalId, {
+        preserveResources,
+        onProgress: progress => this.style.actionStatus(`${progress}% complete`),
+        onStatus: message => this.style.actionStatus(message),
+      })
+      this.style.actionSuccess()
       this.log(preserveResources
         ? `Project "${checklyConfig.projectName}" has been successfully deleted. All resources have been preserved as account-level resources.`
         : `All resources associated with project "${checklyConfig.projectName}" have been successfully deleted.`)
     } catch (err: any) {
-      this.style.longError(`Your project could not be destroyed.`, err)
+      this.style.actionFailure()
+      if (err instanceof ProjectDeployCancelledError) {
+        this.style.longError('Your project could not be destroyed.', err.message)
+      } else if (err instanceof ConflictError) {
+        // deleteProject waits-and-retries behind an in-progress operation, so a
+        // 409 only reaches here once that wait exceeded its deadline.
+        this.style.longError(
+          'An operation for this project is still in progress.',
+          'Try again once it has finished.',
+        )
+      } else {
+        this.style.longError('Your project could not be destroyed.', err)
+      }
       this.exit(1)
     }
   }

--- a/packages/cli/src/rest/__tests__/projects.spec.ts
+++ b/packages/cli/src/rest/__tests__/projects.spec.ts
@@ -8,6 +8,7 @@ function makeAxiosMock (): AxiosInstance {
   return {
     get: vi.fn(),
     post: vi.fn(),
+    delete: vi.fn(),
   } as unknown as AxiosInstance
 }
 
@@ -339,5 +340,106 @@ describe('Projects.deploy cancel-in-progress', () => {
     } finally {
       nowSpy.mockRestore()
     }
+  })
+})
+
+describe('Projects.deleteProject', () => {
+  let api: AxiosInstance
+  let projects: Projects
+
+  beforeEach(() => {
+    api = makeAxiosMock()
+    projects = new Projects(api)
+  })
+
+  it('submits the async delete, follows the SSE stream, reports progress, and resolves on SUCCEEDED', async () => {
+    const deleteDiff = [{ logicalId: 'check-1', type: 'check', action: 'DELETE' }]
+    vi.mocked(api.delete).mockResolvedValue({ data: { id: 'del-1', status: 'PENDING' } } as never)
+    vi.mocked(api.get).mockResolvedValue(
+      sseStream(
+        sse('progress', { status: 'RUNNING', progress: 50 }),
+        sse('complete', { id: 'del-1', status: 'SUCCEEDED', progress: 100, result: { diff: deleteDiff }, error: null }),
+      ) as never,
+    )
+
+    const onProgress = vi.fn()
+    await expect(projects.deleteProject('my-project', { onProgress })).resolves.toBeUndefined()
+
+    expect(api.delete).toHaveBeenCalledWith(
+      '/v1/projects/my-project',
+      expect.objectContaining({ params: { preserveResources: false, dryRun: false } }),
+    )
+    expect(api.get).toHaveBeenCalledWith(
+      '/v1/projects/my-project/deployments/del-1/events',
+      expect.objectContaining({ responseType: 'stream', headers: { Accept: 'text/event-stream' } }),
+    )
+    expect(onProgress).toHaveBeenCalledWith(50)
+  })
+
+  it('passes preserveResources through to the endpoint', async () => {
+    vi.mocked(api.delete).mockResolvedValue({ data: { id: 'del-1', status: 'PENDING' } } as never)
+    vi.mocked(api.get).mockResolvedValue(
+      sseStream(sse('complete', { id: 'del-1', status: 'SUCCEEDED', result: { diff: [] }, error: null })) as never,
+    )
+
+    await projects.deleteProject('my-project', { preserveResources: true })
+
+    expect(api.delete).toHaveBeenCalledWith(
+      '/v1/projects/my-project',
+      expect.objectContaining({ params: { preserveResources: true, dryRun: false } }),
+    )
+  })
+
+  it('resolves without following a stream when the project does not exist (idempotent)', async () => {
+    // A missing project completes synchronously with a plain result body (no status).
+    vi.mocked(api.delete).mockResolvedValue({ data: { project: undefined, diff: [] } } as never)
+
+    await expect(projects.deleteProject('never-deployed')).resolves.toBeUndefined()
+    expect(api.get).not.toHaveBeenCalled()
+  })
+
+  it('throws ProjectDeployFailedError when the deletion ends FAILED', async () => {
+    vi.mocked(api.delete).mockResolvedValue({ data: { id: 'del-1', status: 'PENDING' } } as never)
+    vi.mocked(api.get).mockResolvedValue(
+      sseStream(
+        sse('complete', { id: 'del-1', status: 'FAILED', result: null, error: { code: 'INTERNAL_ERROR', message: 'boom' } }),
+      ) as never,
+    )
+
+    await expect(projects.deleteProject('my-project')).rejects.toThrow(ProjectDeployFailedError)
+  })
+
+  it('throws ProjectDeployCancelledError when the deletion is CANCELLED', async () => {
+    vi.mocked(api.delete).mockResolvedValue({ data: { id: 'del-1', status: 'PENDING' } } as never)
+    vi.mocked(api.get).mockResolvedValue(
+      sseStream(sse('complete', { id: 'del-1', status: 'CANCELLED', result: null, error: null })) as never,
+    )
+
+    await expect(projects.deleteProject('my-project')).rejects.toThrow(ProjectDeployCancelledError)
+  })
+
+  it('waits for an in-flight operation (409) to finish, then retries the delete', async () => {
+    let deletes = 0
+    vi.mocked(api.delete).mockImplementation(() => {
+      deletes += 1
+      return (deletes === 1
+        ? Promise.reject(conflict('old-dep'))
+        : Promise.resolve({ data: { id: 'del-2', status: 'PENDING' } })) as never
+    })
+    vi.mocked(api.get).mockImplementation((url: string) =>
+      (url.includes('/completion')
+        ? Promise.resolve({ data: { id: 'old-dep', status: 'SUCCEEDED' } })
+        : Promise.resolve(sseStream(sse('complete', { id: 'del-2', status: 'SUCCEEDED', result: { diff: [] }, error: null })))) as never,
+    )
+
+    const onStatus = vi.fn()
+    await expect(projects.deleteProject('my-project', { onStatus })).resolves.toBeUndefined()
+
+    expect(api.get).toHaveBeenCalledWith(
+      '/v1/projects/my-project/deployments/old-dep/completion',
+      expect.objectContaining({ params: { maxWaitSeconds: 30 } }),
+    )
+    expect(deletes).toBe(2)
+    expect(onStatus).toHaveBeenCalled()
   })
 })

--- a/packages/cli/src/rest/__tests__/projects.spec.ts
+++ b/packages/cli/src/rest/__tests__/projects.spec.ts
@@ -442,4 +442,29 @@ describe('Projects.deleteProject', () => {
     expect(deletes).toBe(2)
     expect(onStatus).toHaveBeenCalled()
   })
+
+  it('cancels the in-flight operation, waits, and retries when cancelInProgress is set', async () => {
+    let deletes = 0
+    vi.mocked(api.delete).mockImplementation(() => {
+      deletes += 1
+      return (deletes === 1
+        ? Promise.reject(conflict('old-dep'))
+        : Promise.resolve({ data: { id: 'del-2', status: 'PENDING' } })) as never
+    })
+    vi.mocked(api.post).mockResolvedValue({ data: { id: 'old-dep', status: 'RUNNING' } } as never)
+    vi.mocked(api.get).mockImplementation((url: string) =>
+      (url.includes('/completion')
+        ? Promise.resolve({ data: { id: 'old-dep', status: 'CANCELLED' } })
+        : Promise.resolve(sseStream(sse('complete', { id: 'del-2', status: 'SUCCEEDED', result: { diff: [] }, error: null })))) as never,
+    )
+
+    await expect(projects.deleteProject('my-project', { cancelInProgress: true })).resolves.toBeUndefined()
+
+    expect(api.post).toHaveBeenCalledWith('/v1/projects/my-project/deployments/old-dep/cancel')
+    expect(api.get).toHaveBeenCalledWith(
+      '/v1/projects/my-project/deployments/old-dep/completion',
+      expect.objectContaining({ params: { maxWaitSeconds: 30 } }),
+    )
+    expect(deletes).toBe(2)
+  })
 })

--- a/packages/cli/src/rest/projects.ts
+++ b/packages/cli/src/rest/projects.ts
@@ -296,16 +296,22 @@ class Projects {
    */
   async deleteProject (
     logicalId: string,
-    { preserveResources = false, onProgress, onStatus }: {
+    { preserveResources = false, cancelInProgress = false, onProgress, onStatus }: {
       preserveResources?: boolean
+      /**
+       * On a 409 (a deploy or delete is already in progress), cancel that
+       * operation instead of waiting for it to finish, then retry.
+       */
+      cancelInProgress?: boolean
       onProgress?: (progress: number) => void
       /** Human-readable status updates (e.g. while waiting on a predecessor). */
       onStatus?: (message: string) => void
     } = {},
   ): Promise<void> {
     // On a 409 the project already has an operation (deploy or delete) in
-    // progress. Wait for it to reach a final state, then retry — bounded by an
-    // overall deadline so a stuck predecessor can't make us wait forever.
+    // progress. By default we wait for it to reach a final state then retry; with
+    // cancelInProgress we cancel it first. Bounded by an overall deadline so a
+    // stuck predecessor can't make us wait forever.
     const deadlineAt = Date.now() + DEPLOY_CONFLICT_WAIT_DEADLINE_MS
     for (;;) {
       try {
@@ -320,7 +326,7 @@ class Projects {
           throw err
         }
         await this.resolveInProgressDeployment(logicalId, err.data.deploymentId, {
-          cancel: false,
+          cancel: cancelInProgress,
           onStatus,
           deadlineAt,
         })

--- a/packages/cli/src/rest/projects.ts
+++ b/packages/cli/src/rest/projects.ts
@@ -240,9 +240,9 @@ export class InvalidImportPlanStateError extends Error {
   }
 }
 
-// How long deploy() will keep waiting-and-retrying behind an in-progress
-// deployment before giving up and surfacing the 409. Generous, since a large
-// predecessor deploy can legitimately run for many minutes.
+// How long deploy() and deleteProject() will keep waiting-and-retrying behind an
+// in-progress operation before giving up and surfacing the 409. Generous, since a
+// large predecessor deploy or delete can legitimately run for many minutes.
 const DEPLOY_CONFLICT_WAIT_DEADLINE_MS = 30 * 60_000
 
 class Projects {
@@ -287,20 +287,78 @@ class Projects {
   }
 
   /**
-   * @throws {ProjectNotFoundError} If the project does not exist.
+   * Delete a project. The deletion runs asynchronously on the backend: this
+   * submits it, then follows its progress stream to completion, so large projects
+   * are no longer bound by the API gateway request timeout. A project that does
+   * not exist is treated as already deleted (the endpoint is idempotent).
+   *
+   * @throws {ProjectDeployFailedError} If the deletion finishes unsuccessfully.
    */
-  async deleteProject (logicalId: string, { preserveResources = false } = {}) {
-    try {
-      const logicalIdParam = encodeURIComponent(logicalId)
-      return await this.api.delete(`/next/projects/${logicalIdParam}`, {
-        params: { preserveResources },
-      })
-    } catch (err) {
-      if (err instanceof NotFoundError) {
-        throw new ProjectNotFoundError(logicalId)
+  async deleteProject (
+    logicalId: string,
+    { preserveResources = false, onProgress, onStatus }: {
+      preserveResources?: boolean
+      onProgress?: (progress: number) => void
+      /** Human-readable status updates (e.g. while waiting on a predecessor). */
+      onStatus?: (message: string) => void
+    } = {},
+  ): Promise<void> {
+    // On a 409 the project already has an operation (deploy or delete) in
+    // progress. Wait for it to reach a final state, then retry — bounded by an
+    // overall deadline so a stuck predecessor can't make us wait forever.
+    const deadlineAt = Date.now() + DEPLOY_CONFLICT_WAIT_DEADLINE_MS
+    for (;;) {
+      try {
+        await this.submitDeletion(logicalId, { preserveResources, onProgress })
+        return
+      } catch (err) {
+        if (
+          !(err instanceof ConflictError)
+          || typeof err.data.deploymentId !== 'string'
+          || Date.now() >= deadlineAt
+        ) {
+          throw err
+        }
+        await this.resolveInProgressDeployment(logicalId, err.data.deploymentId, {
+          cancel: false,
+          onStatus,
+          deadlineAt,
+        })
+        // loop → re-submit, now that the predecessor has reached a final state
       }
+    }
+  }
 
-      throw err
+  /**
+   * Submit the async delete and follow it to completion. The endpoint responds
+   * either with a deployment to follow (202), or — when there is nothing to delete
+   * (the project does not exist) — a plain result with no deployment to follow.
+   */
+  private async submitDeletion (
+    logicalId: string,
+    { preserveResources, onProgress }: { preserveResources: boolean, onProgress?: (progress: number) => void },
+  ): Promise<void> {
+    const { data } = await this.api.delete<ProjectDeployResponse | ProjectDeployment>(
+      `/v1/projects/${encodeURIComponent(logicalId)}`,
+      { params: { preserveResources, dryRun: false } },
+    )
+
+    // A missing project completes synchronously with a plain result body and no
+    // deployment to follow — already deleted (idempotent).
+    if (!('status' in data)) {
+      return
+    }
+
+    const completed = await this.streamDeploymentEvents(logicalId, data.id, { onProgress })
+
+    if (completed.status === 'CANCELLED') {
+      throw new ProjectDeployCancelledError(
+        'The deletion was cancelled before it finished. A newer operation may have superseded it.',
+      )
+    }
+
+    if (completed.status !== 'SUCCEEDED') {
+      throw new ProjectDeployFailedError(completed.error?.message ?? 'The deletion did not complete successfully.')
     }
   }
 


### PR DESCRIPTION
## Why

`checkly destroy` calls the synchronous `DELETE /next/projects/{logicalId}`, which the API gateway times out at 30s for large projects → HTTP 504, so destroying a big project appears to fail. This is the CLI side of the async-delete work (the backend endpoint lands in checkly/monorepo#2689).

Part of RED-666.

## What

Switch `destroy` to the new async `DELETE /v1/projects/{logicalId}` and follow the operation to completion — reusing the SSE progress stream, completion long-poll, and 409 wait-and-retry helpers the CLI already uses for `deploy`. The deletion is no longer bound by the request timeout.

- **Progress UX**: shows `actionStart` / `% complete` / success / failure, like `deploy`.
- **409 handling**: if a deploy or delete is already in progress for the project, waits for it to finish then retries (bounded by the shared deadline); surfaces a clear message if the wait is exceeded.
- **`--cancel-in-progress-deployment`**: mirrors deploy's flag — cancel the in-progress operation (a deploy *or* a delete) instead of waiting, then retry. Uses the existing operation-agnostic cancel endpoint; no backend change.
- **Idempotent**: a project that no longer exists returns 200 from the new endpoint, so `destroy` treats it as already deleted instead of erroring.
- **`--preserve-resources`** is forwarded unchanged.

The endpoint responds either with a deployment to follow (202) or, for a missing project, a plain result with no deployment — discriminated by the presence of `status`.

## Testing

- `Projects.deleteProject` unit tests (rest/projects.spec.ts): SSE follow + progress → SUCCEEDED, `preserveResources` passthrough, idempotent no-follow, FAILED, CANCELLED, 409 wait-and-retry, and 409 cancel-in-progress.
- `confirm-flow-destroy` tests for the new call shape (progress callbacks), `style` action mocks, and both flag passthroughs.
- `tsc --build` and the `rest/projects` (23) + `confirm-flow-destroy` (8) specs pass. (The repo-wide lint hook is currently broken locally by an unrelated stray nested worktree; the changed files lint clean when scoped, and CI lints a clean checkout.)

## Requires

The backend async delete endpoint (checkly/monorepo#2689) deployed before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
