### PR TITLE
fix(constructs): make SSL/traceroute assertion builders emit backend-valid payloads [SIM-287]

### DIFF
--- a/packages/cli/src/constructs/__tests__/ssl-assertion-codegen.spec.ts
+++ b/packages/cli/src/constructs/__tests__/ssl-assertion-codegen.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+
+import { valueForSslAssertion } from '../ssl-assertion-codegen.js'
+import { SslAssertion } from '../ssl-assertion.js'
+import { GeneratedFile, Output } from '../../sourcegen/index.js'
+
+function render (assertion: SslAssertion): string {
+  const output = new Output()
+  const file = new GeneratedFile('foo.ts')
+  const result = valueForSslAssertion(file, assertion)
+  result.render(output)
+  return output.finalize()
+}
+
+describe('SSL Assertion Codegen', () => {
+  it('generates the new SSL assertion sources', () => {
+    const cases: { input: SslAssertion, expected: string }[] = [
+      {
+        input: { source: 'HANDSHAKE_TIME_MS', property: '', comparison: 'LESS_THAN', target: '500', regex: null },
+        expected: 'SslAssertionBuilder.handshakeTimeMs().lessThan(500)\n',
+      },
+      {
+        input: { source: 'OCSP_STAPLED', property: '', comparison: 'EQUALS', target: 'true', regex: null },
+        expected: "SslAssertionBuilder.ocspStapled().equals('true')\n",
+      },
+      {
+        input: { source: 'SAN_CONTAINS', property: '', comparison: 'EQUALS', target: 'example.com', regex: null },
+        expected: "SslAssertionBuilder.sanContains().equals('example.com')\n",
+      },
+    ]
+    for (const test of cases) {
+      expect(render(test.input)).toEqual(test.expected)
+    }
+  })
+
+  it('generates the new comparison operators', () => {
+    const cases: { input: SslAssertion, expected: string }[] = [
+      {
+        input: { source: 'KEY_SIZE_BITS', property: '', comparison: 'GREATER_THAN_OR_EQUAL', target: '2048', regex: null },
+        expected: 'SslAssertionBuilder.keySizeBits().greaterThanOrEqual(2048)\n',
+      },
+      {
+        input: { source: 'TLS_VERSION', property: '', comparison: 'GREATER_THAN_OR_EQUAL', target: 'TLS1.2', regex: null },
+        expected: "SslAssertionBuilder.tlsVersion().greaterThanOrEqual('TLS1.2')\n",
+      },
+      {
+        input: { source: 'CIPHER_SUITE', property: '', comparison: 'MATCHES', target: '^TLS_AES_.*', regex: null },
+        expected: "SslAssertionBuilder.cipherSuite().matches('^TLS_AES_.*')\n",
+      },
+    ]
+    for (const test of cases) {
+      expect(render(test.input)).toEqual(test.expected)
+    }
+  })
+})

--- a/packages/cli/src/constructs/__tests__/ssl-monitor.spec.ts
+++ b/packages/cli/src/constructs/__tests__/ssl-monitor.spec.ts
@@ -116,6 +116,56 @@ describe('SslMonitor', () => {
     expect(bundle.synthesize()).toMatchObject({ groupId: { ref: 'main-group' } })
   })
 
