### PR TITLE
Refine AI agent operator detection [ship]

### DIFF
--- a/packages/cli/src/helpers/__tests__/cli-mode.spec.ts
+++ b/packages/cli/src/helpers/__tests__/cli-mode.spec.ts
@@ -1,218 +1,343 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { detectOperator, detectCliMode } from '../cli-mode.js'
 
 const operatorEnvVars = [
-  'CLAUDECODE', 'CURSOR_TRACE_ID', 'CURSOR_AGENT', 'TERM_PROGRAM', 'GITHUB_COPILOT',
-  'AIDER', 'WINDSURF', 'CODEIUM_ENV', 'CLINE_ACTIVE', 'CODEX_SANDBOX', 'CODEX_THREAD_ID',
-  'GEMINI_CLI', 'OPENCODE', 'GITHUB_ACTIONS', 'GITLAB_CI', 'CI',
-]
+  'AI_AGENT', 'AGENT', 'CLAUDECODE', 'CLAUDE_CODE', 'CLAUDE_CODE_IS_COWORK',
+  'AMP_CURRENT_THREAD_ID', 'CURSOR_TRACE_ID', 'CURSOR_AGENT', 'CURSOR_EXTENSION_HOST_ROLE',
+  'TERM_PROGRAM', 'VSCODE_AGENT', 'COPILOT_AGENT', 'COPILOT_CLI', 'GITHUB_COPILOT',
+  'COPILOT_MODEL', 'COPILOT_ALLOW_ALL', 'COPILOT_GITHUB_TOKEN', 'AIDER', 'WINDSURF',
+  'WINDSURF_AGENT', 'CODEIUM_ENV', 'CLINE_ACTIVE', 'CODEX_SANDBOX', 'CODEX_CI',
+  'CODEX_THREAD_ID', 'GEMINI_CLI', 'OPENCODE', 'ANTIGRAVITY_AGENT', 'AUGMENT_AGENT',
+  'ANDROID_STUDIO_AGENT', 'KIRO_AGENT_PATH', 'TRAE_AI_SHELL_ID', 'GOOSE_TERMINAL',
+  'GITHUB_AW', 'REPL_ID', 'MONOSPACE_ENV', 'GITHUB_ACTIONS', 'GITLAB_CI', 'CI',
+  'CHECKLY_CLI_MODE', 'HOME', 'PATH',
+] as const
+
+const originalEnv = Object.fromEntries(operatorEnvVars.map(key => [key, process.env[key]]))
+const noAgentFiles = () => false
+
+beforeEach(() => {
+  for (const key of operatorEnvVars) delete process.env[key]
+})
+
+afterEach(() => {
+  for (const key of operatorEnvVars) {
+    const value = originalEnv[key]
+    if (value === undefined) delete process.env[key]
+    else process.env[key] = value
+  }
+})
 
 describe('detectOperator', () => {
-  beforeEach(() => {
-    for (const key of operatorEnvVars) delete process.env[key]
-  })
-
   it('returns "manual" when no agent env vars are set', () => {
-    expect(detectOperator()).toBe('manual')
+    expect(detectOperator(noAgentFiles)).toBe('manual')
   })
 
   it('detects Claude Code', () => {
     process.env.CLAUDECODE = '1'
-    expect(detectOperator()).toBe('claude-code')
+    expect(detectOperator(noAgentFiles)).toBe('claude-code')
   })
 
   it('detects Cursor via CURSOR_TRACE_ID', () => {
     process.env.CURSOR_TRACE_ID = 'some-trace-id'
-    expect(detectOperator()).toBe('cursor')
+    expect(detectOperator(noAgentFiles)).toBe('cursor')
   })
 
   it('detects Cursor via CURSOR_AGENT', () => {
     process.env.CURSOR_AGENT = '1'
-    expect(detectOperator()).toBe('cursor')
+    expect(detectOperator(noAgentFiles)).toBe('cursor')
   })
 
   it('detects VS Code', () => {
     process.env.TERM_PROGRAM = 'vscode'
-    expect(detectOperator()).toBe('vscode')
+    expect(detectOperator(noAgentFiles)).toBe('vscode')
   })
 
   it('does not detect VS Code for other TERM_PROGRAM values', () => {
     process.env.TERM_PROGRAM = 'iTerm.app'
-    expect(detectOperator()).toBe('manual')
+    expect(detectOperator(noAgentFiles)).toBe('manual')
   })
 
   it('detects GitHub Copilot', () => {
     process.env.GITHUB_COPILOT = '1'
-    expect(detectOperator()).toBe('github-copilot')
+    expect(detectOperator(noAgentFiles)).toBe('github-copilot')
   })
 
   it('detects Aider', () => {
     process.env.AIDER = '1'
-    expect(detectOperator()).toBe('aider')
+    expect(detectOperator(noAgentFiles)).toBe('aider')
   })
 
   it('detects Windsurf via WINDSURF env var', () => {
     process.env.WINDSURF = '1'
-    expect(detectOperator()).toBe('windsurf')
+    expect(detectOperator(noAgentFiles)).toBe('windsurf')
   })
 
   it('detects Windsurf via CODEIUM_ENV env var', () => {
     process.env.CODEIUM_ENV = 'production'
-    expect(detectOperator()).toBe('windsurf')
+    expect(detectOperator(noAgentFiles)).toBe('windsurf')
   })
 
   it('detects GitHub Actions', () => {
     process.env.GITHUB_ACTIONS = 'true'
-    expect(detectOperator()).toBe('github-actions')
+    expect(detectOperator(noAgentFiles)).toBe('github-actions')
   })
 
   it('detects GitLab CI', () => {
     process.env.GITLAB_CI = 'true'
-    expect(detectOperator()).toBe('gitlab-ci')
+    expect(detectOperator(noAgentFiles)).toBe('gitlab-ci')
   })
 
   it('detects Cline', () => {
     process.env.CLINE_ACTIVE = '1'
-    expect(detectOperator()).toBe('cline')
+    expect(detectOperator(noAgentFiles)).toBe('cline')
   })
 
   it('detects Codex CLI via CODEX_SANDBOX', () => {
     process.env.CODEX_SANDBOX = '1'
-    expect(detectOperator()).toBe('codex-cli')
+    expect(detectOperator(noAgentFiles)).toBe('codex-cli')
   })
 
   it('detects Codex CLI via CODEX_THREAD_ID', () => {
     process.env.CODEX_THREAD_ID = 'thread-123'
-    expect(detectOperator()).toBe('codex-cli')
+    expect(detectOperator(noAgentFiles)).toBe('codex-cli')
   })
 
   it('detects Gemini CLI', () => {
     process.env.GEMINI_CLI = '1'
-    expect(detectOperator()).toBe('gemini-cli')
+    expect(detectOperator(noAgentFiles)).toBe('gemini-cli')
   })
 
   it('detects OpenCode', () => {
     process.env.OPENCODE = '1'
-    expect(detectOperator()).toBe('opencode')
+    expect(detectOperator(noAgentFiles)).toBe('opencode')
+  })
+
+  it.each([
+    { key: 'CLAUDE_CODE', value: '1', expected: 'claude-code' },
+    { key: 'AMP_CURRENT_THREAD_ID', value: 'thread-123', expected: 'amp' },
+    { key: 'CURSOR_EXTENSION_HOST_ROLE', value: 'agent-exec', expected: 'cursor' },
+    { key: 'VSCODE_AGENT', value: '1', expected: 'vscode-agent' },
+    { key: 'COPILOT_AGENT', value: '1', expected: 'vscode-agent' },
+    { key: 'COPILOT_CLI', value: '1', expected: 'github-copilot-cli' },
+    { key: 'COPILOT_MODEL', value: 'gpt-5', expected: 'github-copilot' },
+    { key: 'WINDSURF_AGENT', value: '1', expected: 'windsurf' },
+    { key: 'CODEX_CI', value: '1', expected: 'codex-cli' },
+    { key: 'ANTIGRAVITY_AGENT', value: '1', expected: 'antigravity' },
+    { key: 'AUGMENT_AGENT', value: '1', expected: 'augment-cli' },
+    { key: 'ANDROID_STUDIO_AGENT', value: '1', expected: 'android-studio-agent' },
+    { key: 'KIRO_AGENT_PATH', value: '/path/to/kiro-agent', expected: 'kiro-agent' },
+    { key: 'TRAE_AI_SHELL_ID', value: 'shell-123', expected: 'trae' },
+    { key: 'GOOSE_TERMINAL', value: '1', expected: 'goose' },
+    { key: 'GITHUB_AW', value: 'true', expected: 'github-agentic-workflow' },
+    { key: 'REPL_ID', value: 'workspace-123', expected: 'replit' },
+  ])('detects $key as $expected', ({ key, value, expected }) => {
+    process.env[key] = value
+    expect(detectOperator(noAgentFiles)).toBe(expected)
+    expect(detectCliMode(noAgentFiles)).toBe(key === 'REPL_ID' ? 'interactive' : 'agent')
+  })
+
+  it('detects named generic agent markers and normalizes known aliases', () => {
+    process.env.AI_AGENT = ' github_copilot_vscode_agent '
+    expect(detectOperator(noAgentFiles)).toBe('vscode-agent')
+
+    delete process.env.AI_AGENT
+    process.env.AGENT = 'goose'
+    expect(detectOperator(noAgentFiles)).toBe('goose')
+  })
+
+  it('uses a specific agent marker over a boolean generic marker', () => {
+    process.env.AGENT = '1'
+    process.env.OPENCODE = '1'
+    expect(detectOperator(noAgentFiles)).toBe('opencode')
+  })
+
+  it('uses a safe generic operator for invalid explicit agent names', () => {
+    process.env.AI_AGENT = 'invalid\nheader'
+    expect(detectOperator(noAgentFiles)).toBe('agent')
+  })
+
+  it('does not allow an explicit agent marker to report itself as manual', () => {
+    process.env.AI_AGENT = 'manual'
+    expect(detectOperator(noAgentFiles)).toBe('agent')
+  })
+
+  it('ignores explicitly disabled generic agent markers', () => {
+    process.env.AI_AGENT = 'false'
+    process.env.AGENT = '0'
+    expect(detectOperator(noAgentFiles)).toBe('manual')
+  })
+
+  it('prioritizes Claude Cowork over its shared Claude Code marker', () => {
+    process.env.CLAUDE_CODE_IS_COWORK = '1'
+    process.env.CLAUDECODE = '1'
+    expect(detectOperator(noAgentFiles)).toBe('claude-cowork')
+  })
+
+  it('detects Devin via its sandbox filesystem marker', () => {
+    expect(detectOperator(path => path === '/opt/.devin')).toBe('devin')
+  })
+
+  it('detects Jules only when its user and VM marker agree', () => {
+    process.env.HOME = '/home/jules'
+    expect(detectOperator(path => path === '/opt/environment_summary.sh')).toBe('jules')
+    expect(detectCliMode(path => path === '/opt/environment_summary.sh')).toBe('agent')
+  })
+
+  it('detects Pi from its agent path segment', () => {
+    process.env.PATH = '/usr/bin:/home/user/.pi/agent/bin'
+    expect(detectOperator(noAgentFiles)).toBe('pi')
+    expect(detectCliMode(noAgentFiles)).toBe('agent')
+  })
+
+  it('detects Firebase Studio without claiming its terminal is agent-driven', () => {
+    process.env.MONOSPACE_ENV = 'true'
+    expect(detectOperator(noAgentFiles)).toBe('firebase-studio')
+    expect(detectCliMode(noAgentFiles)).toBe('interactive')
   })
 
   it('detects generic CI', () => {
     process.env.CI = 'true'
-    expect(detectOperator()).toBe('ci')
+    expect(detectOperator(noAgentFiles)).toBe('ci')
   })
 
   it('prioritizes Cline over VS Code (Cline is a VS Code extension)', () => {
     process.env.CLINE_ACTIVE = '1'
     process.env.TERM_PROGRAM = 'vscode'
-    expect(detectOperator()).toBe('cline')
+    expect(detectOperator(noAgentFiles)).toBe('cline')
   })
 
   it('prioritizes Claude Code over CI', () => {
     process.env.CLAUDECODE = '1'
     process.env.CI = 'true'
-    expect(detectOperator()).toBe('claude-code')
+    expect(detectOperator(noAgentFiles)).toBe('claude-code')
   })
 
   it('prioritizes GitHub Actions over generic CI', () => {
     process.env.GITHUB_ACTIONS = 'true'
     process.env.CI = 'true'
-    expect(detectOperator()).toBe('github-actions')
+    expect(detectOperator(noAgentFiles)).toBe('github-actions')
+  })
+
+  it('prioritizes CI over broad IDE environment markers', () => {
+    process.env.CI = 'true'
+    process.env.TERM_PROGRAM = 'vscode'
+    expect(detectOperator(noAgentFiles)).toBe('ci')
   })
 })
 
 describe('detectCliMode', () => {
-  beforeEach(() => {
-    delete process.env.CHECKLY_CLI_MODE
-    for (const key of operatorEnvVars) delete process.env[key]
-  })
-
   it('returns "interactive" by default', () => {
-    expect(detectCliMode()).toBe('interactive')
+    expect(detectCliMode(noAgentFiles)).toBe('interactive')
   })
 
   it('returns "agent" when operator is claude-code', () => {
     process.env.CLAUDECODE = '1'
-    expect(detectCliMode()).toBe('agent')
+    expect(detectCliMode(noAgentFiles)).toBe('agent')
   })
 
   it('returns "agent" when operator is cursor', () => {
     process.env.CURSOR_TRACE_ID = 'trace'
-    expect(detectCliMode()).toBe('agent')
+    expect(detectCliMode(noAgentFiles)).toBe('agent')
   })
 
   it('returns "agent" when operator is windsurf', () => {
     process.env.WINDSURF = '1'
-    expect(detectCliMode()).toBe('agent')
+    expect(detectCliMode(noAgentFiles)).toBe('agent')
   })
 
   it('returns "agent" when operator is aider', () => {
     process.env.AIDER = '1'
-    expect(detectCliMode()).toBe('agent')
+    expect(detectCliMode(noAgentFiles)).toBe('agent')
   })
 
   it('returns "agent" when operator is github-copilot', () => {
     process.env.GITHUB_COPILOT = '1'
-    expect(detectCliMode()).toBe('agent')
+    expect(detectCliMode(noAgentFiles)).toBe('agent')
   })
 
   it('returns "agent" when operator is cline', () => {
     process.env.CLINE_ACTIVE = '1'
-    expect(detectCliMode()).toBe('agent')
+    expect(detectCliMode(noAgentFiles)).toBe('agent')
   })
 
   it('returns "agent" when operator is codex-cli', () => {
     process.env.CODEX_SANDBOX = '1'
-    expect(detectCliMode()).toBe('agent')
+    expect(detectCliMode(noAgentFiles)).toBe('agent')
   })
 
   it('returns "agent" when operator is gemini-cli', () => {
     process.env.GEMINI_CLI = '1'
-    expect(detectCliMode()).toBe('agent')
+    expect(detectCliMode(noAgentFiles)).toBe('agent')
   })
 
   it('returns "agent" when operator is opencode', () => {
     process.env.OPENCODE = '1'
-    expect(detectCliMode()).toBe('agent')
+    expect(detectCliMode(noAgentFiles)).toBe('agent')
+  })
+
+  it('returns "agent" for current VS Code agent commands', () => {
+    process.env.VSCODE_AGENT = '1'
+    expect(detectCliMode(noAgentFiles)).toBe('agent')
+  })
+
+  it('returns "agent" for custom explicit agent names', () => {
+    process.env.AI_AGENT = 'my-company-agent'
+    expect(detectCliMode(noAgentFiles)).toBe('agent')
+  })
+
+  it('returns "agent" for Devin filesystem markers', () => {
+    expect(detectCliMode(path => path === '/opt/.devin')).toBe('agent')
+  })
+
+  it('keeps a generic Replit workspace interactive', () => {
+    process.env.REPL_ID = 'workspace-123'
+    expect(detectCliMode(noAgentFiles)).toBe('interactive')
+  })
+
+  it('keeps a generic Kiro terminal interactive', () => {
+    process.env.TERM_PROGRAM = 'kiro'
+    expect(detectCliMode(noAgentFiles)).toBe('interactive')
   })
 
   it('returns "ci" when operator is github-actions', () => {
     process.env.GITHUB_ACTIONS = 'true'
-    expect(detectCliMode()).toBe('ci')
+    expect(detectCliMode(noAgentFiles)).toBe('ci')
   })
 
   it('returns "ci" when operator is gitlab-ci', () => {
     process.env.GITLAB_CI = 'true'
-    expect(detectCliMode()).toBe('ci')
+    expect(detectCliMode(noAgentFiles)).toBe('ci')
   })
 
   it('returns "ci" when operator is generic ci', () => {
     process.env.CI = 'true'
-    expect(detectCliMode()).toBe('ci')
+    expect(detectCliMode(noAgentFiles)).toBe('ci')
   })
 
   it('returns "interactive" for vscode (not an agent)', () => {
     process.env.TERM_PROGRAM = 'vscode'
-    expect(detectCliMode()).toBe('interactive')
+    expect(detectCliMode(noAgentFiles)).toBe('interactive')
   })
 
   it('env var CHECKLY_CLI_MODE overrides auto-detection', () => {
     process.env.CLAUDECODE = '1'
     process.env.CHECKLY_CLI_MODE = 'interactive'
-    expect(detectCliMode()).toBe('interactive')
+    expect(detectCliMode(noAgentFiles)).toBe('interactive')
   })
 
   it('env var CHECKLY_CLI_MODE=agent forces agent mode', () => {
     process.env.CHECKLY_CLI_MODE = 'agent'
-    expect(detectCliMode()).toBe('agent')
+    expect(detectCliMode(noAgentFiles)).toBe('agent')
   })
 
   it('env var CHECKLY_CLI_MODE=ci forces ci mode', () => {
     process.env.CHECKLY_CLI_MODE = 'ci'
-    expect(detectCliMode()).toBe('ci')
+    expect(detectCliMode(noAgentFiles)).toBe('ci')
   })
 
   it('ignores invalid CHECKLY_CLI_MODE values and falls back to auto-detect', () => {
     process.env.CHECKLY_CLI_MODE = 'bogus'
-    expect(detectCliMode()).toBe('interactive')
+    expect(detectCliMode(noAgentFiles)).toBe('interactive')
   })
 })

