### PR TITLE
ci: add ship/show/ask auto-approval workflow (same-repo branch PRs only)

### DIFF
--- a/.github/workflows/ship-show-ask.yml
+++ b/.github/workflows/ship-show-ask.yml
@@ -52,16 +52,23 @@ jobs:
           fi
           shopt -u nocasematch
 
-          # This workflow's own currently-active approvals (normally at most one). Capture the
-          # API response into a variable first: a standalone assignment trips `set -e` if the
-          # request fails, whereas a process substitution (mapfile < <(gh ... | jq)) would
-          # swallow the error and yield an empty list — fail-open, skipping a needed dismissal.
-          # --paginate emits one JSON array per page; `jq -s 'add'` flattens them into a single
-          # array before filtering, so the result is correct across pagination.
+          # This workflow's own currently-active approvals (normally at most one). Both the API
+          # response and the jq result are captured via plain $(...) assignments so `set -e`
+          # aborts the run if either command fails; feeding mapfile from a process substitution
+          # (mapfile < <(gh ... | jq)) would discard such failures and yield an empty list —
+          # fail-open, skipping a needed dismissal. --paginate emits one JSON array per page;
+          # `jq -s 'add'` flattens them into a single array before filtering, so the result is
+          # correct across pagination.
           reviews_json=$(gh api --paginate "repos/$REPO/pulls/$PR/reviews")
