### PR TITLE
fix(cli): emit ocspStapled in SSL assertion codegen [SIM-313] [show]

### DIFF
--- a/packages/cli/src/constructs/__tests__/assertion-codegen.spec.ts
+++ b/packages/cli/src/constructs/__tests__/assertion-codegen.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+
+import { GeneratedFile } from '../../sourcegen/index.js'
+import { valueForAssertion } from '../api-assertion-codegen.js'
+import { valueForDnsAssertion } from '../dns-assertion-codegen.js'
+import { valueForGrpcAssertion } from '../grpc-assertion-codegen.js'
+import { valueForIcmpAssertion } from '../icmp-assertion-codegen.js'
+import { valueForSslAssertion } from '../ssl-assertion-codegen.js'
+import { valueForTcpAssertion } from '../tcp-monitor-codegen.js'
+import { valueForTracerouteAssertion } from '../traceroute-assertion-codegen.js'
+import { valueForUrlAssertion } from '../url-assertion-codegen.js'
+
+const genfile = new GeneratedFile('foo.ts')
+
+// A source no assertion union contains. The compile-time exhaustiveness guard is
+// what normally prevents this, so reaching it requires bypassing the type — wire
+// data from a newer backend can still carry such a source at runtime.
+const unknownSource = {
+  source: 'NOT_A_REAL_SOURCE',
+  property: '',
+  comparison: 'EQUALS',
+  target: 'x',
+  regex: null,
+} as unknown as never
+
+describe('unsupportedAssertionSource', () => {
+  // Locks the exact user-visible text of every assertion-source default clause.
+  // The shared helper builds these messages from an optional `kind`, so a
+  // regression there (an empty-string kind, a changed template) would otherwise
+  // pass silently — note the API check's message deliberately carries no kind word.
+  it.each([
+    ['API', () => valueForAssertion(genfile, unknownSource), 'Unsupported assertion source NOT_A_REAL_SOURCE'],
+    ['DNS', () => valueForDnsAssertion(genfile, unknownSource), 'Unsupported DNS assertion source NOT_A_REAL_SOURCE'],
+    ['gRPC', () => valueForGrpcAssertion(genfile, unknownSource), 'Unsupported gRPC assertion source NOT_A_REAL_SOURCE'],
+    ['ICMP', () => valueForIcmpAssertion(genfile, unknownSource), 'Unsupported ICMP assertion source NOT_A_REAL_SOURCE'],
+    ['SSL', () => valueForSslAssertion(genfile, unknownSource), 'Unsupported SSL assertion source NOT_A_REAL_SOURCE'],
+    ['TCP', () => valueForTcpAssertion(genfile, unknownSource), 'Unsupported TCP assertion source NOT_A_REAL_SOURCE'],
+    [
+      'traceroute',
+      () => valueForTracerouteAssertion(genfile, unknownSource),
+      'Unsupported traceroute assertion source NOT_A_REAL_SOURCE',
+    ],
+    ['URL', () => valueForUrlAssertion(genfile, unknownSource), 'Unsupported URL assertion source NOT_A_REAL_SOURCE'],
+  ])('%s codegen throws with its own message for an unknown source', (_name, valueFor, message) => {
+    let thrown: unknown
+    try {
+      valueFor()
+    } catch (err) {
+      thrown = err
+    }
+    expect(thrown).toBeInstanceOf(Error)
+    expect((thrown as Error).message).toBe(message)
+  })
+})

--- a/packages/cli/src/constructs/__tests__/uptime-monitor-codegen.spec.ts
+++ b/packages/cli/src/constructs/__tests__/uptime-monitor-codegen.spec.ts
@@ -181,6 +181,46 @@ describe('SslMonitorCodegen', () => {
     expect(source).toContain('certExpiresInDays()')
     expect(source).toContain('chainTrusted()')
   })
