### PR TITLE
fix(cli): surface CLI-side timeouts in dot and github reporters [RED-676] [show]

### DIFF
--- a/packages/cli/src/reporters/__tests__/__snapshots__/github-md-builder.spec.ts.snap
+++ b/packages/cli/src/reporters/__tests__/__snapshots__/github-md-builder.spec.ts.snap
@@ -20,3 +20,23 @@ Ran **2** checks in **eu-west-1**.
 |✅ Pass|Test API check|API|\`src/some-other-folder/api.check.ts\`|2s |
 "
 `;
+
+exports[`GithubMdBuilder > renders markdown output for a check that failed with a run error > github-markdown-with-run-error 1`] = `
+"# Checkly Test Session Summary
+Ran **1** checks in **eu-west-1**.
+[View detailed test session summary](https://app.checklyhq.com/accounts/test-account-123/test-sessions/0c4c64b3-79c5-44a6-ae07-b580ce73f328)
+|Result|Name|Check Type|Filename|Duration|Link|
+|:-|:-|:-|:-|:-|:-|
+|❌ Fail|Timed out check|-|\`folder/timeout.check.ts\`|- |
+
+## Execution Errors
+
+These checks did not report a result to Checkly, so the test session may show a different status for them.
+
+**Timed out check**
+
+\`\`\`
+Reached timeout of 240 seconds waiting for check result. Use a custom timeout with --timeout
+\`\`\`
+"
+`;

--- a/packages/cli/src/reporters/__tests__/dot.spec.ts
+++ b/packages/cli/src/reporters/__tests__/dot.spec.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import DotReporter from '../dot.js'
+import type { SequenceId } from '../../services/abstract-check-runner.js'
+
+vi.mock('../../rest/api.js', () => ({
+  getDefaults: () => ({
+    baseURL: 'https://api.checklyhq.com',
+    accountId: 'test-account-123',
+    Authorization: 'Bearer test-key',
+    apiKey: 'test-key',
+  }),
+  testSessions: {
+    getShortLink: vi.fn(),
+  },
+}))
+
+const printMock = vi.fn()
+const printLnMock = vi.fn()
+
+vi.mock('../util.js', async () => {
+  const actual = await vi.importActual<typeof import('../util.js')>('../util.js')
+  return {
+    ...actual,
+    print: (...args: Parameters<typeof actual.print>) => printMock(...args),
+    printLn: (...args: Parameters<typeof actual.printLn>) => printLnMock(...args),
+  }
+})
+
+function stripAnsi (input: string): string {
+  return input.replace(
+    // eslint-disable-next-line no-control-regex
+    /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '')
+}
+
+const PUBLIC_RUN_LOCATION = { type: 'PUBLIC' as const, region: 'eu-west-1' }
+
+const SOURCE_FILE = 'folder/playwright.check.ts'
+const SEQUENCE_ID: SequenceId = 'seq-001'
+const RUN_ERROR = 'Reached timeout of 240 seconds waiting for check result. Use a custom timeout with --timeout'
+
+function makeCheck (sourceFile = SOURCE_FILE) {
+  return {
+    name: 'My Playwright Check',
+    getSourceFile: () => sourceFile,
+  }
+}
+
+function makeResult (extra: Record<string, any> = {}, sourceFile = SOURCE_FILE) {
+  return {
+    name: 'My Playwright Check',
+    sourceFile,
+    hasFailures: false,
+    isDegraded: false,
+    isCancelled: false,
+    ...extra,
+  }
+}
+
+function makeReporterWithOneCheck () {
+  const reporter = new DotReporter(PUBLIC_RUN_LOCATION, false)
+  const check = makeCheck()
+  reporter.onBegin([{ check, sequenceId: SEQUENCE_ID }])
+  return { reporter, check }
+}
+
+function printedOutput () {
+  return stripAnsi(printLnMock.mock.calls.map(([text]: [string]) => text).join('\n'))
+}
+
+describe('DotReporter', () => {
+  beforeEach(() => {
+    printMock.mockClear()
+    printLnMock.mockClear()
+  })
+
+  it('should print execution error details for a check that failed with a run error', () => {
+    const { reporter } = makeReporterWithOneCheck()
+
+    reporter.onCheckEnd(SEQUENCE_ID, makeResult({ hasFailures: true, runError: RUN_ERROR }))
+    reporter.onEnd()
+
+    const dots = stripAnsi(printMock.mock.calls.map(([text]: [string]) => text).join(''))
+    expect(dots).toContain('F')
+    const output = printedOutput()
+    expect(output).toContain('Execution Error')
+    expect(output).toContain(RUN_ERROR)
+    expect(output).toContain('My Playwright Check')
+  })
+
+  it('should not print execution error details for a passing check', () => {
+    const { reporter } = makeReporterWithOneCheck()
+
+    reporter.onCheckEnd(SEQUENCE_ID, makeResult())
+    reporter.onEnd()
+
+    const dots = stripAnsi(printMock.mock.calls.map(([text]: [string]) => text).join(''))
+    expect(dots).toContain('.')
+    expect(printedOutput()).not.toContain('Execution Error')
+  })
+
+  it('should not print execution error details for a check that failed without a run error', () => {
+    const { reporter } = makeReporterWithOneCheck()
+
+    reporter.onCheckEnd(SEQUENCE_ID, makeResult({ hasFailures: true }))
+    reporter.onEnd()
+
+    const dots = stripAnsi(printMock.mock.calls.map(([text]: [string]) => text).join(''))
+    expect(dots).toContain('F')
+    expect(printedOutput()).not.toContain('Execution Error')
+  })
+})