-          mapfile -t approvals < <(jq -s -r \
+          approval_ids=$(jq -s -r \
             'add | [.[] | select(.user.login == "github-actions[bot]" and .state == "APPROVED") | .id] | .[]' \
             <<<"$reviews_json")
+          approvals=()
+          # Guard the empty case: mapfile on an empty herestring would yield a one-element array
+          # containing an empty string, which would falsely count as an existing approval.
+          if [[ -n "$approval_ids" ]]; then
+            mapfile -t approvals <<<"$approval_ids"
+          fi
 
           if [[ "$mode" == "approve" ]]; then
             if [[ ${#approvals[@]} -gt 0 ]]; then

--- a/.github/workflows/ship-show-ask.yml
+++ b/.github/workflows/ship-show-ask.yml
@@ -1,0 +1,82 @@
+name: Ship/Show/Ask auto-approval
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited, ready_for_review]
+
+permissions:
+  pull-requests: write
+
+# One run per PR; a fresh title edit / push supersedes an in-flight run. The latest run always
+# re-reads the current title + reviews and fully reconciles, so a cancelled run is never lossy.
+concurrency:
+  group: ship-show-ask-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  ship-show-ask:
+    runs-on: ubuntu-latest
+    # Only act on an OPEN, non-draft PR opened from a branch in this same repo (never forks).
+    # A same-repo branch can only be created by someone with push access, so auto-approval
+    # stays limited to trusted org members/collaborators; fork PRs always follow the normal
+    # manual-review path. (head.repo is null if the head was deleted, so the comparison is
+    # false and the job is skipped — fail-closed.) The open guard avoids a red failure when a
+    # closed/merged PR's title is edited; the draft guard means a tagged draft is approved only
+    # once it is marked ready for review.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.state == 'open' &&
+      github.event.pull_request.draft == false
+    steps:
+      # No checkout: this job only reads the PR title and calls the review API, so no untrusted
+      # PR code is ever executed under pull_request_target's privileged token.
+      - name: Approve or dismiss based on ship/show/ask title tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+
+          # [ship] or [show] anywhere in the title (case-insensitive) => auto-approve.
+          shopt -s nocasematch
+          if [[ "$TITLE" == *"[ship]"* || "$TITLE" == *"[show]"* ]]; then
+            mode=approve
+          else
+            mode=ask
+          fi
+          shopt -u nocasematch
+
+          # This workflow's own currently-active approvals (normally at most one). Capture the
+          # API response into a variable first: a standalone assignment trips `set -e` if the
+          # request fails, whereas a process substitution (mapfile < <(gh ... | jq)) would
+          # swallow the error and yield an empty list — fail-open, skipping a needed dismissal.
+          # --paginate emits one JSON array per page; `jq -s 'add'` flattens them into a single
+          # array before filtering, so the result is correct across pagination.
+          reviews_json=$(gh api --paginate "repos/$REPO/pulls/$PR/reviews")
+          mapfile -t approvals < <(jq -s -r \
+            'add | [.[] | select(.user.login == "github-actions[bot]" and .state == "APPROVED") | .id] | .[]' \
+            <<<"$reviews_json")
+
+          if [[ "$mode" == "approve" ]]; then
+            if [[ ${#approvals[@]} -gt 0 ]]; then
+              echo "PR #$PR already auto-approved; nothing to do."
+            else
+              gh pr review "$PR" --repo "$REPO" --approve \
+                --body "Auto-approved: ship/show PR from a same-repo branch."
+              echo "Approved PR #$PR."
+            fi
+          else
+            # ask / untagged: dismiss every active auto-approval so a stale one can't satisfy
+            # branch protection after the author downgrades the PR to request real review.
+            if [[ ${#approvals[@]} -eq 0 ]]; then
+              echo "PR #$PR in ask mode with no prior auto-approval; nothing to do."
+            else
+              for id in "${approvals[@]}"; do
+                gh api --method PUT "repos/$REPO/pulls/$PR/reviews/$id/dismissals" \
+                  -f message="Auto-approval dismissed: PR no longer tagged [ship]/[show]; manual review required." >/dev/null
+                echo "Dismissed prior auto-approval (review $id) on PR #$PR."
+              done
+            fi
+          fi

--- a/.github/workflows/ship-show-ask.yml
+++ b/.github/workflows/ship-show-ask.yml
@@ -39,9 +39,13 @@ jobs:
         run: |
           set -euo pipefail
 
-          # [ship] or [show] anywhere in the title (case-insensitive) => auto-approve.
+          # A [ship] or [show] tag at the very end of the title (case-insensitive) => auto-approve.
+          # The match is anchored to the end so that incidental mentions elsewhere in a title
+          # don't trigger approval — in particular GitHub's generated revert titles wrap the
+          # original title in quotes (`Revert "feat: x [ship]"`), so a revert of a shipped PR
+          # never ends with the tag and always goes through manual review.
           shopt -s nocasematch
-          if [[ "$TITLE" == *"[ship]"* || "$TITLE" == *"[show]"* ]]; then
+          if [[ "$TITLE" == *"[ship]" || "$TITLE" == *"[show]" ]]; then
             mode=approve
           else
             mode=ask

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,9 @@ Notes:
   review.
 - If you tag a PR `[ship]`/`[show]` and later change the title to `[ask]` (or drop the tag), the
   earlier auto-approval is dismissed so the PR returns to manual review.
+- Dismissing the bot's approval by hand doesn't stick: while the title still ends with
+  `[ship]`/`[show]`, the next push (or other PR update) re-approves. To durably demand review on a
+  tagged PR, submit a **Request changes** review or retitle the PR to `[ask]`.
 - A draft PR tagged `[ship]`/`[show]` is approved only once it's marked ready for review.
 - This only adds an approving review; merging still respects branch protection (passing CI, etc.).
   It does not auto-merge.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,33 @@ When modifying AI context sources (`src/ai-context/skill.md`, `src/ai-context/re
 
 The `skills/checkly/SKILL.md` file is the published copy that agents load. If you forget to regenerate it, CI will flag it as out of date.
 
+## Pull request review: Ship / Show / Ask
+
+This repo supports the [Ship / Show / Ask](https://martinfowler.com/articles/ship-show-ask.html)
+strategy. Signal your intent by tagging the **PR title** (case-insensitive):
+
+- **`[ship]`** — No review needed. `github-actions[bot]` auto-approves the PR; merge it yourself
+  once CI is green. Use for low-risk changes you're confident in.
+- **`[show]`** — Merge now, review after the fact. Also auto-approved; open it for visibility and
+  merge once CI passes, inviting comments for follow-up.
+- **`[ask]`** or **no tag** — Normal review. The PR waits for a human approval before it can merge.
+
+Notes:
+
+- **Auto-approval is limited to PRs opened from a branch in this repository** (i.e. members and
+  collaborators with push access). Pull requests from forks are **never** auto-approved and always
+  require manual review, regardless of the title tag.
+- If you tag a PR `[ship]`/`[show]` and later change the title to `[ask]` (or drop the tag), the
+  earlier auto-approval is dismissed so the PR returns to manual review.
+- A draft PR tagged `[ship]`/`[show]` is approved only once it's marked ready for review.
+- This only adds an approving review; merging still respects branch protection (passing CI, etc.).
+  It does not auto-merge.
+
+The behavior lives in [`.github/workflows/ship-show-ask.yml`](.github/workflows/ship-show-ask.yml).
+It depends on two GitHub settings outside this repo: **Allow GitHub Actions to create and approve
+pull requests** must be enabled, and branch protection on `main` must require an approving review
+(a review count — not a Code Owners review, which a bot can't satisfy).
+
 ## Prerelease experimental version
 
 To publish a NPM package for testing purpose, you can tag the pull-request with the `build` label. A GitHub Action will be

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,8 @@ The `skills/checkly/SKILL.md` file is the published copy that agents load. If yo
 ## Pull request review: Ship / Show / Ask
 
 This repo supports the [Ship / Show / Ask](https://martinfowler.com/articles/ship-show-ask.html)
-strategy. Signal your intent by tagging the **PR title** (case-insensitive):
+strategy. Signal your intent by ending the **PR title** with a tag (case-insensitive), e.g.
+`feat: add retries [ship]`:
 
 - **`[ship]`** — No review needed. `github-actions[bot]` auto-approves the PR; merge it yourself
   once CI is green. Use for low-risk changes you're confident in.
@@ -94,6 +95,9 @@ Notes:
 - **Auto-approval is limited to PRs opened from a branch in this repository** (i.e. members and
   collaborators with push access). Pull requests from forks are **never** auto-approved and always
   require manual review, regardless of the title tag.
+- The tag only counts at the very end of the title. A `[ship]`/`[show]` elsewhere in the title is
+  ignored — so e.g. a GitHub-generated revert title (`Revert "feat: x [ship]"`) still gets manual
+  review.
 - If you tag a PR `[ship]`/`[show]` and later change the title to `[ask]` (or drop the tag), the
   earlier auto-approval is dismissed so the PR returns to manual review.
 - A draft PR tagged `[ship]`/`[show]` is approved only once it's marked ready for review.


### PR DESCRIPTION
Adds a ship/show/ask auto-approval workflow for this repo.

## What

- New `.github/workflows/ship-show-ask.yml`: `github-actions[bot]` auto-approves PRs whose title **ends with** `[ship]` or `[show]` (case-insensitive). `[ask]`/untagged → no approval, and any prior auto-approval is **dismissed** (so downgrading a PR to `[ask]` restores manual review). Approve-only — it does not auto-merge.
- The tag only counts at the very end of the title, so GitHub-generated revert titles (`Revert "feat: x [ship]"`, which embed the original title) and incidental mid-title mentions are never auto-approved.
- `CONTRIBUTING.md` section documenting the convention and prerequisites.

## Fork safety

This is a public repo, so a fork PR must never be auto-approved. The job is gated to `head.repo.full_name == github.repository` — **only branches in this repo, never forks** — and additionally requires the PR to be open and non-draft.

It runs on `pull_request_target` so the gate/logic always come from `main` and can't be tampered with by editing the workflow in a PR branch. It deliberately does **not** `actions/checkout` the PR and reads the title only via an `env` var, so no untrusted code runs and there's no expression injection. Permissions are limited to `pull-requests: write`. API/parse failures fail the run rather than being silently treated as "no approvals to dismiss" (fail-closed).

Implemented directly rather than via a third-party action, to avoid a third-party dependency running in this privileged context.

## Requires two GitHub settings (outside this PR)

1. **Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"** must be enabled (and not disabled at the org level) — otherwise `GITHUB_TOKEN` approvals are rejected and the workflow hard-fails.
2. Branch protection on `main` must require an approving-review **count** (not a Code Owners review — a bot can't satisfy that) for a `[ship]`/`[show]` approval to actually unblock merge.

**Accepted trade-off:** `[ship]` lets a push-access member merge their own PR with no human review; the non-fork gate keeps it limited to trusted contributors. Note that a maintainer dismissing the bot approval is not durable (the next push or PR update re-approves); the durable ways to demand review are a "Request changes" review or retitling to `[ask]` — documented in CONTRIBUTING.md.

Resolves RED-673.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