+
+  it('emits every SslAssertionBuilder source with its target', async () => {
+    const source = await renderResource(env, p => new SslMonitorCodegen(p), resource({
+      request: {
+        sslConfig: { hostname: 'example.com' },
+        assertions: [
+          { source: 'CERT_EXPIRES_IN_DAYS', property: '', comparison: 'GREATER_THAN', target: '20', regex: null },
+          { source: 'KEY_SIZE_BITS', property: '', comparison: 'EQUALS', target: '2048', regex: null },
+          { source: 'CERT_NOT_EXPIRED', property: '', comparison: 'EQUALS', target: 'true', regex: null },
+          { source: 'HOSTNAME_VERIFIED', property: '', comparison: 'EQUALS', target: 'true', regex: null },
+          { source: 'CHAIN_TRUSTED', property: '', comparison: 'EQUALS', target: 'true', regex: null },
+          { source: 'OCSP_STAPLED', property: '', comparison: 'EQUALS', target: 'true', regex: null },
+          { source: 'TLS_VERSION', property: '', comparison: 'EQUALS', target: 'TLS1.3', regex: null },
+          {
+            source: 'CIPHER_SUITE',
+            property: '',
+            comparison: 'EQUALS',
+            target: 'TLS_AES_256_GCM_SHA384',
+            regex: null,
+          },
+          { source: 'SIGNATURE_ALGORITHM', property: '', comparison: 'EQUALS', target: 'SHA256-RSA', regex: null },
+          { source: 'ISSUER_CN', property: '', comparison: 'EQUALS', target: 'Example CA', regex: null },
+          { source: 'CERT_FINGERPRINT_SHA256', property: '', comparison: 'EQUALS', target: 'abc123', regex: null },
+          { source: 'ISSUER_FINGERPRINT_SHA256', property: '', comparison: 'EQUALS', target: 'def456', regex: null },
+        ],
+      },
+    }))
+    expect(source).toContain('certExpiresInDays().greaterThan(20)')
+    expect(source).toContain('keySizeBits().equals(2048)')
+    expect(source).toContain('certNotExpired().equals(\'true\')')
+    expect(source).toContain('hostnameVerified().equals(\'true\')')
+    expect(source).toContain('chainTrusted().equals(\'true\')')
+    expect(source).toContain('ocspStapled().equals(\'true\')')
+    expect(source).toContain('tlsVersion().equals(\'TLS1.3\')')
+    expect(source).toContain('cipherSuite().equals(\'TLS_AES_256_GCM_SHA384\')')
+    expect(source).toContain('signatureAlgorithm().equals(\'SHA256-RSA\')')
+    expect(source).toContain('issuerCn().equals(\'Example CA\')')
+    expect(source).toContain('certFingerprintSha256().equals(\'abc123\')')
+    expect(source).toContain('issuerFingerprintSha256().equals(\'def456\')')
+  })
 })
 
 describe('TracerouteMonitorCodegen', () => {

--- a/packages/cli/src/constructs/api-assertion-codegen.ts
+++ b/packages/cli/src/constructs/api-assertion-codegen.ts
@@ -1,6 +1,6 @@
 import { GeneratedFile, Value } from '../sourcegen/index.js'
 import { Assertion } from './api-assertion.js'
-import { valueForGeneralAssertion, valueForNumericAssertion } from './internal/assertion-codegen.js'
+import { unsupportedAssertionSource, valueForGeneralAssertion, valueForNumericAssertion } from './internal/assertion-codegen.js'
 
 export function valueForAssertion (genfile: GeneratedFile, assertion: Assertion): Value {
   genfile.namedImport('AssertionBuilder', 'checkly/constructs')
@@ -17,6 +17,6 @@ export function valueForAssertion (genfile: GeneratedFile, assertion: Assertion)
     case 'RESPONSE_TIME':
       return valueForNumericAssertion('AssertionBuilder', 'responseTime', assertion)
     default:
-      throw new Error(`Unsupported assertion source ${assertion.source}`)
+      return unsupportedAssertionSource(assertion.source)
   }
 }

--- a/packages/cli/src/constructs/dns-assertion-codegen.ts
+++ b/packages/cli/src/constructs/dns-assertion-codegen.ts
@@ -1,5 +1,5 @@
 import { GeneratedFile, Value } from '../sourcegen/index.js'
-import { valueForGeneralAssertion, valueForNumericAssertion } from './internal/assertion-codegen.js'
+import { unsupportedAssertionSource, valueForGeneralAssertion, valueForNumericAssertion } from './internal/assertion-codegen.js'
 import { DnsAssertion } from './dns-assertion.js'
 
 export function valueForDnsAssertion (genfile: GeneratedFile, assertion: DnsAssertion): Value {
@@ -24,6 +24,6 @@ export function valueForDnsAssertion (genfile: GeneratedFile, assertion: DnsAsse
         hasRegex: false,
       })
     default:
-      throw new Error(`Unsupported DNS assertion source ${assertion.source}`)
+      return unsupportedAssertionSource(assertion.source, 'DNS')
   }
 }

