### PR TITLE
feat(check-parser): bundle .npmrc in Playwright Check Suite bundles by default [RED-691] [show]

### DIFF
--- a/packages/cli/src/ai-context/references/configure-playwright-checks.md
+++ b/packages/cli/src/ai-context/references/configure-playwright-checks.md
@@ -9,10 +9,10 @@
 ## Dependencies
 
 - Use the user's `package.json` and lock file for dependencies. Do not add dependency declarations to check code.
-- For private packages or custom registries, include the registry config file, usually `.npmrc`, with `include`.
-- The `.npmrc` should reference a Checkly environment variable such as `${NPM_TOKEN}`. Tell the user that the token must exist in Checkly before `deploy` or `trigger`.
+- For private packages or custom registries, `.npmrc` is bundled automatically — the workspace-root `.npmrc` and any `.npmrc` beside a package's `package.json` are included by default. You do not need to add `.npmrc` to `include`.
+- The `.npmrc` should reference a Checkly environment variable such as `${NPM_TOKEN}`. Tell the user that the token must exist in Checkly before `deploy` or `trigger`. Because `.npmrc` is uploaded automatically, warn users to reference credentials via environment variables (`${NPM_TOKEN}`) rather than embedding plaintext tokens.
 - Use `installCommand` only when the default package-manager install command is not enough.
-- In Checkly CLI v8.0.0 and later, `include` patterns resolve relative to the Playwright config directory, not the project root. If `playwrightConfigPath` points to a subdirectory, adjust `include` globs. Example: `playwrightConfigPath: "./e2e/playwright.config.ts"` with root `.npmrc` needs `include: ["../.npmrc"]`.
+- In Checkly CLI v8.0.0 and later, `include` patterns resolve relative to the Playwright config directory, not the project root. If `playwrightConfigPath` points to a subdirectory, adjust `include` globs. Example: `playwrightConfigPath: "./e2e/playwright.config.ts"` with a root fixture at `fixtures/data.json` needs `include: ["../fixtures/data.json"]`.
 
 ## Install troubleshooting
 