--- a/packages/cli/src/reporters/__tests__/github-md-builder.spec.ts
+++ b/packages/cli/src/reporters/__tests__/github-md-builder.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi } from 'vitest'
 
 import { GithubMdBuilder } from '../github.js'
+import type { checkFilesMap } from '../abstract-list.js'
 import { generateMapAndTestResultIds } from './helpers.js'
 
 vi.mock('../../rest/api', () => ({
@@ -34,5 +35,35 @@ describe('GithubMdBuilder', () => {
       checkFilesMap,
     }).render()
     expect(markdown).toMatchSnapshot('github-markdown-with-assets-links')
+  })
+  test('renders markdown output for a check that failed with a run error', () => {
+    const runError = 'Reached timeout of 240 seconds waiting for check result. Use a custom timeout with --timeout'
+    // A check that failed with a run error (e.g. the CLI timing out while waiting for a
+    // result) has no check type, response time or test result ID.
+    const map: checkFilesMap = new Map([
+      ['folder/timeout.check.ts', new Map([
+        ['seq-timeout', {
+          result: {
+            name: 'Timed out check',
+            sourceFile: 'folder/timeout.check.ts',
+            hasFailures: true,
+            runError,
+          },
+          titleString: 'Timed out check',
+          numRetries: 0,
+        }],
+      ])],
+    ])
+    const markdown = new GithubMdBuilder({
+      testSessionId,
+      numChecks: 1,
+      runLocation,
+      checkFilesMap: map,
+    }).render()
+    expect(markdown).toMatchSnapshot('github-markdown-with-run-error')
+    expect(markdown).not.toContain('undefined')
+    expect(markdown).not.toContain('NaN')
+    expect(markdown).toContain('## Execution Errors')
+    expect(markdown).toContain(runError)
   })
 })

--- a/packages/cli/src/reporters/abstract-list.ts
+++ b/packages/cli/src/reporters/abstract-list.ts
@@ -4,7 +4,7 @@ import { DateTime } from 'luxon'
 
 import { TestResultsShortLinks } from '../rest/test-sessions.js'
 import { Reporter } from './reporter.js'
-import { CheckStatus, formatCheckTitle, getTestSessionUrl, printLn, resultToCheckStatus } from './util.js'
+import { CheckStatus, formatCheckResult, formatCheckTitle, getTestSessionUrl, printLn, resultToCheckStatus } from './util.js'
 import type { RunLocation, SequenceId } from '../services/abstract-check-runner.js'
 import { Check } from '../constructs/check.js'
 import { testSessions } from '../rest/api.js'