+  describe('assertions', () => {
+    it('synthesizes the new SSL assertion sources with backend-compatible operators', () => {
+      setupProject()
+      const check = new SslMonitor('test-check', {
+        name: 'Test Check',
+        request: {
+          hostname: 'example.com',
+          sslConfig: {},
+          assertions: [
+            SslAssertionBuilder.keySizeBits().greaterThanOrEqual(2048),
+            SslAssertionBuilder.tlsVersion().greaterThanOrEqual('TLS1.2'),
+            SslAssertionBuilder.cipherSuite().matches('^TLS_AES_.*'),
+            SslAssertionBuilder.issuerCn().matches('(?i)let\'s encrypt.*'),
+            SslAssertionBuilder.handshakeTimeMs().lessThan(500),
+            SslAssertionBuilder.ocspStapled().equals(true),
+            SslAssertionBuilder.sanContains().equals('example.com'),
+          ],
+        },
+      })
+
+      const payload = check.synthesize() as any
+      expect(payload.request.assertions).toEqual([
+        expect.objectContaining({ source: 'KEY_SIZE_BITS', comparison: 'GREATER_THAN_OR_EQUAL', target: '2048' }),
+        expect.objectContaining({ source: 'TLS_VERSION', comparison: 'GREATER_THAN_OR_EQUAL', target: 'TLS1.2' }),
+        expect.objectContaining({ source: 'CIPHER_SUITE', comparison: 'MATCHES', target: '^TLS_AES_.*' }),
+        expect.objectContaining({ source: 'ISSUER_CN', comparison: 'MATCHES' }),
+        expect.objectContaining({ source: 'HANDSHAKE_TIME_MS', comparison: 'LESS_THAN', target: '500' }),
+        expect.objectContaining({ source: 'OCSP_STAPLED', comparison: 'EQUALS', target: 'true' }),
+        expect.objectContaining({ source: 'SAN_CONTAINS', comparison: 'EQUALS', target: 'example.com' }),
+      ])
+    })
+
+    it('accepts a "degrade" baseline severity', () => {
+      setupProject()
+      const check = new SslMonitor('test-check', {
+        name: 'Test Check',
+        request: {
+          hostname: 'example.com',
+          sslConfig: {
+            securityBaseline: {
+              minTLSVersion: { value: 'TLS1.2', severity: 'degrade' },
+            },
+          },
+        },
+      })
+      const payload = check.synthesize() as any
+      expect(payload.request.sslConfig.securityBaseline.minTLSVersion.severity).toBe('degrade')
+    })
+  })
+
   describe('validation', () => {
     it('should error when clientCertificateMode is explicit but no certificate id is set', async () => {
       setupProject()
@@ -174,6 +224,43 @@ describe('SslMonitor', () => {
           message: expect.stringContaining('must be less than or equal to "maxResponseTime"'),
         }),
       ]))
+    })
+
+    it('should error when degradedResponseTime exceeds the default maxResponseTime and max is omitted', async () => {
+      setupProject()
+      const check = new SslMonitor('test-check', {
+        name: 'Test Check',
+        // 20000 is within the 30000 degraded bound but above the 10000 default
+        // maxResponseTime the backend applies when max is omitted.
+        degradedResponseTime: 20000,
+        request: {
+          hostname: 'example.com',
+          sslConfig: {},
+        },
+      })
+      const diags = new Diagnostics()
+      await check.validate(diags)
+      expect(diags.isFatal()).toEqual(true)
+      expect(diags.observations).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          message: expect.stringContaining('must be less than or equal to the default "maxResponseTime" of 10000'),
+        }),
+      ]))
+    })
+
+    it('should not error when degradedResponseTime is within the default maxResponseTime and max is omitted', async () => {
+      setupProject()
+      const check = new SslMonitor('test-check', {
+        name: 'Test Check',
+        degradedResponseTime: 5000,
+        request: {
+          hostname: 'example.com',
+          sslConfig: {},
+        },
+      })
+      const diags = new Diagnostics()
+      await check.validate(diags)
+      expect(diags.isFatal()).toEqual(false)
     })
 
     it('should not error for a valid config', async () => {

--- a/packages/cli/src/constructs/__tests__/traceroute-assertion-codegen.spec.ts
+++ b/packages/cli/src/constructs/__tests__/traceroute-assertion-codegen.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+
+import { valueForTracerouteAssertion } from '../traceroute-assertion-codegen.js'
+import { TracerouteAssertion } from '../traceroute-assertion.js'
+import { GeneratedFile, Output } from '../../sourcegen/index.js'
+
+function render (assertion: TracerouteAssertion): string {
+  const output = new Output()
+  const file = new GeneratedFile('foo.ts')
+  const result = valueForTracerouteAssertion(file, assertion)
+  result.render(output)
+  return output.finalize()
+}
+
+describe('Traceroute Assertion Codegen', () => {
+  it('preserves the response-time property as a selector', () => {
+    const cases: { input: TracerouteAssertion, expected: string }[] = [
+      {
+        input: { source: 'RESPONSE_TIME', property: 'max', comparison: 'LESS_THAN', target: '1000', regex: null },
+        expected: 'TracerouteAssertionBuilder.responseTime().max().lessThan(1000)\n',
+      },
+      {
+        input: { source: 'RESPONSE_TIME', property: 'min', comparison: 'GREATER_THAN', target: '10', regex: null },
+        expected: 'TracerouteAssertionBuilder.responseTime().min().greaterThan(10)\n',
+      },
+      {
+        input: { source: 'RESPONSE_TIME', property: 'stdDev', comparison: 'LESS_THAN', target: '50', regex: null },
+        expected: 'TracerouteAssertionBuilder.responseTime().stdDev().lessThan(50)\n',
+      },
+      {
+        input: { source: 'RESPONSE_TIME', property: 'avg', comparison: 'LESS_THAN', target: '1000', regex: null },
+        expected: 'TracerouteAssertionBuilder.responseTime().avg().lessThan(1000)\n',
+      },
+    ]
+    for (const test of cases) {
+      expect(render(test.input)).toEqual(test.expected)
+    }
+  })
+
+  it('emits a bare responseTime() when no property is set', () => {
+    const input: TracerouteAssertion =
+      { source: 'RESPONSE_TIME', property: '', comparison: 'LESS_THAN', target: '1000', regex: null }
+    expect(render(input)).toEqual('TracerouteAssertionBuilder.responseTime().lessThan(1000)\n')
+  })
+
+  it('does not emit a property selector for HOP_COUNT / PACKET_LOSS', () => {
+    const hop: TracerouteAssertion =
+      { source: 'HOP_COUNT', property: '', comparison: 'LESS_THAN', target: '20', regex: null }
+    expect(render(hop)).toEqual('TracerouteAssertionBuilder.hopCount().lessThan(20)\n')
+
+    const loss: TracerouteAssertion =
+      { source: 'PACKET_LOSS', property: '', comparison: 'LESS_THAN', target: '10', regex: null }
+    expect(render(loss)).toEqual('TracerouteAssertionBuilder.packetLoss().lessThan(10)\n')
+  })
+})

--- a/packages/cli/src/constructs/__tests__/traceroute-monitor.spec.ts
+++ b/packages/cli/src/constructs/__tests__/traceroute-monitor.spec.ts
@@ -84,7 +84,60 @@ describe('TracerouteMonitor', () => {
     expect(bundle.synthesize()).toMatchObject({ groupId: { ref: 'main-group' } })
   })
 
+  describe('responseTime() assertions', () => {
+    it('should default the property to "avg" so responseTime().lessThan() is usable', () => {
+      const assertion = TracerouteAssertionBuilder.responseTime().lessThan(1000)
+      expect(assertion).toMatchObject({
+        source: 'RESPONSE_TIME',
+        property: 'avg',
+        comparison: 'LESS_THAN',
+        target: '1000',
+      })
+    })
+
+    it('should support selecting a specific response-time property', () => {
+      expect(TracerouteAssertionBuilder.responseTime().max().lessThan(2000)).toMatchObject({
+        source: 'RESPONSE_TIME',
+        property: 'max',
+        comparison: 'LESS_THAN',
+        target: '2000',
+      })
+      expect(TracerouteAssertionBuilder.responseTime().min().greaterThan(1)).toMatchObject({
+        source: 'RESPONSE_TIME',
+        property: 'min',
+        comparison: 'GREATER_THAN',
+      })
+      expect(TracerouteAssertionBuilder.responseTime().stdDev().lessThan(50)).toMatchObject({
+        source: 'RESPONSE_TIME',
+        property: 'stdDev',
+      })
+      expect(TracerouteAssertionBuilder.responseTime().avg().equals(100)).toMatchObject({
+        source: 'RESPONSE_TIME',
+        property: 'avg',
+        comparison: 'EQUALS',
+      })
+    })
+  })
+
   describe('validation', () => {
+    it('should error when degradedResponseTime exceeds maxResponseTime', async () => {
+      setupProject()
+      const check = new TracerouteMonitor('test-check', {
+        name: 'Test Check',
+        request,
+        degradedResponseTime: 20000,
+        maxResponseTime: 10000,
+      })
+      const diags = new Diagnostics()
+      await check.validate(diags)
+      expect(diags.isFatal()).toEqual(true)
+      expect(diags.observations).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          message: expect.stringContaining('must be less than or equal to "maxResponseTime"'),
+        }),
+      ]))
+    })
+
     it('should error if maxResponseTime is above 30000', async () => {
       setupProject()
       const check = new TracerouteMonitor('test-check', {

--- a/packages/cli/src/constructs/grpc-monitor.ts
+++ b/packages/cli/src/constructs/grpc-monitor.ts
@@ -78,6 +78,9 @@ export class GrpcMonitor extends Monitor {
     await validateResponseTimes(diagnostics, this, {
       degradedResponseTime: 30_000,
       maxResponseTime: 30_000,
+      // Backend default applied when maxResponseTime is omitted (see
+      // grpcResponseTimeLimitFields in response-time-limit-schema.ts).
+      defaultMaxResponseTime: 20_000,
     })
   }
 

--- a/packages/cli/src/constructs/internal/assertion-codegen.ts
+++ b/packages/cli/src/constructs/internal/assertion-codegen.ts
@@ -3,6 +3,10 @@ import { Assertion } from './assertion.js'
 
 export interface ValueForNumericAssertionOptions {
   hasProperty?: boolean
+  // When set, emit the assertion property as a chained selector method call
+  // (e.g. `responseTime().max()`) instead of a method argument, but only when
+  // the property is one of the listed selector names.
+  propertySelectors?: readonly string[]
 }
 
 export function valueForNumericAssertion<Source extends string> (
@@ -19,6 +23,11 @@ export function valueForNumericAssertion<Source extends string> (
         builder.string(assertion.property)
       }
     })
+    const propertySelectors = options?.propertySelectors
+    if (propertySelectors !== undefined && propertySelectors.includes(assertion.property)) {
+      builder.member(ident(assertion.property))
+      builder.call(() => {})
+    }
     switch (assertion.comparison) {
       case 'EQUALS':
         builder.member(ident('equals'))
@@ -40,6 +49,12 @@ export function valueForNumericAssertion<Source extends string> (
         break
       case 'GREATER_THAN':
         builder.member(ident('greaterThan'))
+        builder.call(builder => {
+          builder.number(parseInt(assertion.target, 10))
+        })
+        break
+      case 'GREATER_THAN_OR_EQUAL':
+        builder.member(ident('greaterThanOrEqual'))
         builder.call(builder => {
           builder.number(parseInt(assertion.target, 10))
         })
@@ -131,6 +146,18 @@ export function valueForGeneralAssertion<Source extends string> (
         break
       case 'GREATER_THAN':
         builder.member(ident('greaterThan'))
+        builder.call(builder => {
+          builder.string(assertion.target)
+        })
+        break
+      case 'GREATER_THAN_OR_EQUAL':
+        builder.member(ident('greaterThanOrEqual'))
+        builder.call(builder => {
+          builder.string(assertion.target)
+        })
+        break
+      case 'MATCHES':
+        builder.member(ident('matches'))
         builder.call(builder => {
           builder.string(assertion.target)
         })

--- a/packages/cli/src/constructs/internal/assertion.ts
+++ b/packages/cli/src/constructs/internal/assertion.ts
@@ -8,9 +8,11 @@ type Comparison =
   | 'IS_EMPTY'
   | 'NOT_EMPTY'
   | 'GREATER_THAN'
+  | 'GREATER_THAN_OR_EQUAL'
   | 'LESS_THAN'
   | 'CONTAINS'
   | 'NOT_CONTAINS'
+  | 'MATCHES'
   | 'IS_NULL'
   | 'NOT_NULL'
 
@@ -45,6 +47,10 @@ export class NumericAssertionBuilder<Source extends string, Property extends str
 
   greaterThan (target: number): Assertion<Source> {
     return this._toAssertion('GREATER_THAN', target)
+  }
+
+  greaterThanOrEqual (target: number): Assertion<Source> {
+    return this._toAssertion('GREATER_THAN_OR_EQUAL', target)
   }
 
   /** @private */
@@ -110,12 +116,22 @@ export class GeneralAssertionBuilder<Source extends string> {
     return this._toAssertion('GREATER_THAN', target)
   }
 
+  greaterThanOrEqual (target: string | number | boolean): Assertion<Source> {
+    return this._toAssertion('GREATER_THAN_OR_EQUAL', target)
+  }
+
   contains (target: string): Assertion<Source> {
     return this._toAssertion('CONTAINS', target)
   }
 
   notContains (target: string): Assertion<Source> {
     return this._toAssertion('NOT_CONTAINS', target)
+  }
+
+  matches (regex: string): Assertion<Source> {
+    // MATCHES carries the regular expression in the `target` field (the runner
+    // compiles `target` as the pattern), mirroring EQUALS/CONTAINS.
+    return this._toAssertion('MATCHES', regex)
   }
 
   isNull () {

--- a/packages/cli/src/constructs/internal/common-diagnostics.ts
+++ b/packages/cli/src/constructs/internal/common-diagnostics.ts
@@ -129,6 +129,10 @@ type ResponseTimeProps = {
 type ResponseTimeLimits = {
   degradedResponseTime: number
   maxResponseTime: number
+  // The per-type default that the backend applies to `maxResponseTime` when the
+  // caller omits it. Used so the degraded <= max cross-check still runs (against
+  // the effective max) when only `degradedResponseTime` is set explicitly.
+  defaultMaxResponseTime?: number
 }
 
 // eslint-disable-next-line require-await
@@ -165,5 +169,27 @@ export async function validateResponseTimes (
         ),
       ))
     }
+  }
+
+  // When `maxResponseTime` is omitted the backend applies a per-type default, so
+  // compare `degradedResponseTime` against that effective max. This catches the
+  // case where an explicit degraded value exceeds the default max (which would
+  // otherwise pass CLI validation but produce a broken check server-side).
+  const effectiveMaxResponseTime = props.maxResponseTime ?? limits.defaultMaxResponseTime
+  if (
+    props.degradedResponseTime !== undefined
+    && effectiveMaxResponseTime !== undefined
+    && props.degradedResponseTime > effectiveMaxResponseTime
+  ) {
+    diagnostics.add(new InvalidPropertyValueDiagnostic(
+      'degradedResponseTime',
+      new Error(
+        props.maxResponseTime !== undefined
+          ? `The value of "degradedResponseTime" must be less than or equal to "maxResponseTime".`
+          : `The value of "degradedResponseTime" must be less than or equal to the default `
+            + `"maxResponseTime" of ${effectiveMaxResponseTime}. Set an explicit "maxResponseTime" `
+            + `if you need a higher limit.`,
+      ),
+    ))
   }
 }

--- a/packages/cli/src/constructs/ssl-assertion-codegen.ts
+++ b/packages/cli/src/constructs/ssl-assertion-codegen.ts
@@ -30,6 +30,12 @@ export function valueForSslAssertion (genfile: GeneratedFile, assertion: SslAsse
       return valueForGeneralAssertion('SslAssertionBuilder', 'issuerFingerprintSha256', assertion, generalNoArgs)
     case 'SIGNATURE_ALGORITHM':
       return valueForGeneralAssertion('SslAssertionBuilder', 'signatureAlgorithm', assertion, generalNoArgs)
+    case 'OCSP_STAPLED':
+      return valueForGeneralAssertion('SslAssertionBuilder', 'ocspStapled', assertion, generalNoArgs)
+    case 'HANDSHAKE_TIME_MS':
+      return valueForNumericAssertion('SslAssertionBuilder', 'handshakeTimeMs', assertion)
+    case 'SAN_CONTAINS':
+      return valueForGeneralAssertion('SslAssertionBuilder', 'sanContains', assertion, generalNoArgs)
     default:
       throw new Error(`Unsupported SSL assertion source ${assertion.source}`)
   }

--- a/packages/cli/src/constructs/ssl-assertion.ts
+++ b/packages/cli/src/constructs/ssl-assertion.ts
@@ -12,6 +12,9 @@ type SslAssertionSource =
   | 'ISSUER_FINGERPRINT_SHA256'
   | 'KEY_SIZE_BITS'
   | 'SIGNATURE_ALGORITHM'
+  | 'OCSP_STAPLED'
+  | 'HANDSHAKE_TIME_MS'
+  | 'SAN_CONTAINS'
 
 export type SslAssertion = CoreAssertion<SslAssertionSource>
 
@@ -121,5 +124,31 @@ export class SslAssertionBuilder {
    */
   static signatureAlgorithm () {
     return new GeneralAssertionBuilder<SslAssertionSource>('SIGNATURE_ALGORITHM')
+  }
+
+  /**
+   * Creates an assertion builder for whether a stapled OCSP response was
+   * provided during the handshake.
+   * @returns A general assertion builder for the OCSP-stapled status.
+   */
+  static ocspStapled () {
+    return new GeneralAssertionBuilder<SslAssertionSource>('OCSP_STAPLED')
+  }
+
+  /**
+   * Creates an assertion builder for the TLS handshake time in milliseconds.
+   * @returns A numeric assertion builder for the handshake time.
+   */
+  static handshakeTimeMs () {
+    return new NumericAssertionBuilder<SslAssertionSource>('HANDSHAKE_TIME_MS')
+  }
+
+  /**
+   * Creates an assertion builder for the certificate subject alternative names
+   * (SANs).
+   * @returns A general assertion builder for the SAN entries.
+   */
+  static sanContains () {
+    return new GeneralAssertionBuilder<SslAssertionSource>('SAN_CONTAINS')
   }
 }

--- a/packages/cli/src/constructs/ssl-monitor.ts
+++ b/packages/cli/src/constructs/ssl-monitor.ts
@@ -2,7 +2,8 @@ import { Monitor, MonitorProps } from './monitor.js'
 import { Session } from './session.js'
 import { Diagnostics } from './diagnostics.js'
 import { SslRequest } from './ssl-request.js'
-import { InvalidPropertyValueDiagnostic, RequiredPropertyDiagnostic } from './construct-diagnostics.js'
+import { validateResponseTimes } from './internal/common-diagnostics.js'
+import { RequiredPropertyDiagnostic } from './construct-diagnostics.js'
 
 export interface SslMonitorProps extends MonitorProps {
   /**
@@ -78,18 +79,13 @@ export class SslMonitor extends Monitor {
       ))
     }
 
-    if (
-      this.degradedResponseTime !== undefined
-      && this.maxResponseTime !== undefined
-      && this.degradedResponseTime > this.maxResponseTime
-    ) {
-      diagnostics.add(new InvalidPropertyValueDiagnostic(
-        'degradedResponseTime',
-        new Error(
-          `The value of "degradedResponseTime" must be less than or equal to "maxResponseTime".`,
-        ),
-      ))
-    }
+    await validateResponseTimes(diagnostics, this, {
+      degradedResponseTime: 30_000,
+      maxResponseTime: 30_000,
+      // Backend default applied when maxResponseTime is omitted (see
+      // sslMonitorResponseTimeLimitFields in response-time-limit-schema.ts).
+      defaultMaxResponseTime: 10_000,
+    })
   }
 
   synthesize () {

--- a/packages/cli/src/constructs/ssl-request.ts
+++ b/packages/cli/src/constructs/ssl-request.ts
@@ -5,10 +5,10 @@ import { IPFamily } from './ip.js'
  * The severity applied to an SSL security-baseline rule.
  *
  * - `fail` marks the monitor as failing when the rule is violated.
- * - `warn` marks the monitor as degraded when the rule is violated.
+ * - `degrade` marks the monitor as degraded when the rule is violated.
  * - `ignore` disables the rule.
  */
-export type SslBaselineSeverity = 'fail' | 'warn' | 'ignore'
+export type SslBaselineSeverity = 'fail' | 'degrade' | 'ignore'
 
 /**
  * A baseline rule whose value is a TLS version string (e.g. `TLS1.2`/`TLS1.3`).

--- a/packages/cli/src/constructs/traceroute-assertion-codegen.ts
+++ b/packages/cli/src/constructs/traceroute-assertion-codegen.ts
@@ -7,7 +7,13 @@ export function valueForTracerouteAssertion (genfile: GeneratedFile, assertion: 
 
   switch (assertion.source) {
     case 'RESPONSE_TIME':
-      return valueForNumericAssertion('TracerouteAssertionBuilder', 'responseTime', assertion)
+      // The forward API selects the response-time property via a chained method
+      // (`responseTime().max().lessThan(...)`), so emit the property as a
+      // selector instead of dropping it. An empty/unknown property round-trips
+      // to a bare `responseTime()` (which defaults to `avg`).
+      return valueForNumericAssertion('TracerouteAssertionBuilder', 'responseTime', assertion, {
+        propertySelectors: ['avg', 'min', 'max', 'stdDev'],
+      })
     case 'HOP_COUNT':
       return valueForNumericAssertion('TracerouteAssertionBuilder', 'hopCount', assertion)
     case 'PACKET_LOSS':

--- a/packages/cli/src/constructs/traceroute-assertion.ts
+++ b/packages/cli/src/constructs/traceroute-assertion.ts
@@ -8,13 +8,54 @@ type TracerouteAssertionSource =
 export type TracerouteAssertion = CoreAssertion<TracerouteAssertionSource>
 
 /**
+ * The statistical property of the traceroute response time to assert against.
+ * The backend requires one of these for `RESPONSE_TIME` assertions.
+ */
+export type TracerouteResponseTimeProperty = 'avg' | 'min' | 'max' | 'stdDev'
+
+/**
+ * A numeric assertion builder for traceroute response time. It defaults to the
+ * `avg` property so `responseTime().lessThan(1000)` works out of the box, and
+ * exposes `avg()`/`min()`/`max()`/`stdDev()` to select a specific property.
+ */
+class TracerouteResponseTimeAssertionBuilder
+  extends NumericAssertionBuilder<TracerouteAssertionSource, TracerouteResponseTimeProperty> {
+  constructor () {
+    super('RESPONSE_TIME', 'avg')
+  }
+
+  /** Asserts against the average response time. */
+  avg () {
+    return new NumericAssertionBuilder<TracerouteAssertionSource, TracerouteResponseTimeProperty>('RESPONSE_TIME', 'avg')
+  }
+
+  /** Asserts against the minimum response time. */
+  min () {
+    return new NumericAssertionBuilder<TracerouteAssertionSource, TracerouteResponseTimeProperty>('RESPONSE_TIME', 'min')
+  }
+
+  /** Asserts against the maximum response time. */
+  max () {
+    return new NumericAssertionBuilder<TracerouteAssertionSource, TracerouteResponseTimeProperty>('RESPONSE_TIME', 'max')
+  }
+
+  /** Asserts against the standard deviation of the response time. */
+  stdDev () {
+    return new NumericAssertionBuilder<TracerouteAssertionSource, TracerouteResponseTimeProperty>('RESPONSE_TIME', 'stdDev')
+  }
+}
+
+/**
  * Builder class for creating traceroute monitor assertions.
  * Provides methods to create assertions for traceroute probe responses.
  *
  * @example
  * ```typescript
- * // Response time assertions
+ * // Response time assertions (defaults to the average)
  * TracerouteAssertionBuilder.responseTime().lessThan(1000)
+ *
+ * // Response time assertions against a specific property
+ * TracerouteAssertionBuilder.responseTime().max().lessThan(2000)
  *
  * // Hop count assertions
  * TracerouteAssertionBuilder.hopCount().lessThan(20)
@@ -25,11 +66,13 @@ export type TracerouteAssertion = CoreAssertion<TracerouteAssertionSource>
  */
 export class TracerouteAssertionBuilder {
   /**
-   * Creates an assertion builder for traceroute response time.
-   * @returns A numeric assertion builder for response time in milliseconds.
+   * Creates an assertion builder for traceroute response time in milliseconds.
+   * Defaults to the `avg` property; use `avg()`/`min()`/`max()`/`stdDev()` to
+   * select a specific property.
+   * @returns A numeric assertion builder for response time.
    */
   static responseTime () {
-    return new NumericAssertionBuilder<TracerouteAssertionSource>('RESPONSE_TIME')
+    return new TracerouteResponseTimeAssertionBuilder()
   }
 
   /**

--- a/packages/cli/src/constructs/traceroute-monitor.ts
+++ b/packages/cli/src/constructs/traceroute-monitor.ts
@@ -78,6 +78,9 @@ export class TracerouteMonitor extends Monitor {
     await validateResponseTimes(diagnostics, this, {
       degradedResponseTime: 30_000,
       maxResponseTime: 30_000,
+      // Backend default applied when maxResponseTime is omitted (see
+      // tracerouteResponseTimeLimitFields in response-time-limit-schema.ts).
+      defaultMaxResponseTime: 20_000,
     })
   }
 


### PR DESCRIPTION
## SIM-287

Fixes CLI assertion builders that generated payloads the backend rejects, or couldn't express supported checks. Targets `feat/cli-pertype-result-rendering` (#1362).

- **Traceroute `responseTime()` was unusable** — it synthesized `property:''`, but the backend requires `property ∈ {avg,min,max,stdDev}` → 400. Now defaults to `avg` and adds `.avg()/.min()/.max()/.stdDev()` selectors; codegen preserves the property on round-trip (was silently collapsing to `avg`).
- **SSL baseline severity** `'warn'` → `'degrade'` to match the backend enum (`['fail','degrade','ignore']`).
- **Missing operators** — added `greaterThanOrEqual` (→ `GREATER_THAN_OR_EQUAL`, needed for `KEY_SIZE_BITS`/`TLS_VERSION`) and `matches` (→ `MATCHES`, for `CIPHER_SUITE`/`ISSUER_CN`); wired both into codegen.
- **Missing SSL sources** — added `OCSP_STAPLED`, `HANDSHAKE_TIME_MS`, `SAN_CONTAINS` (builders + codegen).
- **`degraded ≤ max` validation** — added once in the shared `validateResponseTimes`; also guards the case where `maxResponseTime` is omitted (compares against the per-type default).

Codegen (`checkly import`) was updated alongside so the new sources/operators/selectors round-trip instead of throwing or corrupting.

## Tests
New `ssl-assertion-codegen.spec.ts` and `traceroute-assertion-codegen.spec.ts` round-trip the new sources/operators and traceroute property preservation; `ssl-monitor`/`traceroute-monitor` specs cover the new severity, selectors, and the degraded>max diagnostic.

## Verified live
`TracerouteAssertionBuilder.responseTime().max().lessThan(…)` now round-trips as `max` and evaluates: *`response time property "max" is less than target … Received: 6.8`*.

## Note
The `degraded ≤ max` check now applies to all monitor types (was SSL-only inline) — a small, intentional broadening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NC9pESYE5wGqy5TKRzufyc