--- a/packages/cli/src/helpers/cli-mode.ts
+++ b/packages/cli/src/helpers/cli-mode.ts
@@ -1,30 +1,106 @@
+import { existsSync } from 'node:fs'
+
 export type CliMode = 'interactive' | 'ci' | 'agent'
 
 const VALID_CLI_MODES: ReadonlySet<string> = new Set(['interactive', 'ci', 'agent'])
 
 const AGENT_OPERATORS: ReadonlySet<string> = new Set([
   'claude-code', 'cursor', 'windsurf', 'aider', 'github-copilot',
-  'cline', 'codex-cli', 'gemini-cli', 'opencode',
+  'cline', 'codex-cli', 'gemini-cli', 'opencode', 'claude-cowork',
+  'vscode-agent', 'github-copilot-cli', 'amp', 'goose', 'antigravity',
+  'augment-cli', 'android-studio-agent', 'kiro-agent', 'trae', 'devin', 'jules',
+  'github-agentic-workflow', 'pi', 'agent',
 ])
 
 const CI_OPERATORS: ReadonlySet<string> = new Set([
   'github-actions', 'gitlab-ci', 'ci',
 ])
 
-export function detectOperator (): string {
-  if (process.env.CLAUDECODE) return 'claude-code'
-  if (process.env.CURSOR_TRACE_ID || process.env.CURSOR_AGENT) return 'cursor'
-  if (process.env.GITHUB_COPILOT) return 'github-copilot'
+const EXPLICIT_AGENT_ALIASES: Readonly<Record<string, string>> = {
+  'claude': 'claude-code',
+  'cowork': 'claude-cowork',
+  'codex': 'codex-cli',
+  'openai-codex': 'codex-cli',
+  'cursor-cli': 'cursor',
+  'gemini': 'gemini-cli',
+  'copilot': 'github-copilot',
+  'copilot-cli': 'github-copilot-cli',
+  'github-copilot-vscode-agent': 'vscode-agent',
+  'github_copilot_vscode_agent': 'vscode-agent',
+  'augment': 'augment-cli',
+}
+
+const DISABLED_AGENT_VALUES: ReadonlySet<string> = new Set(['0', 'false', 'no', 'off'])
+const GENERIC_AGENT_VALUES: ReadonlySet<string> = new Set(['1', 'true', 'yes', 'on'])
+const RESERVED_OPERATOR_NAMES: ReadonlySet<string> = new Set(['manual'])
+const VALID_OPERATOR_NAME = /^[a-z0-9][a-z0-9_-]{0,63}$/
+
+function normalizeExplicitAgent (value: string | undefined): string | undefined {
+  const normalized = value?.trim().toLowerCase()
+  if (!normalized || DISABLED_AGENT_VALUES.has(normalized)) return undefined
+  if (GENERIC_AGENT_VALUES.has(normalized)) return 'agent'
+  if (RESERVED_OPERATOR_NAMES.has(normalized) || !VALID_OPERATOR_NAME.test(normalized)) return 'agent'
+  return EXPLICIT_AGENT_ALIASES[normalized] ?? normalized.replaceAll('_', '-')
+}
+
+function detectExplicitAgent (): string | undefined {
+  return normalizeExplicitAgent(process.env.AI_AGENT)
+    ?? normalizeExplicitAgent(process.env.AGENT)
+}
+
+export function detectOperator (fileExists: (path: string) => boolean = existsSync): string {
+  const explicitAgent = detectExplicitAgent()
+  // Named generic markers identify wrappers that would otherwise look like their underlying agent.
+  if (explicitAgent && explicitAgent !== 'agent') return explicitAgent
+
+  // Cowork uses Claude Code's runtime too, so this more specific marker must win.
+  if (process.env.CLAUDE_CODE_IS_COWORK) return 'claude-cowork'
+  if (process.env.AMP_CURRENT_THREAD_ID) return 'amp'
+  if (process.env.CLAUDECODE || process.env.CLAUDE_CODE) return 'claude-code'
+  if (
+    process.env.CURSOR_TRACE_ID
+    || process.env.CURSOR_AGENT
+    || process.env.CURSOR_EXTENSION_HOST_ROLE === 'agent-exec'
+  ) return 'cursor'
+  if (process.env.VSCODE_AGENT || process.env.COPILOT_AGENT) return 'vscode-agent'
+  if (process.env.COPILOT_CLI) return 'github-copilot-cli'
+  if (
+    process.env.GITHUB_COPILOT
+    || process.env.COPILOT_MODEL
+    || process.env.COPILOT_ALLOW_ALL
+    || process.env.COPILOT_GITHUB_TOKEN
+  ) return 'github-copilot'
   if (process.env.AIDER) return 'aider'
-  if (process.env.WINDSURF || process.env.CODEIUM_ENV) return 'windsurf'
+  if (process.env.WINDSURF || process.env.WINDSURF_AGENT || process.env.CODEIUM_ENV) return 'windsurf'
   if (process.env.CLINE_ACTIVE) return 'cline'
-  if (process.env.CODEX_SANDBOX || process.env.CODEX_THREAD_ID) return 'codex-cli'
+  if (process.env.CODEX_SANDBOX || process.env.CODEX_CI || process.env.CODEX_THREAD_ID) return 'codex-cli'
   if (process.env.GEMINI_CLI) return 'gemini-cli'
   if (process.env.OPENCODE) return 'opencode'
-  if (process.env.TERM_PROGRAM === 'vscode') return 'vscode'
+  if (process.env.ANTIGRAVITY_AGENT) return 'antigravity'
+  if (process.env.AUGMENT_AGENT) return 'augment-cli'
+  if (process.env.ANDROID_STUDIO_AGENT) return 'android-studio-agent'
+  if (process.env.KIRO_AGENT_PATH) return 'kiro-agent'
+  if (process.env.TRAE_AI_SHELL_ID) return 'trae'
+  if (process.env.GOOSE_TERMINAL) return 'goose'
+  if (process.env.GITHUB_AW === 'true') return 'github-agentic-workflow'
+  if (fileExists('/opt/.devin')) return 'devin'
+  if (process.env.HOME === '/home/jules' && fileExists('/opt/environment_summary.sh')) return 'jules'
+  if (process.env.PATH?.includes('/.pi/agent') || process.env.PATH?.includes('\\.pi\\agent')) return 'pi'
+
+  // Boolean generic markers are deliberately checked after specific signals such as OPENCODE=1.
+  if (explicitAgent === 'agent') return 'agent'
+
+  // CI wins over broad IDE/workspace signals; strong agent signals above still win over CI.
   if (process.env.GITHUB_ACTIONS) return 'github-actions'
   if (process.env.GITLAB_CI) return 'gitlab-ci'
   if (process.env.CI) return 'ci'
+
+  if (process.env.TERM_PROGRAM === 'vscode') return 'vscode'
+  if (process.env.TERM_PROGRAM === 'kiro') return 'kiro'
+  // REPL_ID identifies the whole workspace, not specifically Replit Agent, so it stays interactive.
+  if (process.env.REPL_ID) return 'replit'
+  // Firebase Studio markers identify the environment, not specifically an agent invocation.
+  if (process.env.MONOSPACE_ENV || fileExists('/google/idx')) return 'firebase-studio'
   return 'manual'
 }
 
@@ -33,23 +109,29 @@ export const OPERATOR_TO_PLATFORM: Record<string, string> = {
   'cursor': 'cursor',
   'windsurf': 'windsurf',
   'github-copilot': 'github-copilot',
+  'github-copilot-cli': 'github-copilot',
+  'vscode-agent': 'github-copilot',
   'vscode': 'github-copilot',
   'cline': 'cline',
   'codex-cli': 'codex',
   'gemini-cli': 'gemini-cli',
   'aider': 'claude',
   'opencode': 'opencode',
+  'claude-cowork': 'claude',
+  'amp': 'amp',
+  'goose': 'goose',
 }
 
-export function detectCliMode (): CliMode {
+export function detectCliMode (fileExists: (path: string) => boolean = existsSync): CliMode {
   const envMode = process.env.CHECKLY_CLI_MODE
   if (envMode && VALID_CLI_MODES.has(envMode)) {
     return envMode as CliMode
   }
 
-  const operator = detectOperator()
+  const operator = detectOperator(fileExists)
 
   if (AGENT_OPERATORS.has(operator)) return 'agent'
+  if (detectExplicitAgent()) return 'agent'
   if (CI_OPERATORS.has(operator)) return 'ci'
   return 'interactive'
 }

--- a/packages/cli/src/rest/__tests__/api.spec.ts
+++ b/packages/cli/src/rest/__tests__/api.spec.ts
@@ -1,25 +1,52 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { afterEach, describe, it, expect, beforeEach } from 'vitest'
 import { detectOperator } from '../../helpers/cli-mode.js'
 
 describe('detectOperator', () => {
   const envVarsToClean = [
+    'AI_AGENT',
+    'AGENT',
     'CLAUDECODE',
+    'CLAUDE_CODE',
+    'CLAUDE_CODE_IS_COWORK',
+    'AMP_CURRENT_THREAD_ID',
     'CURSOR_TRACE_ID',
     'CURSOR_AGENT',
+    'CURSOR_EXTENSION_HOST_ROLE',
     'TERM_PROGRAM',
+    'VSCODE_AGENT',
+    'COPILOT_AGENT',
+    'COPILOT_CLI',
     'GITHUB_COPILOT',
+    'COPILOT_MODEL',
+    'COPILOT_ALLOW_ALL',
+    'COPILOT_GITHUB_TOKEN',
     'AIDER',
     'WINDSURF',
+    'WINDSURF_AGENT',
     'CODEIUM_ENV',
     'CLINE_ACTIVE',
     'CODEX_SANDBOX',
+    'CODEX_CI',
     'CODEX_THREAD_ID',
     'GEMINI_CLI',
     'OPENCODE',
+    'ANTIGRAVITY_AGENT',
+    'AUGMENT_AGENT',
+    'ANDROID_STUDIO_AGENT',
+    'KIRO_AGENT_PATH',
+    'TRAE_AI_SHELL_ID',
+    'GOOSE_TERMINAL',
+    'GITHUB_AW',
+    'REPL_ID',
+    'MONOSPACE_ENV',
     'GITHUB_ACTIONS',
     'GITLAB_CI',
     'CI',
-  ]
+    'HOME',
+    'PATH',
+  ] as const
+  const originalEnv = Object.fromEntries(envVarsToClean.map(key => [key, process.env[key]]))
+  const noAgentFiles = () => false
 
   beforeEach(() => {
     for (const key of envVarsToClean) {
@@ -27,74 +54,82 @@ describe('detectOperator', () => {
     }
   })
 
+  afterEach(() => {
+    for (const key of envVarsToClean) {
+      const value = originalEnv[key]
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
+  })
+
   it('returns "manual" when no agent env vars are set', () => {
-    expect(detectOperator()).toBe('manual')
+    expect(detectOperator(noAgentFiles)).toBe('manual')
   })
 
   it('detects Claude Code', () => {
     process.env.CLAUDECODE = '1'
-    expect(detectOperator()).toBe('claude-code')
+    expect(detectOperator(noAgentFiles)).toBe('claude-code')
   })
 
   it('detects Cursor', () => {
     process.env.CURSOR_TRACE_ID = 'some-trace-id'
-    expect(detectOperator()).toBe('cursor')
+    expect(detectOperator(noAgentFiles)).toBe('cursor')
   })
 
   it('detects VS Code', () => {
     process.env.TERM_PROGRAM = 'vscode'
-    expect(detectOperator()).toBe('vscode')
+    expect(detectOperator(noAgentFiles)).toBe('vscode')
   })
 
   it('does not detect VS Code for other TERM_PROGRAM values', () => {
     process.env.TERM_PROGRAM = 'iTerm.app'
-    expect(detectOperator()).toBe('manual')
+    expect(detectOperator(noAgentFiles)).toBe('manual')
   })
 
   it('detects GitHub Copilot', () => {
     process.env.GITHUB_COPILOT = '1'
-    expect(detectOperator()).toBe('github-copilot')
+    expect(detectOperator(noAgentFiles)).toBe('github-copilot')
   })
 
   it('detects Aider', () => {
     process.env.AIDER = '1'
-    expect(detectOperator()).toBe('aider')
+    expect(detectOperator(noAgentFiles)).toBe('aider')
   })
 
   it('detects Windsurf via WINDSURF env var', () => {
     process.env.WINDSURF = '1'
-    expect(detectOperator()).toBe('windsurf')
+    expect(detectOperator(noAgentFiles)).toBe('windsurf')
   })
 
   it('detects Windsurf via CODEIUM_ENV env var', () => {
     process.env.CODEIUM_ENV = 'production'
-    expect(detectOperator()).toBe('windsurf')
+    expect(detectOperator(noAgentFiles)).toBe('windsurf')
   })
 
   it('detects GitHub Actions', () => {
     process.env.GITHUB_ACTIONS = 'true'
-    expect(detectOperator()).toBe('github-actions')
+    expect(detectOperator(noAgentFiles)).toBe('github-actions')
   })
 
   it('detects GitLab CI', () => {
     process.env.GITLAB_CI = 'true'
-    expect(detectOperator()).toBe('gitlab-ci')
+    expect(detectOperator(noAgentFiles)).toBe('gitlab-ci')
   })
 
   it('detects generic CI', () => {
     process.env.CI = 'true'
-    expect(detectOperator()).toBe('ci')
+    expect(detectOperator(noAgentFiles)).toBe('ci')
   })
 
   it('prioritizes Claude Code over CI', () => {
     process.env.CLAUDECODE = '1'
     process.env.CI = 'true'
-    expect(detectOperator()).toBe('claude-code')
+    expect(detectOperator(noAgentFiles)).toBe('claude-code')
   })
 
   it('prioritizes GitHub Actions over generic CI', () => {
     process.env.GITHUB_ACTIONS = 'true'
     process.env.CI = 'true'
-    expect(detectOperator()).toBe('github-actions')
+    expect(detectOperator(noAgentFiles)).toBe('github-actions')
   })
 })


### PR DESCRIPTION
## Summary

Refine CLI operator detection so newer AI agents and AI-enabled development environments no longer fall through to `manual` attribution.

## What changed

- add validated, header-safe support for the emerging `AI_AGENT` / `AGENT` convention
- detect additional agent runtimes including Cowork, Amp, VS Code Agent, Copilot CLI, Antigravity, Augment, Android Studio Agent, Kiro Agent, Trae, Goose, GitHub Agentic Workflows, Devin, Jules, and Pi
- extend Codex, Cursor, Copilot, Windsurf, and related existing detections with current execution markers
- attribute broad environments such as Replit, Kiro terminals, VS Code terminals, and Firebase Studio without treating every command there as agent-driven
- make strong agent signals win over CI, and CI win over broad IDE/workspace markers
- preserve automatic Checkly skill installation for Amp and Goose
- sanitize generic operator names before sending them through `x-checkly-operator`

## Why

The existing detector covered the first generation of AI coding tools, but several newer actors and newer signals from existing tools were not represented. Their CLI usage was therefore reported as `manual`, which understates agent usage.

The implementation distinguishes direct agent-execution signals from environment-only signals to improve attribution without turning every IDE terminal invocation into agent mode.

## Research

Signals were cross-checked against current first-party source or documentation where available, plus maintained detection implementations in GitHub CLI, Vercel, and Firebase CLI.

Some closed-source tools do not publish stable subprocess markers. The generic `AI_AGENT=<name>` / `AGENT=<name>` path provides a safe fallback for those wrappers.

## Validation

- focused Vitest suites: 94 tests passed
- focused ESLint
- TypeScript `prepare:dist`
- Oclif `prepack` / manifest generation
- `git diff --check`