--- a/packages/cli/src/constructs/grpc-assertion-codegen.ts
+++ b/packages/cli/src/constructs/grpc-assertion-codegen.ts
@@ -1,5 +1,5 @@
 import { GeneratedFile, Value } from '../sourcegen/index.js'
-import { valueForGeneralAssertion, valueForNumericAssertion } from './internal/assertion-codegen.js'
+import { unsupportedAssertionSource, valueForGeneralAssertion, valueForNumericAssertion } from './internal/assertion-codegen.js'
 import { GrpcAssertion } from './grpc-assertion.js'
 
 export function valueForGrpcAssertion (genfile: GeneratedFile, assertion: GrpcAssertion): Value {
@@ -31,6 +31,6 @@ export function valueForGrpcAssertion (genfile: GeneratedFile, assertion: GrpcAs
         hasRegex: false,
       })
     default:
-      throw new Error(`Unsupported gRPC assertion source ${assertion.source}`)
+      return unsupportedAssertionSource(assertion.source, 'gRPC')
   }
 }

--- a/packages/cli/src/constructs/icmp-assertion-codegen.ts
+++ b/packages/cli/src/constructs/icmp-assertion-codegen.ts
@@ -1,5 +1,5 @@
 import { GeneratedFile, Value } from '../sourcegen/index.js'
-import { valueForGeneralAssertion, valueForNumericAssertion } from './internal/assertion-codegen.js'
+import { unsupportedAssertionSource, valueForGeneralAssertion, valueForNumericAssertion } from './internal/assertion-codegen.js'
 import { IcmpAssertion } from './icmp-assertion.js'
 
 export function valueForIcmpAssertion (genfile: GeneratedFile, assertion: IcmpAssertion): Value {
@@ -16,6 +16,6 @@ export function valueForIcmpAssertion (genfile: GeneratedFile, assertion: IcmpAs
         hasRegex: false,
       })
     default:
-      throw new Error(`Unsupported ICMP assertion source ${assertion.source}`)
+      return unsupportedAssertionSource(assertion.source, 'ICMP')
   }
 }

--- a/packages/cli/src/constructs/internal/assertion-codegen.ts
+++ b/packages/cli/src/constructs/internal/assertion-codegen.ts
@@ -1,6 +1,19 @@
 import { expr, ident, Value } from '../../sourcegen/index.js'
 import { Assertion } from './assertion.js'
 
+/**
+ * Rejects an assertion source that has no codegen case.
+ *
+ * The `never` parameter makes an unhandled source a compile-time error: adding a
+ * member to a monitor's assertion source union without adding the matching codegen
+ * case fails to typecheck. The runtime throw remains because wire data may carry a
+ * source this version of the CLI does not know about.
+ */
+export function unsupportedAssertionSource (source: never, kind?: string): never {
+  const prefix = kind === undefined ? 'Unsupported' : `Unsupported ${kind}`
+  throw new Error(`${prefix} assertion source ${String(source)}`)
+}
+
 export interface ValueForNumericAssertionOptions {
   hasProperty?: boolean
 }

--- a/packages/cli/src/constructs/ssl-assertion-codegen.ts
+++ b/packages/cli/src/constructs/ssl-assertion-codegen.ts
@@ -1,5 +1,5 @@
 import { GeneratedFile, Value } from '../sourcegen/index.js'
