### PR TITLE
ci: skip lint, tests and e2e for meta-file-only changes [RED-708] [ship]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,48 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # Detects whether anything outside the ignore list below changed. Meta files
+  # (agent instructions, docs, license, .gitignore) cannot affect lint,
+  # packaging or test outcomes, so a change touching only those skips the whole
+  # matrix.
+  #
+  # The filter runs inside a job rather than as an `on: paths-ignore` trigger:
+  # a workflow skipped by a trigger-level path filter never reports a status, so
+  # required checks stay pending forever and block merge. The CI gates below
+  # depend on this job, so if it fails, the gates fail rather than passing on a
+  # matrix that never ran.
+  # ---------------------------------------------------------------------------
+  changes:
+    name: detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          # 'every' makes a file match `code` only when it matches *all* the
+          # patterns, i.e. when it is none of the ignored paths. `code` is
+          # therefore true when at least one changed file lives outside the
+          # ignore list.
+          predicate-quantifier: 'every'
+          filters: |
+            code:
+              - '!.claude/**'
+              - '!AGENTS.md'
+              - '!CLAUDE.md'
+              - '!CONTRIBUTING.md'
+              - '!LICENSE'
+              - '!README.md'
+              - '!.gitignore'
+
   lint:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -39,6 +80,8 @@ jobs:
   # ---------------------------------------------------------------------------
   test-ubuntu:
     name: test - ubuntu
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -61,6 +104,8 @@ jobs:
           retention-days: 1
   test-windows:
     name: test - windows
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: blacksmith-4vcpu-windows-2025
     steps:
       - uses: actions/checkout@v3
@@ -88,7 +133,8 @@ jobs:
   # ---------------------------------------------------------------------------
   test-e2e-checkly-ubuntu:
     name: e2e - checkly - ubuntu
-    if: github.event_name == 'pull_request'
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -110,7 +156,8 @@ jobs:
           CHECKLY_EMPTY_API_KEY: ${{ secrets.E2E_EMPTY_CHECKLY_API_KEY }}
   test-e2e-checkly-windows:
     name: e2e - checkly - windows (${{ matrix.shard }})
-    if: github.event_name == 'pull_request'
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.code == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -140,7 +187,8 @@ jobs:
   # ---------------------------------------------------------------------------
   test-e2e-create-checkly-ubuntu:
     name: e2e - create-checkly - ubuntu
-    if: github.event_name == 'pull_request'
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -155,7 +203,8 @@ jobs:
       - run: pnpm --filter create-checkly run test:e2e
   test-e2e-create-checkly-windows:
     name: e2e - create-checkly - windows
-    if: github.event_name == 'pull_request'
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.code == 'true'
     runs-on: blacksmith-4vcpu-windows-2025
     steps:
       - uses: actions/checkout@v3
@@ -179,6 +228,7 @@ jobs:
     name: CI gate - ubuntu
     if: always()
     needs:
+      - changes
       - lint
       - test-ubuntu
       - test-e2e-checkly-ubuntu
@@ -189,8 +239,11 @@ jobs:
         run: |
           results="${{ join(needs.*.result, ', ') }}"
           echo "Ubuntu job results: $results"
-          # 'skipped' is allowed (e2e jobs are skipped on push-to-main); only
-          # 'failure'/'cancelled' should fail the gate.
+          # 'skipped' is allowed (e2e jobs are skipped on push-to-main, and
+          # every job is skipped for meta-file-only changes); only
+          # 'failure'/'cancelled' should fail the gate. `changes` is a
+          # dependency so that a failure to compute the path filter fails the
+          # gate instead of green-lighting a matrix that never ran.
           if [[ "$results" == *failure* || "$results" == *cancelled* ]]; then
             echo "::error::One or more Ubuntu jobs did not succeed"
             exit 1
@@ -199,6 +252,7 @@ jobs:
     name: CI gate - windows
     if: always()
     needs:
+      - changes
       - test-windows
       - test-e2e-checkly-windows
       - test-e2e-create-checkly-windows


### PR DESCRIPTION
Linear: RED-708

The `test` workflow runs lint, unit tests on Ubuntu + Windows, and six e2e jobs on every PR — including PRs that only touch repo meta files (agent instructions, docs, license, `.gitignore`). None of those can affect lint, packaging or test outcomes, so the full matrix is wasted on trivial PRs.

A new `changes` job runs `dorny/paths-filter` with `predicate-quantifier: every` over a negated ignore list, so its `code` output is true only when at least one changed file lives **outside** `.claude/**`, the root markdown files, `LICENSE` and `.gitignore`. The seven heavy jobs are gated on that output. A PR touching meta files *and* source still runs the full matrix.

Two things worth a reviewer's attention:

- **The filter runs inside a job, not as an `on: paths-ignore` trigger.** A workflow skipped by a trigger-level path filter never reports a status, so a required check stays pending forever and blocks merge. `check-ai-context.yml` already documents this constraint and solves it the same way.
- **It fails closed.** `gate-ubuntu` / `gate-windows` keep running (`if: always()`) and already treat `skipped` as passing, so branch protection still gets a green status when the matrix is skipped. Both gates now also `needs: changes`, so if the filter job itself fails, the gates fail rather than green-lighting a matrix that never ran.

## Verification

Gate logic simulated against the exact `join(needs.*.result)` strings each scenario produces:

| Scenario | Gate |
| --- | --- |
| meta-only PR (heavy jobs skipped) | passes |
| normal PR, all green | passes |
| normal PR, unit test fails | fails |
| push to main (e2e skipped by design) | passes |
| `changes` job itself fails | **fails** (fail-closed) |
| run cancelled | fails |

The filter patterns were also simulated against picomatch (the matcher `paths-filter` uses): meta-only changesets yield `code=false`; source, workflow, lockfile, `packages/cli/README.md`, and mixed docs+source changesets all yield `code=true`. `actionlint` reports no new findings (the pre-existing `checkout@v3` and Blacksmith-runner-label warnings are unchanged).

## Depends on #1400

The `.claude/**` entry assumes files there can't affect lint — true today only because the directory holds nothing but markdown. #1400 adds `.claude/` to ESLint's `globalIgnores`, which turns that assumption into an enforced invariant. Worth merging #1400 first; otherwise a future `.claude/hooks/*.mjs` could skip the lint job that would have caught it.