@@ -277,6 +277,20 @@ export default abstract class AbstractListReporter implements Reporter {
     printLn(statusString)
     // Ansi escape code for erasing the line and moving the cursor up
     this._clearString = '\r\x1B[K\r\x1B[1A'.repeat(statusString.split('\n').length + 1)
+  }
+
+  // Checks that fail with a run error (e.g. the CLI timing out while waiting for a result)
+  // never produce a result in the Checkly backend, so the CLI output is the only place the
+  // error is visible. This lets terse reporters print those errors at the end of the run.
+  _printExecutionErrors () {
+    for (const [, checkMap] of this.checkFilesMap!.entries()) {
+      for (const [, { result }] of checkMap.entries()) {
+        if (result?.runError) {
+          printLn(formatCheckTitle(CheckStatus.FAILED, result))
+          printLn(indentString(formatCheckResult(result), 4), 2, 1)
+        }
+      }
+    }
   }
 
   async _printTestSessionsUrl () {

--- a/packages/cli/src/reporters/dot.ts
+++ b/packages/cli/src/reporters/dot.ts
@@ -11,6 +11,7 @@ export default class DotReporter extends AbstractListReporter {
 
   onEnd () {
     this._printBriefSummary()
+    this._printExecutionErrors()
     this._printTestSessionsUrl()
   }
 

--- a/packages/cli/src/reporters/github.ts
+++ b/packages/cli/src/reporters/github.ts
@@ -100,6 +100,7 @@ export default class GithubReporter extends AbstractListReporter {
 
   onEnd () {
     this._printBriefSummary()
+    this._printExecutionErrors()
     const githubMdBuilder = new GithubMdBuilder({
       testSessionId: this.testSessionId,
       numChecks: this.numChecks!,

--- a/packages/cli/src/reporters/github.ts
+++ b/packages/cli/src/reporters/github.ts
@@ -3,7 +3,7 @@ import * as path from 'path'
 
 import AbstractListReporter, { checkFilesMap } from './abstract-list.js'
 import { SequenceId } from '../services/abstract-check-runner.js'
-import { CheckStatus, formatDuration, getTestSessionUrl, printLn, resultToCheckStatus } from './util.js'
+import { CheckStatus, formatDuration, formatRunError, getTestSessionUrl, printLn, resultToCheckStatus } from './util.js'
 
 const outputFile = './checkly-github-report.md'
 
@@ -27,6 +27,7 @@ export class GithubMdBuilder {
   tableHeaders: Array<string>
   extraTableHeadersWithLinks: Array<string>
   tableRows: Array<string> = []
+  executionErrors: Array<string> = []
   hasFilenames: boolean
 
   readonly header: string = '# Checkly Test Session Summary'
@@ -68,9 +69,11 @@ export class GithubMdBuilder {
         const tableRow: Array<string> = [
           `${checkStatus === CheckStatus.FAILED ? '❌ Fail' : checkStatus === CheckStatus.DEGRADED ? '⚠️ Degraded' : '✅ Pass'}`,
           `${result.name}`,
-          `${result.checkType}`,
+          // A check that failed with a run error (e.g. the CLI timing out while waiting for
+          // a result) has no check type or response time, so fall back to a placeholder.
+          `${result.checkType ?? '-'}`,
           this.hasFilenames ? `\`${result.sourceFile}\`` : undefined,
-          `${formatDuration(result.responseTime)} `,
+          `${result.responseTime != null ? formatDuration(result.responseTime) : '-'} `,
         ].filter(nonNullable)
 
         if (this.testSessionId && testResultId) {
@@ -79,14 +82,24 @@ export class GithubMdBuilder {
         }
 
         this.tableRows.push(this.tableSeparator + tableRow.join(this.tableSeparator) + this.tableSeparator)
+
+        if (result.runError) {
+          this.executionErrors.push(`**${result.name}**\n\n\`\`\`\n${formatRunError(result.runError)}\n\`\`\``)
+        }
       }
     }
 
-    const markdown = this.header + '\n'
+    let markdown = this.header + '\n'
       + this.subHeader.join('\n') + '\n'
       + this.tableSeparator + this.tableHeaders.join('|') + this.tableSeparator + '\n'
       + this.tableSeparatorFiller.repeat(this.tableHeaders.length) + this.tableSeparator + '\n'
       + this.tableRows.sort((a, b) => a < b ? 1 : -1).join('\n') + '\n'
+
+    if (this.executionErrors.length > 0) {
+      markdown += '\n## Execution Errors\n\n'
+        + 'These checks did not report a result to Checkly, so the test session may show a different status for them.\n\n'
+        + this.executionErrors.join('\n\n') + '\n'
+    }
 
     return markdown
   }

--- a/packages/cli/src/reporters/util.ts
+++ b/packages/cli/src/reporters/util.ts
@@ -661,7 +661,7 @@ function formatLogs (logs: Array<{ level: string, msg: string, time: number }>) 
   }).join('\n')
 }
 
-function formatRunError (err: string | Error): string {
+export function formatRunError (err: string | Error): string {
   if (typeof err === 'string') {
     return err
   } else {


### PR DESCRIPTION
Linear: RED-676

When the CLI times out waiting for a check result (`--timeout`), the check never reports a result to Checkly, so the test session in the UI may show it as passing — the reporter output is the only place the timeout is visible. The `list`, `ci`, and `json` reporters already surface it; `dot` and `github` did not.

## Changes

- **`dot` and `github` reporters (console):** after the end-of-run summary, print the failed check title and execution error details for any result carrying a `runError`, reusing the same formatting as the `list`/`ci` reporters. Regular check failures are unaffected, keeping the dot output terse.
- **`github` markdown report:** add an `## Execution Errors` section listing each affected check with its run error, and render `-` instead of `undefined` (Check Type) and `NaNs` (Duration) for checks that have no result.

Since the fix is reporter-level, it applies to `test`, `trigger`, and `pw-test` alike.

## Example output

From `pnpm checkly test --timeout 5 --reporter <reporter>` with one passing API check and one Playwright check that hits the CLI timeout (trimmed; account-specific URLs redacted).

### dot

Before:

```
Running 2 checks in eu-central-1.

.F
1 failed, 1 passed, 2 total
```

After:

```
Running 2 checks in eu-central-1.

.F
1 failed, 1 passed, 2 total

✖ Playwright Check Example #1

    ──Execution Error───────────────────────────────────────────────────────────
    Reached timeout of 5 seconds waiting for check result. Use a custom timeout with --timeout
```

### github

The console output gains the same execution-error block as `dot` above (it previously only printed the counts). The generated `checkly-github-report.md`:

Before:

```
# Checkly Test Session Summary
Ran **2** checks in **eu-central-1**.
[View detailed test session summary](https://app.checklyhq.com/...)
|Result|Name|Check Type|Filename|Duration|Link|
|:-|:-|:-|:-|:-|:-|
|❌ Fail|Playwright Check Example #1|undefined|`__checks__/playwright.check.ts`|NaNs |
|✅ Pass|API Check Example #1|API|`__checks__/api.check.ts`|152ms |[Full test report](https://app.checklyhq.com/...)|
```

After:

````
# Checkly Test Session Summary
Ran **2** checks in **eu-central-1**.
[View detailed test session summary](https://app.checklyhq.com/...)
|Result|Name|Check Type|Filename|Duration|Link|
|:-|:-|:-|:-|:-|:-|
|❌ Fail|Playwright Check Example #1|-|`__checks__/playwright.check.ts`|- |
|✅ Pass|API Check Example #1|API|`__checks__/api.check.ts`|122ms |[Full test report](https://app.checklyhq.com/...)|

## Execution Errors

These checks did not report a result to Checkly, so the test session may show a different status for them.

**Playwright Check Example #1**

```
Reached timeout of 5 seconds waiting for check result. Use a custom timeout with --timeout
```
````

🤖 Generated with [Claude Code](https://claude.com/claude-code)
