### PR TITLE
fix(cli): tidy SSL baseline block in checks get --result [SIM-291][ship]

### DIFF
--- a/packages/cli/src/formatters/__tests__/__snapshots__/check-result-detail.spec.ts.snap
+++ b/packages/cli/src/formatters/__tests__/__snapshots__/check-result-detail.spec.ts.snap
@@ -317,15 +317,15 @@ exports[`formatResultDetail > SSL check result > renders markdown snapshot > ssl
 - **OCSP stapled:** no
 
 ## Security Baseline
-- ✔ min TLS version (fail)
-- ✔ min key size (fail)
-- ✔ weak signature algorithm (fail)
-- ✖ weak cipher suite (fail)
-- ✔ known bad CA (fail)
-- ✔ recommended TLS version (ignore)
-- ✔ recommended key size (ignore)
-- ✔ OCSP must-staple respected (ignore)
-- ✔ SCT present (ignore)
+- ✔ min TLS version: TLS 1.3
+- ✔ min key size: 256-bit
+- ✔ weak signature algorithm: ECDSA-SHA256
+- ✖ weak cipher suite: TLS_AES_256_GCM_SHA384
+- ✔ known bad CA
+- ✔ recommended TLS version: TLS 1.3
+- ✔ recommended key size: 256-bit
+- ✔ OCSP must-staple respected: not stapled
+- ✔ SCT present
 
 ## Assertions
 - ✖ CERT_EXPIRES_IN_DAYS is greater than target "99999". Received: 52.
@@ -366,15 +366,15 @@ Serial:         35428337808578903465180920265426569102
 OCSP stapled:   no
 
 SECURITY BASELINE
-  ✔ min TLS version (fail)
-  ✔ min key size (fail)
-  ✔ weak signature algorithm (fail)
-  ✖ weak cipher suite (fail)
-  ✔ known bad CA (fail)
-  ✔ recommended TLS version (ignore)
-  ✔ recommended key size (ignore)
-  ✔ OCSP must-staple respected (ignore)
-  ✔ SCT present (ignore)
+  ✔ min TLS version: TLS 1.3
+  ✔ min key size: 256-bit
+  ✔ weak signature algorithm: ECDSA-SHA256
+  ✖ weak cipher suite: TLS_AES_256_GCM_SHA384
+  ✔ known bad CA
+  ✔ recommended TLS version: TLS 1.3
+  ✔ recommended key size: 256-bit
+  ✔ OCSP must-staple respected: not stapled
+  ✔ SCT present
 
 ASSERTIONS
   ✖ CERT_EXPIRES_IN_DAYS is greater than target "99999". Received: 52.

--- a/packages/cli/src/formatters/__tests__/check-result-detail.spec.ts
+++ b/packages/cli/src/formatters/__tests__/check-result-detail.spec.ts
@@ -579,9 +579,9 @@ describe('formatResultDetail', () => {
     it('renders the per-rule security baseline (terminal)', () => {
       const result = stripAnsi(formatResultDetail(sslCheckResult, 'terminal'))
       expect(result).toContain('SECURITY BASELINE')
-      expect(result).toContain(`${PASS} min TLS version (fail)`)
-      expect(result).toContain(`${FAIL} weak cipher suite (fail)`)
-      expect(result).toContain(`${PASS} recommended TLS version (ignore)`)
+      expect(result).toContain(`${PASS} min TLS version`)
+      expect(result).toContain(`${FAIL} weak cipher suite`)
+      expect(result).toContain(`${PASS} recommended TLS version`)
       // The one-line summary is still present in the RESULT block.
       expect(result).toContain('Baseline:')
     })
@@ -589,9 +589,9 @@ describe('formatResultDetail', () => {
     it('renders the per-rule security baseline (markdown)', () => {
       const result = formatResultDetail(sslCheckResult, 'md')
       expect(result).toContain('## Security Baseline')
-      expect(result).toContain(`- ${PASS} min TLS version (fail)`)
-      expect(result).toContain(`- ${FAIL} weak cipher suite (fail)`)
-      expect(result).toContain(`- ${PASS} SCT present (ignore)`)
+      expect(result).toContain(`- ${PASS} min TLS version`)
+      expect(result).toContain(`- ${FAIL} weak cipher suite`)
+      expect(result).toContain(`- ${PASS} SCT present`)
       expect(result).toBe(stripAnsi(result))
     })
 

--- a/packages/cli/src/formatters/check-result-detail.ts
+++ b/packages/cli/src/formatters/check-result-detail.ts
@@ -1085,12 +1085,39 @@ function appendSslCertificateMd (lines: string[], resp: Record<string, unknown>)
 // tuples so terminal and markdown can render the same rules with format-specific
 // styling. A rule that carries neither a `violated` flag nor a scalar value is
 // skipped.
+// Observed value for a baseline rule, pulled from the SSL response so the result
+// shows *what* was seen (e.g. "min TLS version: TLS1.3"), not just the rule name.
+// Rules without a single observed value (knownBadCA, sctPresent) return undefined.
+function sslBaselineObservedValue (key: string, resp: Record<string, unknown>): string | undefined {
+  const cert = asObject(resp.certificate)
+  switch (key) {
+    case 'minTLSVersion':
+    case 'recommendedTLSVersion':
+      return str(resp.protocol)
+    case 'minKeySizeBits':
+    case 'recommendedKeySizeBits': {
+      const bits = cert ? num(cert.keySizeBits) : undefined
+      return bits != null ? `${bits}-bit` : undefined
+    }
+    case 'weakSignatureAlgorithm':
+      return cert ? str(cert.signatureAlgorithm) : undefined
+    case 'weakCipherSuite':
+      return str(resp.cipherSuite)
+    case 'ocspMustStapleRespected': {
+      const stapled = boolFlag(resp.ocspStapled)
+      return stapled == null ? undefined : (stapled ? 'stapled' : 'not stapled')
+    }
+    default:
+      return undefined
+  }
+}
+
 function sslBaselineRules (
   resp: Record<string, unknown>,
-): Array<{ human: string, violated?: boolean, severity?: string, scalar?: string }> {
+): Array<{ human: string, violated?: boolean, severity?: string, scalar?: string, value?: string }> {
   const baseline = asObject(resp.securityBaseline)
   if (!baseline) return []
-  const rules: Array<{ human: string, violated?: boolean, severity?: string, scalar?: string }> = []
+  const rules: Array<{ human: string, violated?: boolean, severity?: string, scalar?: string, value?: string }> = []
   for (const [key, human] of SSL_BASELINE_RULES) {
     const rule = baseline[key]
     if (rule == null) continue
@@ -1099,7 +1126,7 @@ function sslBaselineRules (
       const violated = boolFlag(obj.violated)
       const severity = str(obj.severity)
       if (violated == null && severity == null) continue
-      rules.push({ human, violated, severity })
+      rules.push({ human, violated, severity, value: sslBaselineObservedValue(key, resp) })
     } else if (typeof rule === 'string' || typeof rule === 'number' || typeof rule === 'boolean') {
       rules.push({ human, scalar: String(rule) })
     }
@@ -1114,16 +1141,16 @@ function appendSslBaselineTerminal (lines: string[], resp: Record<string, unknow
   lines.push(heading('SECURITY BASELINE', 2, 'terminal'))
   for (const rule of rules) {
     if (rule.violated == null && rule.scalar == null) {
-      lines.push(`  ${chalk.dim('·')} ${rule.human}${rule.severity ? chalk.dim(` (${rule.severity})`) : ''}`)
+      lines.push(`  ${chalk.dim('·')} ${rule.human}`)
       continue
     }
     if (rule.scalar != null) {
       lines.push(`  ${chalk.dim('·')} ${rule.human}: ${rule.scalar}`)
       continue
     }
-    const head = `${rule.violated ? assertionSymbols.error : assertionSymbols.success} ${rule.human}`
+    const head = `${rule.violated ? assertionSymbols.error : assertionSymbols.success} ${rule.human}${rule.value ? `: ${rule.value}` : ''}`
     const coloredHead = rule.violated ? chalk.red(head) : chalk.green(head)
-    lines.push(`  ${coloredHead}${rule.severity ? chalk.dim(` (${rule.severity})`) : ''}`)
+    lines.push(`  ${coloredHead}`)
   }
 }
 
@@ -1138,11 +1165,11 @@ function appendSslBaselineMd (lines: string[], resp: Record<string, unknown>): v
       continue
     }
     if (rule.violated == null) {
-      lines.push(`- ${rule.human}${rule.severity ? ` (${rule.severity})` : ''}`)
+      lines.push(`- ${rule.human}`)
       continue
     }
     const sym = rule.violated ? assertionSymbols.error : assertionSymbols.success
-    lines.push(`- ${sym} ${rule.human}${rule.severity ? ` (${rule.severity})` : ''}`)
+    lines.push(`- ${sym} ${rule.human}${rule.value ? `: ${rule.value}` : ''}`)
   }
 }
 
@@ -1176,7 +1203,11 @@ function formatSslResultTerminal (ssl: SslCheckResult): string[] {
   const verdict = str(ssl.baselineVerdict)
   const grade = str(ssl.baselineGrade)
   if (verdict || grade) {
-    const verdictStr = verdict ? (verdict === 'PASS' ? chalk.green(verdict) : chalk.red(verdict)) : ''
+    let verdictStr = ''
+    if (verdict) {
+      const v = verdict.toLowerCase()
+      verdictStr = v === 'pass' ? chalk.green(verdict) : v === 'warn' ? chalk.yellow(verdict) : chalk.red(verdict)
+    }
     lines.push(`${label('Baseline:')}${[verdictStr, grade ? `grade ${grade}` : ''].filter(Boolean).join(' ')}`)
   }
 


### PR DESCRIPTION
Three result-rendering fixes to the SSL security-baseline block in `checkly checks get --result`:

1. **Verdict colour** — the verdict was compared to `'PASS'` (uppercase), so a lowercase `pass` always fell through to **red**. Now normalised and mapped `pass→green` / `warn→yellow` / `fail→red`.
2. **Drop the config-time severity suffix** — each rule showed `(fail)`/`(ignore)`, the *configured* severity. That is a configuration concern and is confusing in a result (a green ✔ next to "fail"). Removed.
3. **Show the observed value per rule** — e.g. `min TLS version: TLS1.3`, `min key size: 256-bit`, `weak signature algorithm: ECDSA-SHA256`, `weak cipher suite: <suite>`, `OCSP must-staple respected: stapled` — pulled from the SSL response. Rules with no single scalar value (`known bad CA`, `SCT present`) stay name-only.

Before:
```
Baseline:       pass grade A-     ← pass shown in red
  ✔ min TLS version (fail)
```
After:
```
Baseline:       pass grade A-     ← pass green
  ✔ min TLS version: TLS1.3
```

Snapshots + explicit assertions updated; all `check-result-detail` tests pass (72), tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)