### PR TITLE
Forward GitHub Check name metadata [ship]

### DIFF
--- a/packages/cli/src/rest/__tests__/test-sessions.spec.ts
+++ b/packages/cli/src/rest/__tests__/test-sessions.spec.ts
@@ -7,7 +7,10 @@ describe('TestSessions REST client', () => {
     commitId: 'abc123',
     github: {
       reporting: true,
+      source: 'checkly-action',
       checkName: 'Checkly PR code checks',
+      pullRequestNumber: '5',
+      environmentUrl: 'https://preview.example.com',
       repository: 'checkly/playwright-reporter-demo',
       sha: 'abc123',
       runId: '123456',

--- a/packages/cli/src/rest/__tests__/test-sessions.spec.ts
+++ b/packages/cli/src/rest/__tests__/test-sessions.spec.ts
@@ -7,6 +7,7 @@ describe('TestSessions REST client', () => {
     commitId: 'abc123',
     github: {
       reporting: true,
+      checkName: 'Checkly PR code checks',
       repository: 'checkly/playwright-reporter-demo',
       sha: 'abc123',
       runId: '123456',

--- a/packages/cli/src/rest/__tests__/test-sessions.spec.ts
+++ b/packages/cli/src/rest/__tests__/test-sessions.spec.ts
@@ -8,7 +8,7 @@ describe('TestSessions REST client', () => {
     github: {
       reporting: true,
       source: 'checkly-action',
-      checkName: 'Checkly PR code checks',
+      githubCheckName: 'Checkly PR code checks',
       pullRequestNumber: '5',
       environmentUrl: 'https://preview.example.com',
       repository: 'checkly/playwright-reporter-demo',

--- a/packages/cli/src/services/__tests__/util.spec.ts
+++ b/packages/cli/src/services/__tests__/util.spec.ts
@@ -121,7 +121,7 @@ describe('util', () => {
         github: {
           reporting: true,
           source: 'checkly-action',
-          checkName: 'Checkly PR code checks',
+          githubCheckName: 'Checkly PR code checks',
           pullRequestNumber: '5',
           environmentUrl: 'https://preview.example.com',
           repository: 'checkly/playwright-reporter-demo',

--- a/packages/cli/src/services/__tests__/util.spec.ts
+++ b/packages/cli/src/services/__tests__/util.spec.ts
@@ -12,6 +12,7 @@ const ENV_KEYS = [
   'CHECKLY_REPO_URL',
   'CHECKLY_REPO_BRANCH',
   'CHECKLY_GITHUB_REPORT',
+  'CHECKLY_GITHUB_CHECK_NAME',
   'CHECKLY_GITHUB_REPOSITORY',
   'CHECKLY_GITHUB_SHA',
   'CHECKLY_GITHUB_RUN_ID',
@@ -95,6 +96,7 @@ describe('util', () => {
 
     it('should include GitHub Actions metadata when Checkly GitHub reporting is enabled', () => {
       process.env.CHECKLY_GITHUB_REPORT = 'true'
+      process.env.CHECKLY_GITHUB_CHECK_NAME = 'Checkly PR code checks'
       process.env.CHECKLY_GITHUB_REPOSITORY = 'checkly/playwright-reporter-demo'
       process.env.CHECKLY_GITHUB_SHA = 'abc123def456'
       process.env.CHECKLY_GITHUB_RUN_ID = '123456'
@@ -112,6 +114,7 @@ describe('util', () => {
         repoUrl: 'https://github.com/checkly/playwright-reporter-demo',
         github: {
           reporting: true,
+          checkName: 'Checkly PR code checks',
           repository: 'checkly/playwright-reporter-demo',
           sha: 'abc123def456',
           runId: '123456',

--- a/packages/cli/src/services/__tests__/util.spec.ts
+++ b/packages/cli/src/services/__tests__/util.spec.ts
@@ -12,7 +12,10 @@ const ENV_KEYS = [
   'CHECKLY_REPO_URL',
   'CHECKLY_REPO_BRANCH',
   'CHECKLY_GITHUB_REPORT',
+  'CHECKLY_GITHUB_SOURCE',
   'CHECKLY_GITHUB_CHECK_NAME',
+  'CHECKLY_GITHUB_PULL_REQUEST_NUMBER',
+  'CHECKLY_GITHUB_ENVIRONMENT_URL',
   'CHECKLY_GITHUB_REPOSITORY',
   'CHECKLY_GITHUB_SHA',
   'CHECKLY_GITHUB_RUN_ID',
@@ -96,7 +99,10 @@ describe('util', () => {
 
     it('should include GitHub Actions metadata when Checkly GitHub reporting is enabled', () => {
       process.env.CHECKLY_GITHUB_REPORT = 'true'
+      process.env.CHECKLY_GITHUB_SOURCE = 'checkly-action'
       process.env.CHECKLY_GITHUB_CHECK_NAME = 'Checkly PR code checks'
+      process.env.CHECKLY_GITHUB_PULL_REQUEST_NUMBER = '5'
+      process.env.CHECKLY_GITHUB_ENVIRONMENT_URL = 'https://preview.example.com'
       process.env.CHECKLY_GITHUB_REPOSITORY = 'checkly/playwright-reporter-demo'
       process.env.CHECKLY_GITHUB_SHA = 'abc123def456'
       process.env.CHECKLY_GITHUB_RUN_ID = '123456'
@@ -114,7 +120,10 @@ describe('util', () => {
         repoUrl: 'https://github.com/checkly/playwright-reporter-demo',
         github: {
           reporting: true,
+          source: 'checkly-action',
           checkName: 'Checkly PR code checks',
+          pullRequestNumber: '5',
+          environmentUrl: 'https://preview.example.com',
           repository: 'checkly/playwright-reporter-demo',
           sha: 'abc123def456',
           runId: '123456',

--- a/packages/cli/src/services/util.ts
+++ b/packages/cli/src/services/util.ts
@@ -20,7 +20,10 @@ export interface GitInformation {
 
 export interface GitHubActionsInformation {
   reporting: true
+  source?: string
   checkName?: string
+  pullRequestNumber?: string
+  environmentUrl?: string
   repository?: string
   sha?: string
   runId?: string
@@ -150,7 +153,10 @@ export function getGitInformation (repoUrl?: string): GitInformation | null {
   if (isGitHubReportingEnabled()) {
     gitInformation.github = {
       reporting: true,
+      source: process.env.CHECKLY_GITHUB_SOURCE,
       checkName: process.env.CHECKLY_GITHUB_CHECK_NAME,
+      pullRequestNumber: process.env.CHECKLY_GITHUB_PULL_REQUEST_NUMBER,
+      environmentUrl: process.env.CHECKLY_GITHUB_ENVIRONMENT_URL,
       repository: process.env.CHECKLY_GITHUB_REPOSITORY,
       sha: process.env.CHECKLY_GITHUB_SHA,
       runId: process.env.CHECKLY_GITHUB_RUN_ID,

--- a/packages/cli/src/services/util.ts
+++ b/packages/cli/src/services/util.ts
@@ -20,6 +20,7 @@ export interface GitInformation {
 
 export interface GitHubActionsInformation {
   reporting: true
+  checkName?: string
   repository?: string
   sha?: string
   runId?: string
@@ -149,6 +150,7 @@ export function getGitInformation (repoUrl?: string): GitInformation | null {
   if (isGitHubReportingEnabled()) {
     gitInformation.github = {
       reporting: true,
+      checkName: process.env.CHECKLY_GITHUB_CHECK_NAME,
       repository: process.env.CHECKLY_GITHUB_REPOSITORY,
       sha: process.env.CHECKLY_GITHUB_SHA,
       runId: process.env.CHECKLY_GITHUB_RUN_ID,

--- a/packages/cli/src/services/util.ts
+++ b/packages/cli/src/services/util.ts
@@ -21,7 +21,7 @@ export interface GitInformation {
 export interface GitHubActionsInformation {
   reporting: true
   source?: string
-  checkName?: string
+  githubCheckName?: string
   pullRequestNumber?: string
   environmentUrl?: string
   repository?: string
@@ -154,7 +154,7 @@ export function getGitInformation (repoUrl?: string): GitInformation | null {
     gitInformation.github = {
       reporting: true,
       source: process.env.CHECKLY_GITHUB_SOURCE,
-      checkName: process.env.CHECKLY_GITHUB_CHECK_NAME,
+      githubCheckName: process.env.CHECKLY_GITHUB_CHECK_NAME,
       pullRequestNumber: process.env.CHECKLY_GITHUB_PULL_REQUEST_NUMBER,
       environmentUrl: process.env.CHECKLY_GITHUB_ENVIRONMENT_URL,
       repository: process.env.CHECKLY_GITHUB_REPOSITORY,


### PR DESCRIPTION
## Summary
- Add optional `checkName` to GitHub Actions metadata captured by `getGitInformation()`.
- Forward `CHECKLY_GITHUB_CHECK_NAME` through detached test-session and trigger payloads.

## Testing
- `pnpm --filter checkly exec vitest --run src/services/__tests__/util.spec.ts src/rest/__tests__/test-sessions.spec.ts`