### PR TITLE
feat(cli): declare agent runs via x-checkly-source: AGENT [ship]

### DIFF
--- a/packages/cli/src/rest/__tests__/request-interceptor.spec.ts
+++ b/packages/cli/src/rest/__tests__/request-interceptor.spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// api.ts builds its axios instance and resource classes at import time via
+// getDefaults(); stub the config service so importing it needs no credentials.
+vi.mock('../../services/config.js', () => ({
+  default: {
+    getApiKey: () => 'test-key',
+    getAccountId: () => 'test-account',
+    getApiUrl: () => 'https://api.checklyhq.com',
+    hasValidCredentials: () => true,
+  },
+}))
+
+vi.mock('../../helpers/cli-mode.js', () => ({
+  detectCliMode: vi.fn(() => 'interactive'),
+  detectOperator: vi.fn(() => 'manual'),
+}))
+
+import { requestInterceptor } from '../api.js'
+import { detectCliMode } from '../../helpers/cli-mode.js'
+
+describe('requestInterceptor x-checkly-source', () => {
+  const sourceHeader = () => {
+    const config = { headers: {} } as any
+    return requestInterceptor(config).headers['x-checkly-source']
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('reports AGENT when the CLI is driven by an agent', () => {
+    vi.mocked(detectCliMode).mockReturnValue('agent')
+    expect(sourceHeader()).toBe('AGENT')
+  })
+
+  it('reports CLI for interactive and CI runs', () => {
+    vi.mocked(detectCliMode).mockReturnValue('interactive')
+    expect(sourceHeader()).toBe('CLI')
+
+    vi.mocked(detectCliMode).mockReturnValue('ci')
+    expect(sourceHeader()).toBe('CLI')
+  })
+})

--- a/packages/cli/src/rest/api.ts
+++ b/packages/cli/src/rest/api.ts
@@ -31,7 +31,7 @@ import AlertNotifications from './alert-notifications.js'
 import Rca from './rca.js'
 import Cancel from './cancel.js'
 import { handleErrorResponse, UnauthorizedError } from './errors.js'
-import { detectOperator } from '../helpers/cli-mode.js'
+import { detectCliMode, detectOperator } from '../helpers/cli-mode.js'
 
 export function getDefaults () {
   const apiKey = config.getApiKey()
@@ -82,7 +82,10 @@ export function requestInterceptor (config: InternalAxiosRequestConfig) {
     config.headers['x-checkly-account'] = accountId
   }
 
-  config.headers['x-checkly-source'] = 'CLI'
+  // Declare who is driving the CLI. An agent run reports `AGENT` so the backend
+  // can tell agent-created import plans apart from human ones (same API key) —
+  // it keys the abandoned-reservation GC off this. Everything else is `CLI`.
+  config.headers['x-checkly-source'] = detectCliMode() === 'agent' ? 'AGENT' : 'CLI'
   config.headers['x-checkly-ci-name'] = CIname
   config.headers['x-checkly-operator'] = detectOperator()
 


### PR DESCRIPTION
## What
When the CLI is driven by an agent (`detectCliMode() === 'agent'`), send `x-checkly-source: AGENT` on API requests instead of the hardcoded `CLI`.

```diff
- config.headers['x-checkly-source'] = 'CLI'
+ config.headers['x-checkly-source'] = detectCliMode() === 'agent' ? 'AGENT' : 'CLI'
```

## Why
Authentication can't distinguish an agent from a human — they share the same API key. The backend needs a self-declared signal to tell **agent-created import plans apart from human ones**, so it can safely garbage-collect abandoned agent onboarding reservations (agent onboarding reserves pending mappings server-side that outlive the throwaway sandbox; if the user never finalizes with `checkly import commit`, they'd linger forever).

`detectCliMode()` already returns `'agent'` for agent-driven runs — including when the AI runner sets `CHECKLY_CLI_MODE=agent` — so this just routes that existing signal onto the source header. Composes with the agent-drivable import flow from #1402.

## Backend counterpart
The backend adds `AGENT` to its client-source vocabulary, persists this header onto the import plan's new `source` column, and runs a daily reaper over `source = 'AGENT' AND committedAt IS NULL AND createdAt < now() - TTL`. This CLI change is what makes `source = 'AGENT'` actually get set.

## Testing
- New `rest/__tests__/request-interceptor.spec.ts`: asserts `AGENT` in agent mode, `CLI` for interactive/CI.
- Existing `detectOperator` suite unaffected (16/16 green together); `tsc` + eslint clean.

Note: no `[ship]` tag — leaving the release call to maintainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)