@@ -40,8 +40,8 @@ import { PlaywrightCheck } from "checkly/constructs"
 new PlaywrightCheck("checkout-suite", {
   name: "Checkout suite",
   playwrightConfigPath: "./e2e/playwright.config.ts",
-  // Include root .npmrc for private package or registry auth.
-  include: ["../.npmrc"],
+  // .npmrc is bundled automatically for private packages or registry auth —
+  // no include entry needed.
 })
 ```
 - `playwrightConfigPath` is resolved **relative to the `.check.ts` file that declares the construct**, not the project root. If your check lives in `monitoring/suites.check.ts` and your config in `playwright.config.ts` at the repo root, use `'../playwright.config.ts'`.

--- a/packages/cli/src/services/check-parser/__tests__/cache-hash.spec.ts
+++ b/packages/cli/src/services/check-parser/__tests__/cache-hash.spec.ts
@@ -149,6 +149,95 @@ describe('composeCacheHash', () => {
     expect(without).not.toBe(withMember)
   })
 
+  test('omitting npmrcs matches passing an empty array (no-op)', () => {
+    const root = buf('{"name":"root"}')
+    const lockfile = { name: 'package-lock.json', hash: sha256('lock') }
+    expect(composeCacheHash({
+      lockfile,
+      packageJsons: [{ path: 'package.json', raw: root }],
+      excludedFields: ['version'],
+    })).toBe(composeCacheHash({
+      lockfile,
+      packageJsons: [{ path: 'package.json', raw: root }],
+      npmrcs: [],
+      excludedFields: ['version'],
+    }))
+  })
+
+  test('adding a root .npmrc changes the hash', () => {
+    const root = buf('{"name":"root"}')
+    const lockfile = { name: 'package-lock.json', hash: sha256('lock') }
+    const without = composeCacheHash({
+      lockfile,
+      packageJsons: [{ path: 'package.json', raw: root }],
+      excludedFields: ['version'],
+    })
+    const withNpmrc = composeCacheHash({
+      lockfile,
+      packageJsons: [{ path: 'package.json', raw: root }],
+      npmrcs: [{ path: '.npmrc', hash: sha256('registry=https://example.com/') }],
+      excludedFields: ['version'],
+    })
+    expect(without).not.toBe(withNpmrc)
+  })
+
+  test('changing .npmrc content changes the hash', () => {
+    const root = buf('{"name":"root"}')
+    const lockfile = { name: 'package-lock.json', hash: sha256('lock') }
+    const a = composeCacheHash({
+      lockfile,
+      packageJsons: [{ path: 'package.json', raw: root }],
+      npmrcs: [{ path: '.npmrc', hash: sha256('registry=https://a.example.com/') }],
+      excludedFields: ['version'],
+    })
+    const b = composeCacheHash({
+      lockfile,
+      packageJsons: [{ path: 'package.json', raw: root }],
+      npmrcs: [{ path: '.npmrc', hash: sha256('registry=https://b.example.com/') }],
+      excludedFields: ['version'],
+    })
+    expect(a).not.toBe(b)
+  })
+
+  test('adding a member .npmrc changes the hash', () => {
+    const root = buf('{"name":"root"}')
+    const lockfile = { name: 'package-lock.json', hash: sha256('lock') }
+    const rootOnly = composeCacheHash({
+      lockfile,
+      packageJsons: [{ path: 'package.json', raw: root }],
+      npmrcs: [{ path: '.npmrc', hash: sha256('root-npmrc') }],
+      excludedFields: ['version'],
+    })
+    const withMember = composeCacheHash({
+      lockfile,
+      packageJsons: [{ path: 'package.json', raw: root }],
+      npmrcs: [
+        { path: '.npmrc', hash: sha256('root-npmrc') },
+        { path: 'apps/main/.npmrc', hash: sha256('member-npmrc') },
+      ],
+      excludedFields: ['version'],
+    })
+    expect(rootOnly).not.toBe(withMember)
+  })
+
+  test('input order of npmrcs does not affect the hash', () => {
+    const root = buf('{"name":"root"}')
+    const lockfile = { name: 'package-lock.json', hash: sha256('lock') }
+    const a = { path: '.npmrc', hash: sha256('root-npmrc') }
+    const b = { path: 'apps/main/.npmrc', hash: sha256('member-npmrc') }
+    expect(composeCacheHash({
+      lockfile,
+      packageJsons: [{ path: 'package.json', raw: root }],
+      npmrcs: [b, a],
+      excludedFields: ['version'],
+    })).toBe(composeCacheHash({
+      lockfile,
+      packageJsons: [{ path: 'package.json', raw: root }],
+      npmrcs: [a, b],
+      excludedFields: ['version'],
+    }))
+  })
+
   test('lockfile content change changes the hash', () => {
     const root = buf('{"name":"root"}')
     const a = composeCacheHash({
@@ -192,6 +281,11 @@ describe('composeCacheHash', () => {
   // and the same excluded fields must produce this exact digest in
   // terraform-provider-checkly's composeBundleChecksum. If you change this
   // fixture, mirror the change in the TF provider's test suite.
+  //
+  // NOTE: composeCacheHash also hashes `npmrc:` records (added for .npmrc
+  // bundling). This fixture has no .npmrc so the digest is unchanged, but
+  // projects that DO have an .npmrc will hash differently until the TF
+  // provider mirrors the npmrc record type.
   test('matches the cross-language parity fixture digest', () => {
     const lockfileBytes = buf('{"lockfileVersion":3}\n')
     const rootPackageJson = buf([

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/npmrc-example/.npmrc
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/npmrc-example/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.example.com/
+//registry.example.com/:_authToken=${NPM_TOKEN}

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/npmrc-example/apps/main/.npmrc
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/npmrc-example/apps/main/.npmrc
@@ -1,0 +1,1 @@
+@scope:registry=https://npm.example.com/

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/npmrc-example/apps/main/package.json
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/npmrc-example/apps/main/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "main",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "license": "ISC"
+}

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/npmrc-example/apps/main/playwright.config.js
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/npmrc-example/apps/main/playwright.config.js
@@ -1,0 +1,5 @@
+const { defineConfig } = require('@playwright/test')
+
+module.exports = defineConfig({
+  testDir: './tests'
+})

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/npmrc-example/apps/main/tests/.npmrc
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/npmrc-example/apps/main/tests/.npmrc
@@ -1,0 +1,4 @@
+; A .npmrc in a subdirectory that is not a workspace package root. Package
+; managers never read .npmrc from below the install directory, so this must NOT
+; be bundled.
+registry=https://should-not-be-bundled.example.com/

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/npmrc-example/apps/main/tests/foo.spec.js
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/npmrc-example/apps/main/tests/foo.spec.js
@@ -1,0 +1,2 @@
+// A test that pulls in no dependencies; the point of this fixture is to
+// exercise .npmrc bundling, not the import graph.

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/npmrc-example/package-lock.json
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/npmrc-example/package-lock.json
@@ -1,0 +1,24 @@
+{
+  "name": "npmrc-example",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "npmrc-example",
+      "version": "1.0.0",
+      "license": "ISC",
+      "workspaces": [
+        "apps/*"
+      ]
+    },
+    "apps/main": {
+      "version": "1.0.0",
+      "license": "ISC"
+    },
+    "node_modules/main": {
+      "resolved": "apps/main",
+      "link": true
+    }
+  }
+}

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/npmrc-example/package.json
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/npmrc-example/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "npmrc-example",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "license": "ISC",
+  "workspaces": [
+    "apps/*"
+  ]
+}

--- a/packages/cli/src/services/check-parser/__tests__/check-parser.spec.ts
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser.spec.ts
@@ -8,6 +8,8 @@ import { FixtureSandbox } from '../../../testing/fixture-sandbox.js'
 import { BunDetector, NpmDetector, PNpmDetector } from '../package-files/package-manager.js'
 import { FAUX_PACKAGE_DESCRIPTION } from '../faux-package.js'
 import { Workspace } from '../package-files/workspace.js'
+import { PlaywrightConfig } from '../../playwright-config.js'
+import { pathToPosix } from '../../util.js'
 
 const defaultNpmModules = [
   'timers', 'tls', 'url', 'util', 'zlib', '@faker-js/faker', '@opentelemetry/api', '@opentelemetry/sd-trace-base',
@@ -28,6 +30,56 @@ describe('dependency-parser - parser()', () => {
 
   afterAll(async () => {
     await fixt?.destroy()
+  })
+
+  describe('.npmrc bundling', () => {
+    const toAbsolutePath = (...filepath: string[]) => fixt.abspath('npmrc-example', ...filepath)
+
+    const rootNpmrc = () => pathToPosix(toAbsolutePath('.npmrc'))
+    const nestedNpmrc = () => pathToPosix(toAbsolutePath('apps', 'main', '.npmrc'))
+    // A .npmrc in a subdirectory that is not a workspace package root — must
+    // never be bundled, since package managers do not read .npmrc from below
+    // the install directory.
+    const subdirNpmrc = () => pathToPosix(toAbsolutePath('apps', 'main', 'tests', '.npmrc'))
+
+    let workspace: Workspace | undefined
+    beforeAll(async () => {
+      workspace = await new NpmDetector().lookupWorkspace(toAbsolutePath('.'))
+      expect(workspace).toBeDefined()
+    })
+
+    // Drives the real Playwright bundling entry point (getFilesAndDependencies),
+    // so the assertion also exercises the determineFileOps===0 routing that
+    // copies .npmrc into the bundle verbatim rather than trying to parse it.
+    const bundledPaths = async (restricted: boolean): Promise<string[]> => {
+      const parser = new Parser({
+        checkUnsupportedModules: false,
+        restricted,
+        workspace,
+      })
+      const configPath = toAbsolutePath('apps', 'main', 'playwright.config.js')
+      const pwConfig = new PlaywrightConfig(configPath, { testDir: './tests' })
+      const { files, errors } = await parser.getFilesAndDependencies(pwConfig)
+      expect(errors).toEqual([])
+      return files.map(f => f.filePath)
+    }
+
+    it('bundles the workspace-root and package-root .npmrc in unrestricted mode', async () => {
+      const paths = await bundledPaths(false)
+      expect(paths).toContain(rootNpmrc())
+      expect(paths).toContain(nestedNpmrc())
+    })
+
+    it('does not bundle a .npmrc below a package root', async () => {
+      const paths = await bundledPaths(false)
+      expect(paths).not.toContain(subdirNpmrc())
+    })
+
+    it('does not bundle .npmrc in restricted mode', async () => {
+      const paths = await bundledPaths(true)
+      expect(paths).not.toContain(rootNpmrc())
+      expect(paths).not.toContain(nestedNpmrc())
+    })
   })
 
   describe('unrestricted mode', () => {

--- a/packages/cli/src/services/check-parser/cache-hash.ts
+++ b/packages/cli/src/services/check-parser/cache-hash.ts
@@ -25,9 +25,22 @@ export interface LockfileInput {
   hash: Buffer
 }
 
+export interface NpmrcInput {
+  /**
+   * Forward-slash relative path matching the .npmrc's location in the eventual
+   * archive (e.g. ".npmrc" or "packages/app/.npmrc").
+   */
+  path: string
+  /**
+   * Raw 32-byte SHA-256 digest of the .npmrc contents.
+   */
+  hash: Buffer
+}
+
 export interface ComposeCacheHashInput {
   lockfile?: LockfileInput
   packageJsons: PackageJsonInput[]
+  npmrcs?: NpmrcInput[]
   excludedFields: string[]
 }
 
@@ -139,6 +152,9 @@ export function canonicalizePackageJson (raw: Buffer, excludedFields: string[]):
  *   2. One record per package.json sorted byte-wise by path, labeled
  *      `package.json:<relative/path>`, whose content is the canonicalized
  *      package.json bytes.
+ *   3. One record per .npmrc sorted byte-wise by path, labeled
+ *      `npmrc:<relative/path>`, whose content is the raw 32-byte SHA-256
+ *      digest of the .npmrc contents.
  */
 export function composeCacheHash (input: ComposeCacheHashInput): string {
   const hash = createHash('sha256')
@@ -166,6 +182,16 @@ export function composeCacheHash (input: ComposeCacheHashInput): string {
     writeRecord(`package.json:${entry.path}`, canonical)
   }
 
+  const sortedNpmrcs = [...(input.npmrcs ?? [])].sort((a, b) => {
+    if (a.path < b.path) return -1
+    if (a.path > b.path) return 1
+    return 0
+  })
+
+  for (const entry of sortedNpmrcs) {
+    writeRecord(`npmrc:${entry.path}`, entry.hash)
+  }
+
   return hash.digest('hex')
 }
 
@@ -176,15 +202,21 @@ function uint64BE (n: number): Buffer {
 }
 
 /**
- * Reads the workspace lockfile and every workspace package.json (root +
- * member packages) and returns the inputs needed by {@link composeCacheHash}.
+ * Reads the workspace lockfile, every workspace package.json, and every
+ * workspace `.npmrc` (root + member packages) and returns the inputs needed
+ * by {@link composeCacheHash}.
  *
  * Paths are normalized to forward slashes and made relative to the
  * workspace root so that they match what ends up in the bundle archive.
+ *
+ * `.npmrc` is hashed so that repointing a registry (which need not touch the
+ * lockfile) invalidates the bundle cache. Packages without an `.npmrc`
+ * contribute nothing, so a workspace with no `.npmrc` produces a hash
+ * identical to before this input existed.
  */
 export async function loadWorkspaceCacheHashInputs (
   workspace: Workspace,
-): Promise<{ lockfile?: LockfileInput, packageJsons: PackageJsonInput[] }> {
+): Promise<{ lockfile?: LockfileInput, packageJsons: PackageJsonInput[], npmrcs: NpmrcInput[] }> {
   const allPackages = [workspace.root, ...workspace.packages]
 
   const packageJsons = await Promise.all(allPackages.map(async pkg => {
@@ -196,6 +228,29 @@ export async function loadWorkspaceCacheHashInputs (
     }
   }))
 
+  const npmrcResults = await Promise.all(allPackages.map(async (pkg): Promise<NpmrcInput | undefined> => {
+    const npmrcPath = path.join(pkg.path, '.npmrc')
+    let bytes: Buffer
+    try {
+      bytes = await fs.readFile(npmrcPath)
+    } catch (err) {
+      // A missing .npmrc simply contributes nothing. Any other error (e.g.
+      // EACCES on a present file) must surface rather than silently dropping a
+      // file that would still be bundled — that would desync the cache key from
+      // the bundle contents.
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        return undefined
+      }
+      throw err
+    }
+    const rel = path.relative(workspace.root.path, npmrcPath)
+    return {
+      path: rel.split(path.sep).join('/'),
+      hash: createHash('sha256').update(bytes).digest(),
+    }
+  }))
+  const npmrcs = npmrcResults.filter((entry): entry is NpmrcInput => entry !== undefined)
+
   let lockfile: LockfileInput | undefined
   if (workspace.lockfile.isOk()) {
     const lockfilePath = workspace.lockfile.ok()
@@ -206,7 +261,7 @@ export async function loadWorkspaceCacheHashInputs (
     }
   }
 
-  return { lockfile, packageJsons }
+  return { lockfile, packageJsons, npmrcs }
 }
 
 /**

--- a/packages/cli/src/services/check-parser/package-files/resolver.ts
+++ b/packages/cli/src/services/check-parser/package-files/resolver.ts
@@ -17,6 +17,8 @@ import { Package, Workspace } from './workspace.js'
 
 const debug = Debug('checkly:cli:services:check-parser:resolver')
 
+const NPMRC_FILENAME = '.npmrc'
+
 /**
  * Candidate file paths for an `extends` target. TypeScript appends `.json` when
  * the specifier has no extension and falls back to `<dir>/tsconfig.json` when it
@@ -239,6 +241,12 @@ type WorkspaceRootConfigFileLocalDependency = {
   sourceFile: SourceFile
 }
 
+type WorkspaceNpmrcLocalDependency = {
+  kind: 'workspace-npmrc'
+  importPath: string
+  sourceFile: SourceFile
+}
+
 type NearestPackageJsonFileLocalDependency = {
   kind: 'nearest-package-json-file'
   importPath: string
@@ -306,6 +314,7 @@ type LocalDependency =
   | WorkspaceRootTSConfigFileLocalDependency
   | WorkspaceRootLockfileLocalDependency
   | WorkspaceRootConfigFileLocalDependency
+  | WorkspaceNpmrcLocalDependency
   | NearestPackageJsonFileLocalDependency
   | NearestTSConfigFileLocalDependency
   | SupportingTSConfigFileLocalDependency
@@ -579,6 +588,27 @@ export class PackageFilesResolver {
             kind: 'workspace-root-config-file',
             importPath: filePath,
             sourceFile: configFile,
+          })
+        }
+      }
+
+      // Bundle the .npmrc from the workspace root and every workspace member
+      // package root. These carry registry configuration (alternate registries,
+      // auth) that the cloud install needs to resolve dependencies. This is the
+      // exact set a package manager consults (project .npmrc is read from the
+      // install directory upward, never from subdirectories below it), and it
+      // matches the set fed into the workspace cache hash, so a bundled .npmrc
+      // is always reflected in the cache key.
+      for (const pkg of [this.workspace.root, ...this.workspace.packages]) {
+        const npmrc = await this.cache.exactSourceFile(
+          path.join(pkg.path, NPMRC_FILENAME),
+        )
+        if (npmrc !== undefined) {
+          debug('Found workspace .npmrc file %s', npmrc.meta.filePath)
+          resolved.local.push({
+            kind: 'workspace-npmrc',
+            importPath: filePath,
+            sourceFile: npmrc,
           })
         }
       }


### PR DESCRIPTION
Linear: RED-691

## What & why

Playwright Check Suites (PWCS) upload the project as a tarball and run the user's own package-manager `install` in the Checkly cloud. When a project uses an alternate/private npm registry configured in `.npmrc`, that file was only bundled if the user manually listed it in the `include` prop — otherwise the install resolved against the default registry and private packages failed to resolve.

This bundles `.npmrc` automatically for PWCS.

## How

- Routes `.npmrc` through the existing workspace/package-files machinery (the same path that already bundles the lockfile and `pnpm-workspace.yaml`), emitting it as a `workspace-npmrc` local dependency.
- Bundles the `.npmrc` at the **workspace root and every workspace-member package root** — exactly the set a package manager reads (project `.npmrc` is consulted from the install directory upward, never from subdirectories below it). A `.npmrc` below a package root is intentionally not bundled.
- Gated on non-restricted parsing, so only Playwright Check Suites are affected; Browser/Multistep/API check bundles are unchanged.
- Feeds the same root + member `.npmrc` set into the workspace cache hash, so changing a bundled `.npmrc` invalidates the bundle cache. The bundled set and the hashed set are identical by construction. Projects without an `.npmrc` hash byte-identically as before.
- Docs updated: `.npmrc` no longer needs a manual `include` entry, with a warning to reference credentials via `${NPM_TOKEN}` rather than embedding plaintext tokens (since the file is now uploaded automatically).

## Follow-up (cross-repo)

Adding `npmrc:` records to the workspace cache hash makes this hash diverge from the Terraform provider's `composeBundleChecksum` for projects that have an `.npmrc`, until the provider mirrors the record type. This is flagged in a code comment (`cache-hash.spec.ts`). Impact is a missed cache-reuse in the mixed-tool case, not incorrectness.

## Testing

- New fixture + unit tests: root and package-root `.npmrc` are bundled; a `.npmrc` below a package root is not; nothing is bundled in restricted mode.
- Cache-hash tests: adding/editing a root or member `.npmrc` changes the hash; a project with no `.npmrc` produces a byte-identical hash (no-op).
- Full `check-parser` + `cache-hash` suites, typecheck, and lint pass; `sync:skills` produces no drift.