-import { valueForGeneralAssertion, valueForNumericAssertion } from './internal/assertion-codegen.js'
+import { unsupportedAssertionSource, valueForGeneralAssertion, valueForNumericAssertion } from './internal/assertion-codegen.js'
 import { SslAssertion } from './ssl-assertion.js'
 
 const generalNoArgs = { hasProperty: false, hasRegex: false }
@@ -33,6 +33,6 @@ export function valueForSslAssertion (genfile: GeneratedFile, assertion: SslAsse
     case 'SIGNATURE_ALGORITHM':
       return valueForGeneralAssertion('SslAssertionBuilder', 'signatureAlgorithm', assertion, generalNoArgs)
     default:
-      throw new Error(`Unsupported SSL assertion source ${assertion.source}`)
+      return unsupportedAssertionSource(assertion.source, 'SSL')
   }
 }

--- a/packages/cli/src/constructs/ssl-assertion-codegen.ts
+++ b/packages/cli/src/constructs/ssl-assertion-codegen.ts
@@ -18,6 +18,8 @@ export function valueForSslAssertion (genfile: GeneratedFile, assertion: SslAsse
       return valueForGeneralAssertion('SslAssertionBuilder', 'hostnameVerified', assertion, generalNoArgs)
     case 'CHAIN_TRUSTED':
       return valueForGeneralAssertion('SslAssertionBuilder', 'chainTrusted', assertion, generalNoArgs)
+    case 'OCSP_STAPLED':
+      return valueForGeneralAssertion('SslAssertionBuilder', 'ocspStapled', assertion, generalNoArgs)
     case 'TLS_VERSION':
       return valueForGeneralAssertion('SslAssertionBuilder', 'tlsVersion', assertion, generalNoArgs)
     case 'CIPHER_SUITE':

--- a/packages/cli/src/constructs/tcp-monitor-codegen.ts
+++ b/packages/cli/src/constructs/tcp-monitor-codegen.ts
@@ -1,5 +1,5 @@
 import { expr, GeneratedFile, ident, Value } from '../sourcegen/index.js'
-import { valueForGeneralAssertion, valueForNumericAssertion } from './internal/assertion-codegen.js'
+import { unsupportedAssertionSource, valueForGeneralAssertion, valueForNumericAssertion } from './internal/assertion-codegen.js'
 import { Codegen, Context } from './internal/codegen/index.js'
 import { buildMonitorProps, MonitorResource } from './monitor-codegen.js'
 import { TcpAssertion, TcpRequest } from './tcp-monitor.js'
@@ -20,7 +20,7 @@ export function valueForTcpAssertion (genfile: GeneratedFile, assertion: TcpAsse
     case 'RESPONSE_TIME':
       return valueForNumericAssertion('TcpAssertionBuilder', 'responseTime', assertion)
     default:
-      throw new Error(`Unsupported TCP assertion source ${assertion.source}`)
+      return unsupportedAssertionSource(assertion.source, 'TCP')
   }
 }
 

--- a/packages/cli/src/constructs/traceroute-assertion-codegen.ts
+++ b/packages/cli/src/constructs/traceroute-assertion-codegen.ts
@@ -1,5 +1,5 @@
 import { GeneratedFile, Value } from '../sourcegen/index.js'
-import { valueForNumericAssertion } from './internal/assertion-codegen.js'
+import { unsupportedAssertionSource, valueForNumericAssertion } from './internal/assertion-codegen.js'
 import { TracerouteAssertion } from './traceroute-assertion.js'
 
 export function valueForTracerouteAssertion (genfile: GeneratedFile, assertion: TracerouteAssertion): Value {
@@ -13,6 +13,6 @@ export function valueForTracerouteAssertion (genfile: GeneratedFile, assertion: 
     case 'PACKET_LOSS':
       return valueForNumericAssertion('TracerouteAssertionBuilder', 'packetLoss', assertion)
     default:
-      throw new Error(`Unsupported traceroute assertion source ${assertion.source}`)
+      return unsupportedAssertionSource(assertion.source, 'traceroute')
   }
 }

--- a/packages/cli/src/constructs/url-assertion-codegen.ts
+++ b/packages/cli/src/constructs/url-assertion-codegen.ts
@@ -1,6 +1,6 @@
 import { GeneratedFile, Value } from '../sourcegen/index.js'
 import { UrlAssertion } from './url-assertion.js'
