### PR TITLE
docs(traceroute): note the protocol-dependent default port (SIM-311)[ship]

### DIFF
--- a/packages/cli/src/constructs/traceroute-request.ts
+++ b/packages/cli/src/constructs/traceroute-request.ts
@@ -37,11 +37,14 @@ export interface TracerouteRequest {
 
   /**
    * The destination port for TCP/UDP/SCTP probes. Ignored (and not sent) when
-   * `protocol` is `ICMP`.
+   * `protocol` is `ICMP`. When omitted, the default is protocol-dependent: `443`
+   * for TCP, and `33434` (a closed high port) for UDP/SCTP — UDP/SCTP arrival is
+   * only confirmed by an ICMP "port unreachable" from a closed port, whereas 443
+   * is typically open and would never confirm arrival.
    *
    * @minimum 1
    * @maximum 65535
-   * @defaultValue 443
+   * @defaultValue 443 for TCP, 33434 for UDP/SCTP
    */
   port?: number
 


### PR DESCRIPTION
## What & why

Follow-up to [SIM-311](https://linear.app/checklyhq/issue/SIM-311) (backend/runner fix: [checkly/monorepo#3057](https://github.com/checkly/monorepo/pull/3057)).

The traceroute `port` field's `@defaultValue` JSDoc said **443** unconditionally, but the default is **protocol-dependent**: `443` for TCP and `33434` (a closed high port) for UDP/SCTP — UDP/SCTP arrival is only confirmed by an ICMP "port unreachable" from a closed port, whereas 443 is typically open and never confirms arrival.

**Doc-only, no behavior change:** the construct already sends `undefined` when `port` is omitted, so the backend's (now protocol-aware) default governs. This just makes the documented default accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)