### PR TITLE
refactor(grpc): drop storeResponseBody from GrpcMonitor

### DIFF
--- a/packages/cli/src/constructs/__tests__/grpc-monitor.spec.ts
+++ b/packages/cli/src/constructs/__tests__/grpc-monitor.spec.ts
@@ -62,7 +62,6 @@ describe('GrpcMonitor', () => {
         grpcConfig: {
           mode: 'BEHAVIOR',
           tls: true,
-          storeResponseBody: true,
           serviceDefinition: 'REFLECTION',
           method: '/grpc.health.v1.Health/Check',
         },

--- a/packages/cli/src/constructs/__tests__/uptime-monitor-codegen.spec.ts
+++ b/packages/cli/src/constructs/__tests__/uptime-monitor-codegen.spec.ts
@@ -74,7 +74,6 @@ describe('GrpcMonitorCodegen', () => {
       grpcConfig: {
         mode: 'BEHAVIOR',
         tls: true,
-        storeResponseBody: true,
         serviceDefinition: 'REFLECTION',
         method: '/grpc.health.v1.Health/Check',
       },

--- a/packages/cli/src/constructs/__tests__/uptime-monitor-export-snippets.spec.ts
+++ b/packages/cli/src/constructs/__tests__/uptime-monitor-export-snippets.spec.ts
@@ -36,7 +36,6 @@ describe('backend-style export snippets', () => {
         grpcConfig: {
           mode: 'BEHAVIOR',
           tls: true,
-          storeResponseBody: true,
           serviceDefinition: 'REFLECTION',
           method: '/grpc.health.v1.Health/Check',
         },

--- a/packages/cli/src/constructs/grpc-request-codegen.ts
+++ b/packages/cli/src/constructs/grpc-request-codegen.ts
@@ -35,10 +35,6 @@ export function valueForGrpcRequest (
         builder.boolean('tls', config.tls)
       }
 
-      if (config.storeResponseBody !== undefined) {
-        builder.boolean('storeResponseBody', config.storeResponseBody)
-      }
-
       if (config.serviceDefinition) {
         builder.string('serviceDefinition', config.serviceDefinition)
       }

--- a/packages/cli/src/constructs/grpc-request.ts
+++ b/packages/cli/src/constructs/grpc-request.ts
@@ -53,13 +53,6 @@ export interface GrpcConfig {
   tls?: boolean
 
   /**
-   * Whether to store the gRPC response body with the check result.
-   *
-   * @defaultValue true
-   */
-  storeResponseBody?: boolean
-
-  /**
    * gRPC metadata (request headers) sent with the call.
    */
   metadata?: Array<GrpcMetadata>


### PR DESCRIPTION
## What

Removes `storeResponseBody` from the `GrpcMonitor` request. gRPC checks always store the response body now — the backend removed the per-check "store response body" toggle and no longer accepts or returns the field, so exposing it in the construct is misleading.

## Changes

- Drop `storeResponseBody?: boolean` from the `GrpcRequest` construct type.
- Drop the field from the codegen emitter (`grpc-request-codegen.ts`), so `checkly import` no longer generates it.
- Remove it from the affected construct fixtures.

## Notes

Minor breaking type change: a project that explicitly set `storeResponseBody` in a `GrpcMonitor` will now get a TypeScript error. The field was already a no-op (the API ignores it), so removing it just surfaces that. No runtime behavior change — bodies are always stored.
