### PR TITLE
chore: ignore .claude/ in ESLint config [RED-706] [ship]

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,6 +43,9 @@ const checklyStyle = {
 
 export default defineConfig([
   globalIgnores([
+    // Holds git worktrees, each a full checkout of the repo with its own
+    // in-progress code that must not be linted as part of this checkout.
+    '**/.claude/',
     '**/dist/',
     `**/gen/`,
     '**/__checks__/**/*.spec.{js,ts,mjs}',


### PR DESCRIPTION
Linear: RED-706

The root lint script is `eslint .`, and `lint-staged` runs that same whole-repo command on any staged `*.{ts,js,mjs}` file. ESLint flat config does not auto-ignore dot-directories, so ESLint walks into `.claude/worktrees/<name>/` — where each git worktree holds a full checkout of the repo with its own in-progress code. That code gets linted as part of the parent checkout, producing failures unrelated to the change actually being committed.

This adds `**/.claude/` to `globalIgnores` in `eslint.config.mjs`. Nothing under `.claude/` needs linting (the only tracked content is markdown command files), and linting *inside* a worktree is unaffected, since a worktree has no `.claude/worktrees/` of its own.

## Verification

With a probe file containing `var x = 1;;` planted at `.claude/worktrees/probe/bad.ts`:

- before the change, `eslint .` reports 3 errors + 1 warning for it
- after the change, `pnpm run lint` exits 0

A baseline `pnpm run lint` over the real tree still passes, so nothing previously linted has dropped out of scope.