-import { valueForNumericAssertion } from './internal/assertion-codegen.js'
+import { unsupportedAssertionSource, valueForNumericAssertion } from './internal/assertion-codegen.js'
 
 export function valueForUrlAssertion (genfile: GeneratedFile, assertion: UrlAssertion): Value {
   genfile.namedImport('UrlAssertionBuilder', 'checkly/constructs')
@@ -9,6 +9,6 @@ export function valueForUrlAssertion (genfile: GeneratedFile, assertion: UrlAsse
     case 'STATUS_CODE':
       return valueForNumericAssertion('UrlAssertionBuilder', 'statusCode', assertion)
     default:
-      throw new Error(`Unsupported URL assertion source ${assertion.source}`)
+      return unsupportedAssertionSource(assertion.source, 'URL')
   }
 }


### PR DESCRIPTION
Linear: SIM-313

## What this fixes

`checkly import` throws `Unsupported SSL assertion source OCSP_STAPLED` and aborts whenever it renders an existing SSL monitor that carries an OCSP-stapling assertion. Users who configured that assertion in the UI cannot export it to code.

#1392 added `'OCSP_STAPLED'` to the `SslAssertionSource` union and `SslAssertionBuilder.ocspStapled()`, but never added the matching case to `valueForSslAssertion`. The switch fell through to its `default: throw`.

## Why it wasn't caught

The `switch (assertion.source)` ends in `default: throw`, which leaves it **non-exhaustive at compile time** — adding a member to the union produces no type error, so `tsc` stayed green and the gap only surfaced as a runtime throw. Coverage was thin too: the SSL codegen round-trip test exercised only `CERT_EXPIRES_IN_DAYS` and `CHAIN_TRUSTED`.

## Changes

**1. `fix(cli): emit ocspStapled in SSL assertion codegen`**

Adds `case 'OCSP_STAPLED'` to `valueForSslAssertion`, mapping to `ocspStapled` with the existing `generalNoArgs` shape — identical to the neighbouring `chainTrusted` / `hostnameVerified` / `certNotExpired` cases. Extends the codegen round-trip test to cover all 12 SSL assertion sources with their exact emitted call chains.

**2. `refactor(cli): make assertion-source codegen switches exhaustive`**

Addresses the root cause. Adds a shared guard in `internal/assertion-codegen.ts`:

```ts
export function unsupportedAssertionSource (source: never, kind?: string): never
```

and uses it as the `default:` in all eight assertion-source switches (api, dns, grpc, icmp, ssl, tcp, traceroute, url). Because `Assertion<Source>.source` is typed as the literal union, TypeScript narrows it to `never` in an exhaustive `default:`, so an unhandled member now **fails to compile**. The runtime throw is retained because wire data may carry a source this version of the CLI does not know about.

`kind` is optional so the API check's message — which has no kind word — stays byte-identical. All eight messages are unchanged and are now locked by `assertion-codegen.spec.ts`.

The *comparison* switches cannot be guarded the same way: `Assertion.comparison` is typed `string` rather than the `Comparison` union, which would require retyping wire data.

## Verification

- The new codegen test fails with `Unsupported SSL assertion source OCSP_STAPLED` before the fix and passes after.
- The exhaustiveness guard was verified to bite: temporarily adding `| 'BOGUS_SOURCE'` to `SslAssertionSource` fails with `error TS2345: Argument of type '"BOGUS_SOURCE"' is not assignable to parameter of type 'never'`.
- `assertion-codegen.spec.ts` was mutation-tested: rewriting the helper's prefix to `` `Unsupported ${kind ?? ''}` `` makes the API row fail on the resulting double space.
- `tsc --build` clean, `eslint` clean, full unit suite 115 files / 1464 passed / 2 skipped.

## Follow-up (not in this PR)

The same `default: throw` non-exhaustiveness remains in `check-codegen.ts` (two `switch (checkType)` sites), `alert-escalation-policy-codegen.ts`, and `retry-strategy-codegen.ts`. The last needs its `as RetryStrategyType` cast removed before a `never` guard would take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
