### PR TITLE
fix(cli): avoid duplicate detached CI output [ship]

### DIFF
--- a/packages/cli/src/reporters/__tests__/abstract-list.spec.ts
+++ b/packages/cli/src/reporters/__tests__/abstract-list.spec.ts
@@ -61,6 +61,21 @@ function countOccurrences (text: string, substring: string): number {
   return text.split(substring).length - 1
 }
 
+function withStdoutTty<T> (isTTY: boolean, callback: () => T): T {
+  const stdoutDescriptor = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+  Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: isTTY })
+
+  try {
+    return callback()
+  } finally {
+    if (stdoutDescriptor) {
+      Object.defineProperty(process.stdout, 'isTTY', stdoutDescriptor)
+    } else {
+      delete (process.stdout as { isTTY?: boolean }).isTTY
+    }
+  }
+}
+
 describe('AbstractListReporter', () => {
   beforeEach(() => {
     printLnMock.mockClear()
@@ -99,11 +114,13 @@ describe('AbstractListReporter', () => {
   })
 
   it('should populate _clearString after _printSummary runs', () => {
-    const { reporter } = makeReporterWithOneCheck()
+    withStdoutTty(true, () => {
+      const { reporter } = makeReporterWithOneCheck()
 
-    reporter._printSummary()
+      reporter._printSummary()
 
-    expect(reporter._clearString).not.toBe('')
+      expect(reporter._clearString).not.toBe('')
+    })
   })
 
   it('should include cancellation message with --detach hint after onCancel', () => {
@@ -137,6 +154,20 @@ describe('AbstractListReporter', () => {
     expect(countOccurrences(summary, `Test session ID: ${TEST_SESSION_ID}`)).toBe(1)
     expect(countOccurrences(summary, `Inspect session: checkly test-sessions get ${TEST_SESSION_ID} --watch`)).toBe(1)
     expect(countOccurrences(summary, `Open session: ${TEST_SESSION_URL}`)).toBe(1)
+  })
+
+  it('does not redraw the check list for detached non-TTY output', () => {
+    withStdoutTty(false, () => {
+      const { reporter } = makeReporterWithOneCheck(TEST_SESSION_ID)
+      reporter.onDetach()
+
+      const summary = printLnMock.mock.calls.map(([text]: [string]) => text).join('\n')
+      expect(countOccurrences(summary, SOURCE_FILE)).toBe(1)
+      expect(countOccurrences(summary, 'My API Check')).toBe(1)
+      expect(summary).toContain('Checks will continue running in the cloud.')
+      expect(summary).toContain('1 scheduling, 1 total')
+      expect(summary).not.toContain('\x1B[K')
+    })
   })
 
   it('should render existing detailed session summary link output', async () => {

--- a/packages/cli/src/reporters/abstract-list.ts
+++ b/packages/cli/src/reporters/abstract-list.ts
@@ -149,14 +149,26 @@ export default abstract class AbstractListReporter implements Reporter {
 
   onCancel (): void {
     this._isCancelling = true
-    this._clearSummary()
-    this._printSummary()
+    if (this._shouldRenderLiveSummary()) {
+      this._clearSummary()
+      this._printSummary()
+      return
+    }
+    this._printSummary({ includeCheckTitles: false })
   }
 
   onDetach (): void {
     this._isDetaching = true
-    this._clearSummary()
-    this._printSummary()
+    if (this._shouldRenderLiveSummary()) {
+      this._clearSummary()
+      this._printSummary()
+      return
+    }
+    this._printSummary({ includeCheckTitles: false })
+  }
+
+  private _shouldRenderLiveSummary (): boolean {
+    return process.stdout.isTTY === true
   }
 
   // Clear the summary which was printed by _printStatus from stdout
@@ -169,17 +181,18 @@ export default abstract class AbstractListReporter implements Reporter {
     }
   }
 
-  _printSummary (opts: { skipCheckCount?: boolean } = {}) {
+  _printSummary (opts: { skipCheckCount?: boolean, includeCheckTitles?: boolean } = {}) {
     const counts = {
       numFailed: 0, numPassed: 0, numDegraded: 0,
       numRunning: 0, numRetrying: 0, scheduling: 0, numCancelled: 0,
     }
     const status = []
-    if (this.checkFilesMap!.size === 1 && this.checkFilesMap!.has(undefined)) {
+    const includeCheckTitles = opts.includeCheckTitles ?? true
+    if (includeCheckTitles && this.checkFilesMap!.size === 1 && this.checkFilesMap!.has(undefined)) {
       status.push(chalk.bold('Summary:'))
     }
     for (const [sourceFile, checkMap] of this.checkFilesMap!.entries()) {
-      if (sourceFile) status.push(sourceFile)
+      if (includeCheckTitles && sourceFile) status.push(sourceFile)
       for (const [, { titleString, result, checkStatus }] of checkMap.entries()) {
         if (checkStatus === CheckStatus.SCHEDULING) {
           counts.scheduling++
@@ -196,7 +209,9 @@ export default abstract class AbstractListReporter implements Reporter {
         } else {
           counts.numPassed++
         }
-        status.push(sourceFile ? indentString(titleString, 2) : titleString)
+        if (includeCheckTitles) {
+          status.push(sourceFile ? indentString(titleString, 2) : titleString)
+        }
       }
     }
 
@@ -241,8 +256,10 @@ export default abstract class AbstractListReporter implements Reporter {
 
     const statusString = status.join('\n')
     printLn(statusString)
-    // Ansi escape code for erasing the line and moving the cursor up
-    this._clearString = '\r\x1B[K\r\x1B[1A'.repeat(statusString.split('\n').length + 1)
+    if (this._shouldRenderLiveSummary()) {
+      // Ansi escape code for erasing the line and moving the cursor up.
+      this._clearString = '\r\x1B[K\r\x1B[1A'.repeat(statusString.split('\n').length + 1)
+    }
   }
 
   _printBriefSummary () {
@@ -275,8 +292,10 @@ export default abstract class AbstractListReporter implements Reporter {
     status.push('')
     const statusString = status.join('\n')
     printLn(statusString)
-    // Ansi escape code for erasing the line and moving the cursor up
-    this._clearString = '\r\x1B[K\r\x1B[1A'.repeat(statusString.split('\n').length + 1)
+    if (this._shouldRenderLiveSummary()) {
+      // Ansi escape code for erasing the line and moving the cursor up.
+      this._clearString = '\r\x1B[K\r\x1B[1A'.repeat(statusString.split('\n').length + 1)
+    }
   }
 
   // Checks that fail with a run error (e.g. the CLI timing out while waiting for a result)


### PR DESCRIPTION
## Affected Components
* [x] CLI
* [ ] Create CLI
* [x] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

## Notes for the Reviewer

Detached `test` and `trigger` runs now avoid terminal redraws when stdout is not a TTY, including GitHub Actions logs. The initial check list remains, followed by a concise scheduling or cancellation summary, without duplicate check titles or ANSI cursor-control output. Interactive terminals retain their live summary redraw.

Regression coverage asserts a detached non-TTY run prints each check once and emits no cursor-clear sequence.

## Verification

- `pnpm lint`
- `pnpm --filter checkly test` (122 files, 1,621 passed, 2 skipped)

## New Dependency Submission

None.