### PR TITLE
Add checks run for ordinary check sessions

### DIFF
--- a/packages/cli/e2e/__tests__/help.spec.ts
+++ b/packages/cli/e2e/__tests__/help.spec.ts
@@ -57,7 +57,7 @@ describe('help', () => {
   alert-channels   List and inspect alert channels in your Checkly account.
   api              Make an authenticated HTTP request to the Checkly API.
   assets           List and download result assets.
-  checks           List and inspect checks in your Checkly account.
+  checks           List, inspect, and run checks in your Checkly account.
   destroy          Destroy your project with all its related resources.
   env              Manage Checkly environment variables.
   help             Display help for checkly.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -78,7 +78,7 @@
         "description": "List and download result assets."
       },
       "checks": {
-        "description": "List and inspect checks in your Checkly account."
+        "description": "List, inspect, and run checks in your Checkly account."
       },
       "env": {
         "description": "Manage Checkly environment variables."

--- a/packages/cli/src/ai-context/__tests__/references.spec.ts
+++ b/packages/cli/src/ai-context/__tests__/references.spec.ts
@@ -47,6 +47,9 @@ describe('AI context investigation references', () => {
   it('documents check result attempts and asset retrieval', async () => {
     const content = normalizeLineEndings(await readReference('investigate-checks.md'))
 
+    expect(content).toContain('npx checkly checks run --tags production')
+    expect(content).toContain('creates ordinary Check Sessions')
+    expect(content).toContain('Test Sessions do not update normal check health')
     expect(content).toContain('npx checkly checks get <check-id> --result <result-id> --include-attempts --output json')
     expect(content).toContain('"result": {}')
     expect(content).toContain('"attempts": []')

--- a/packages/cli/src/ai-context/context.ts
+++ b/packages/cli/src/ai-context/context.ts
@@ -72,7 +72,7 @@ export const REFERENCES = [
 export const INVESTIGATE_REFERENCES = [
   {
     id: 'investigate-checks',
-    description: 'Inspect checks (`checks list`, `checks get`), retry attempts, result assets, and trigger on-demand runs',
+    description: 'Inspect checks (`checks list`, `checks get`), retry attempts, result assets, and run on-demand monitoring or test sessions',
   },
   {
     id: 'investigate-alerting',

--- a/packages/cli/src/ai-context/references/investigate-checks.md
+++ b/packages/cli/src/ai-context/references/investigate-checks.md
@@ -146,11 +146,27 @@ Flags:
 
 Pass one or more check IDs as positional arguments to get stats for specific checks only.
 
-## Trigger checks
+## Run checks with normal monitoring behavior
+
+```bash
+npx checkly checks run --tags production
+npx checkly checks run --check-id <check-id>
+npx checkly checks run --tags critical,api --detach
+```
+
+`checks run` creates ordinary Check Sessions using the checks' deployed
+configuration and locations. These runs update check health and apply configured
+alerting rules. The command waits for completion by default; use `--detach` to
+schedule the runs and exit immediately.
+
+## Trigger a recorded test session
 
 ```bash
 npx checkly trigger --tags production
 npx checkly trigger --tags critical,api
 ```
 
-Triggers existing deployed checks by tag. Useful for on-demand verification.
+`trigger` runs deployed checks as a Test Session. Use it for CI verification or
+when you need Test Session options such as location, environment, or retry
+overrides. Test Sessions do not update normal check health or send configured
+monitoring alerts.

--- a/packages/cli/src/commands/__tests__/checks-run.spec.ts
+++ b/packages/cli/src/commands/__tests__/checks-run.spec.ts
@@ -1,0 +1,217 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { CheckSession, CompletedCheckSession } from '../../rest/check-sessions.js'
+
+vi.mock('../../rest/api.js', () => ({
+  checkSessions: {
+    trigger: vi.fn(),
+    pollUntilComplete: vi.fn(),
+  },
+}))
+
+import * as api from '../../rest/api.js'
+import {
+  CheckSessionWaitTimeoutError,
+  NoMatchingChecksError,
+} from '../../rest/check-sessions.js'
+import ChecksRun from '../checks/run.js'
+
+const pendingSessions: CheckSession[] = [
+  {
+    checkSessionId: '8166fa86-c9b4-4162-8541-d380c6c212d8',
+    checkSessionLink: 'https://app.checklyhq.com/check-sessions/8166fa86-c9b4-4162-8541-d380c6c212d8',
+    checkId: 'a4cd4ad9-4815-4a9e-92d2-0a7c562ee69a',
+    checkType: 'API',
+    name: 'Production API',
+    status: 'PROGRESS',
+    startedAt: '2026-07-21T12:00:00.000Z',
+    stoppedAt: null,
+    timeElapsed: 0,
+    runLocations: ['us-east-1'],
+    runSource: 'TRIGGER_API',
+  },
+  {
+    checkSessionId: '16e22c0d-22a5-4d03-93c5-91bc38ac3c85',
+    checkSessionLink: 'https://app.checklyhq.com/check-sessions/16e22c0d-22a5-4d03-93c5-91bc38ac3c85',
+    checkId: '22336fd1-c407-4bf7-a793-91c2246fd08f',
+    checkType: 'BROWSER',
+    name: 'Checkout journey',
+    status: 'PROGRESS',
+    startedAt: '2026-07-21T12:00:00.000Z',
+    stoppedAt: null,
+    timeElapsed: 0,
+    runLocations: ['eu-west-1'],
+    runSource: 'TRIGGER_API',
+  },
+]
+
+const completedSessions: CompletedCheckSession[] = pendingSessions.map((session, index) => ({
+  ...session,
+  status: index === 0 ? 'PASSED' : 'DEGRADED',
+  stoppedAt: '2026-07-21T12:00:01.000Z',
+  timeElapsed: 1_000,
+  results: [],
+}))
+
+function defaultFlags (overrides: Record<string, unknown> = {}) {
+  return {
+    'tags': undefined,
+    'check-id': undefined,
+    'refresh-cache': false,
+    'timeout': 600,
+    'detach': false,
+    'fail-on-no-matching': true,
+    'output': 'table',
+    ...overrides,
+  }
+}
+
+function createCommandContext (flags: Record<string, unknown>) {
+  const logged: string[] = []
+  return {
+    parse: vi.fn().mockResolvedValue({ flags }),
+    error: vi.fn((message: string) => {
+      throw new Error(message)
+    }),
+    log: vi.fn((message?: string) => {
+      if (message) logged.push(message)
+    }),
+    style: {
+      outputFormat: undefined,
+      actionStart: vi.fn(),
+      actionStatus: vi.fn(),
+      actionSuccess: vi.fn(),
+      actionFailure: vi.fn(),
+      longError: vi.fn(),
+    },
+    logged,
+  }
+}
+
+describe('checks run command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.exitCode = undefined
+    vi.mocked(api.checkSessions.trigger).mockResolvedValue({ sessions: pendingSessions })
+    vi.mocked(api.checkSessions.pollUntilComplete)
+      .mockImplementation(id => Promise.resolve(completedSessions.find(session => session.checkSessionId === id)!))
+  })
+
+  it('maps selectors to the public check sessions API and waits by default', async () => {
+    const ctx = createCommandContext(defaultFlags({
+      'tags': ['production,api', 'critical'],
+      'check-id': [pendingSessions[0].checkId],
+      'refresh-cache': true,
+      'timeout': 120,
+    }))
+
+    await ChecksRun.prototype.run.call(ctx as any)
+
+    expect(api.checkSessions.trigger).toHaveBeenCalledWith({
+      target: {
+        matchTags: [['production', 'api'], ['critical']],
+        checkId: [pendingSessions[0].checkId],
+      },
+      refreshCache: true,
+    })
+    expect(api.checkSessions.pollUntilComplete).toHaveBeenCalledTimes(2)
+    expect(api.checkSessions.pollUntilComplete).toHaveBeenCalledWith(
+      pendingSessions[0].checkSessionId,
+      expect.any(Number),
+    )
+    expect(ctx.style.actionStart).toHaveBeenCalledWith('Waiting for check sessions to complete...')
+    expect(ctx.style.actionSuccess).toHaveBeenCalled()
+    expect(ctx.logged[0]).toContain('2 check sessions completed')
+    expect(process.exitCode).toBeUndefined()
+  })
+
+  it('omits the target when no selectors are provided', async () => {
+    const ctx = createCommandContext(defaultFlags({ detach: true }))
+
+    await ChecksRun.prototype.run.call(ctx as any)
+
+    expect(api.checkSessions.trigger).toHaveBeenCalledWith({ refreshCache: false })
+  })
+
+  it('detaches without requesting completion', async () => {
+    const ctx = createCommandContext(defaultFlags({ detach: true }))
+
+    await ChecksRun.prototype.run.call(ctx as any)
+
+    expect(api.checkSessions.pollUntilComplete).not.toHaveBeenCalled()
+    expect(ctx.style.actionStart).not.toHaveBeenCalled()
+    expect(ctx.logged[0]).toContain('2 check sessions started.')
+  })
+
+  it('prints a stable JSON envelope without spinner output', async () => {
+    const ctx = createCommandContext(defaultFlags({ output: 'json' }))
+
+    await ChecksRun.prototype.run.call(ctx as any)
+
+    expect(JSON.parse(ctx.logged[0])).toEqual({ sessions: completedSessions })
+    expect(ctx.style.actionStart).not.toHaveBeenCalled()
+  })
+
+  it.each(['FAILED', 'TIMED_OUT', 'CANCELLED'] as const)('exits 1 when a session is %s', async status => {
+    vi.mocked(api.checkSessions.pollUntilComplete).mockResolvedValue({
+      ...completedSessions[0],
+      status,
+    })
+    vi.mocked(api.checkSessions.trigger).mockResolvedValue({ sessions: [pendingSessions[0]] })
+    const ctx = createCommandContext(defaultFlags())
+
+    await ChecksRun.prototype.run.call(ctx as any)
+
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('fails by default when no checks match', async () => {
+    vi.mocked(api.checkSessions.trigger).mockRejectedValue(new NoMatchingChecksError())
+    const ctx = createCommandContext(defaultFlags())
+
+    await ChecksRun.prototype.run.call(ctx as any)
+
+    expect(ctx.logged).toContain('No matching checks were found.')
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('can succeed when no checks match', async () => {
+    vi.mocked(api.checkSessions.trigger).mockRejectedValue(new NoMatchingChecksError())
+    const ctx = createCommandContext(defaultFlags({ 'fail-on-no-matching': false }))
+
+    await ChecksRun.prototype.run.call(ctx as any)
+
+    expect(process.exitCode).toBeUndefined()
+  })
+
+  it('reports an overall completion timeout and leaves sessions running', async () => {
+    vi.mocked(api.checkSessions.trigger).mockResolvedValue({ sessions: [pendingSessions[0]] })
+    vi.mocked(api.checkSessions.pollUntilComplete)
+      .mockRejectedValue(new CheckSessionWaitTimeoutError(pendingSessions[0].checkSessionId))
+    const ctx = createCommandContext(defaultFlags())
+
+    await ChecksRun.prototype.run.call(ctx as any)
+
+    expect(ctx.style.actionFailure).toHaveBeenCalled()
+    expect(ctx.style.longError).toHaveBeenCalledWith(
+      'Timed out waiting for check sessions.',
+      expect.stringContaining('--detach'),
+    )
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('rejects a non-positive timeout before scheduling', async () => {
+    const ctx = createCommandContext(defaultFlags({ timeout: 0 }))
+
+    await expect(ChecksRun.prototype.run.call(ctx as any))
+      .rejects
+      .toThrow('--timeout must be an integer greater than 0.')
+    expect(api.checkSessions.trigger).not.toHaveBeenCalled()
+  })
+
+  it('has intentional command metadata', () => {
+    expect(ChecksRun.readOnly).toBe(false)
+    expect(ChecksRun.destructive).toBe(false)
+    expect(ChecksRun.idempotent).toBe(false)
+  })
+})

--- a/packages/cli/src/commands/__tests__/checks-run.spec.ts
+++ b/packages/cli/src/commands/__tests__/checks-run.spec.ts
@@ -184,6 +184,20 @@ describe('checks run command', () => {
     expect(process.exitCode).toBeUndefined()
   })
 
+  it('prints an empty JSON envelope when no checks match without failing', async () => {
+    vi.mocked(api.checkSessions.trigger).mockRejectedValue(new NoMatchingChecksError())
+    const ctx = createCommandContext(defaultFlags({
+      'fail-on-no-matching': false,
+      'output': 'json',
+    }))
+
+    await ChecksRun.prototype.run.call(ctx as any)
+
+    expect(ctx.logged).toHaveLength(1)
+    expect(JSON.parse(ctx.logged[0])).toEqual({ sessions: [] })
+    expect(process.exitCode).toBeUndefined()
+  })
+
   it('reports an overall completion timeout and leaves sessions running', async () => {
     vi.mocked(api.checkSessions.trigger).mockResolvedValue({ sessions: [pendingSessions[0]] })
     vi.mocked(api.checkSessions.pollUntilComplete)

--- a/packages/cli/src/commands/__tests__/command-metadata.spec.ts
+++ b/packages/cli/src/commands/__tests__/command-metadata.spec.ts
@@ -5,6 +5,7 @@ import { BaseCommand } from '../baseCommand.js'
 import ChecksList from '../checks/list.js'
 import ChecksGet from '../checks/get.js'
 import ChecksStats from '../checks/stats.js'
+import ChecksRun from '../checks/run.js'
 import StatusPagesList from '../status-pages/list.js'
 import StatusPagesGet from '../status-pages/get.js'
 import AlertChannelsList from '../alert-channels/list.js'
@@ -62,6 +63,7 @@ const commands: Array<[string, typeof BaseCommand]> = [
   ['checks list', ChecksList],
   ['checks get', ChecksGet],
   ['checks stats', ChecksStats],
+  ['checks run', ChecksRun],
   ['status-pages list', StatusPagesList],
   ['status-pages get', StatusPagesGet],
   ['test-sessions list', TestSessionsList],

--- a/packages/cli/src/commands/checks/run.ts
+++ b/packages/cli/src/commands/checks/run.ts
@@ -145,7 +145,11 @@ export default class ChecksRun extends AuthCommand {
       }
 
       if (err instanceof NoMatchingChecksError) {
-        this.log('No matching checks were found.')
+        if (flags.output === 'json') {
+          this.log(JSON.stringify({ sessions: [] }, null, 2))
+        } else {
+          this.log('No matching checks were found.')
+        }
         if (flags['fail-on-no-matching']) {
           process.exitCode = 1
         }

--- a/packages/cli/src/commands/checks/run.ts
+++ b/packages/cli/src/commands/checks/run.ts
@@ -1,0 +1,168 @@
+import { Flags } from '@oclif/core'
+
+import { AuthCommand } from '../authCommand.js'
+import { outputFlag } from '../../helpers/flags.js'
+import * as api from '../../rest/api.js'
+import {
+  CheckSessionWaitTimeoutError,
+  NoMatchingChecksError,
+  type CheckSession,
+  type CompletedCheckSession,
+  type TriggerCheckSessionsRequest,
+} from '../../rest/check-sessions.js'
+import { formatCheckSessionsRun } from '../../formatters/check-sessions.js'
+import type { OutputFormat } from '../../formatters/render.js'
+
+const DEFAULT_TIMEOUT_SECONDS = 600
+const COMPLETION_CONCURRENCY = 10
+
+async function mapWithConcurrency<T, R> (
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length)
+  let nextIndex = 0
+
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    while (nextIndex < items.length) {
+      const index = nextIndex++
+      results[index] = await fn(items[index])
+    }
+  })
+
+  await Promise.all(workers)
+  return results
+}
+
+function hasFailed (session: CompletedCheckSession): boolean {
+  return ['FAILED', 'TIMED_OUT', 'CANCELLED'].includes(session.status)
+}
+
+export default class ChecksRun extends AuthCommand {
+  static hidden = false
+  static readOnly = false
+  static destructive = false
+  static idempotent = false
+  static description = 'Run deployed checks now using their configured locations and alerting rules.'
+
+  static flags = {
+    'tags': Flags.string({
+      char: 't',
+      description: 'Select checks using a comma-separated list of tags.'
+        + ' Checks must contain all tags in one --tags filter.'
+        + ' Repeat --tags to match any of multiple filters.',
+      multiple: true,
+    }),
+    'check-id': Flags.string({
+      description: 'Run specific checks by ID. Accepts comma-separated values and can be repeated.',
+      multiple: true,
+      delimiter: ',',
+    }),
+    'refresh-cache': Flags.boolean({
+      description: 'Refresh the selected checks cache before running.',
+      default: false,
+    }),
+    'timeout': Flags.integer({
+      description: 'A timeout (in seconds) to wait for all check sessions to complete.',
+      default: DEFAULT_TIMEOUT_SECONDS,
+    }),
+    'detach': Flags.boolean({
+      char: 'd',
+      description: 'Start the check sessions and exit without waiting for results.',
+      default: false,
+    }),
+    'fail-on-no-matching': Flags.boolean({
+      description: 'Exit with a failing status code when there are no matching checks. Enabled by default.',
+      default: true,
+      allowNo: true,
+    }),
+    'output': outputFlag({ default: 'table' }),
+  }
+
+  async run (): Promise<void> {
+    const { flags } = await this.parse(ChecksRun)
+    this.style.outputFormat = flags.output
+
+    if (flags.timeout < 1) {
+      this.error('--timeout must be an integer greater than 0.')
+    }
+
+    const request: TriggerCheckSessionsRequest = {
+      refreshCache: flags['refresh-cache'],
+    }
+    if (flags.tags || flags['check-id']) {
+      request.target = {
+        matchTags: flags.tags?.map(tags => tags.split(',')),
+        checkId: flags['check-id'],
+      }
+    }
+
+    let watching = false
+    try {
+      const response = await api.checkSessions.trigger(request)
+      let sessions: CheckSession[] = response.sessions
+
+      if (!flags.detach) {
+        const deadlineAt = Date.now() + flags.timeout * 1_000
+        const showAction = flags.output === 'table'
+        let completedCount = 0
+
+        if (showAction) {
+          watching = true
+          this.style.actionStart('Waiting for check sessions to complete...')
+        }
+
+        sessions = await mapWithConcurrency(response.sessions, COMPLETION_CONCURRENCY, async session => {
+          const completed = await api.checkSessions.pollUntilComplete(session.checkSessionId, deadlineAt)
+          completedCount++
+          if (showAction) {
+            this.style.actionStatus(`${completedCount}/${response.sessions.length}`)
+          }
+          return completed
+        })
+
+        if (showAction) {
+          this.style.actionSuccess()
+          watching = false
+        }
+
+        if ((sessions as CompletedCheckSession[]).some(hasFailed)) {
+          process.exitCode = 1
+        }
+      }
+
+      if (flags.output === 'json') {
+        this.log(JSON.stringify({ sessions }, null, 2))
+        return
+      }
+
+      const format: OutputFormat = flags.output === 'md' ? 'md' : 'terminal'
+      this.log(formatCheckSessionsRun(sessions, format, { detached: flags.detach }))
+    } catch (err: any) {
+      if (watching) {
+        this.style.actionFailure()
+      }
+
+      if (err instanceof NoMatchingChecksError) {
+        this.log('No matching checks were found.')
+        if (flags['fail-on-no-matching']) {
+          process.exitCode = 1
+        }
+        return
+      }
+
+      if (err instanceof CheckSessionWaitTimeoutError) {
+        this.style.longError(
+          'Timed out waiting for check sessions.',
+          `The check sessions are still running in Checkly. Increase --timeout or use --detach to exit after scheduling.`,
+        )
+        process.exitCode = 1
+        return
+      }
+
+      this.style.longError('Failed to run checks.', err)
+      process.exitCode = 1
+    }
+  }
+}

--- a/packages/cli/src/formatters/__tests__/check-sessions.spec.ts
+++ b/packages/cli/src/formatters/__tests__/check-sessions.spec.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { formatCheckSessionsRun } from '../check-sessions.js'
+import { stripAnsi } from '../render.js'
+import type { CheckSession } from '../../rest/check-sessions.js'
+
+const sessions: CheckSession[] = [
+  {
+    checkSessionId: '8166fa86-c9b4-4162-8541-d380c6c212d8',
+    checkSessionLink: 'https://app.checklyhq.com/check-sessions/8166fa86-c9b4-4162-8541-d380c6c212d8',
+    checkId: 'a4cd4ad9-4815-4a9e-92d2-0a7c562ee69a',
+    checkType: 'API',
+    name: 'Production API',
+    status: 'PASSED',
+    startedAt: '2026-07-21T12:00:00.000Z',
+    stoppedAt: '2026-07-21T12:00:01.000Z',
+    timeElapsed: 1_000,
+    runLocations: ['us-east-1'],
+    runSource: 'TRIGGER_API',
+  },
+  {
+    checkSessionId: '16e22c0d-22a5-4d03-93c5-91bc38ac3c85',
+    checkSessionLink: 'https://app.checklyhq.com/check-sessions/16e22c0d-22a5-4d03-93c5-91bc38ac3c85',
+    checkId: '22336fd1-c407-4bf7-a793-91c2246fd08f',
+    checkType: 'PLAYWRIGHT',
+    name: 'Checkout journey',
+    status: 'FAILED',
+    startedAt: '2026-07-21T12:00:00.000Z',
+    stoppedAt: '2026-07-21T12:02:03.000Z',
+    timeElapsed: 123_000,
+    runLocations: ['eu-west-1', 'us-east-1'],
+    runSource: 'TRIGGER_API',
+  },
+]
+
+describe('formatCheckSessionsRun', () => {
+  const originalColumns = process.stdout.columns
+
+  beforeEach(() => {
+    Object.defineProperty(process.stdout, 'columns', { configurable: true, value: 180 })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process.stdout, 'columns', { configurable: true, value: originalColumns })
+  })
+
+  it('renders a readable terminal summary, table, and navigation hints', () => {
+    const output = stripAnsi(formatCheckSessionsRun(sessions, 'terminal', { detached: false }))
+
+    expect(output).toContain('2 check sessions completed: 1 passed, 1 failed.')
+    expect(output).toContain('Configured alerting rules apply to these check runs.')
+    expect(output).toContain('STATUS')
+    expect(output).toContain('NAME')
+    expect(output).toContain('LOCATIONS')
+    expect(output).toContain('CHECK ID')
+    expect(output).toContain('SESSION ID')
+    expect(output).toContain('Production API')
+    expect(output).toContain('Checkout journey')
+    expect(output).toContain('2m 3s')
+    expect(output).toContain('checkly checks get <check-id>')
+    expect(output).toContain(sessions[0].checkSessionLink)
+  })
+
+  it('describes detached sessions as started', () => {
+    const output = stripAnsi(formatCheckSessionsRun([
+      { ...sessions[0], status: 'PROGRESS', stoppedAt: null, timeElapsed: 0 },
+    ], 'terminal', { detached: true }))
+
+    expect(output).toContain('1 check session started.')
+    expect(output).toContain('progress')
+    expect(output).not.toContain('completed:')
+  })
+
+  it('renders session links in markdown output', () => {
+    const output = formatCheckSessionsRun(sessions, 'md', { detached: false })
+
+    expect(output).toContain('# Check sessions')
+    expect(output).toContain('| Status | Name | Type | Locations | Duration | Check ID | Session ID |')
+    expect(output).toContain(`[${sessions[0].checkSessionId}](${sessions[0].checkSessionLink})`)
+    expect(output).toContain('> Configured alerting rules apply to these check runs.')
+  })
+})

--- a/packages/cli/src/formatters/check-sessions.ts
+++ b/packages/cli/src/formatters/check-sessions.ts
@@ -1,0 +1,129 @@
+import chalk from 'chalk'
+
+import type { CheckSession, CheckSessionStatus } from '../rest/check-sessions.js'
+import {
+  type ColumnDef,
+  type OutputFormat,
+  formatCheckType,
+  renderAdaptiveTable,
+  renderCommandHints,
+} from './render.js'
+
+function formatStatus (status: CheckSessionStatus, format: OutputFormat): string {
+  const label = status.toLowerCase().replace(/_/g, ' ')
+  if (format === 'md') return label
+
+  switch (status) {
+    case 'PASSED':
+      return chalk.green(label)
+    case 'DEGRADED':
+    case 'PROGRESS':
+    case 'PROGRESS_DEGRADED':
+    case 'STARTED':
+      return chalk.yellow(label)
+    case 'FAILED':
+    case 'PROGRESS_FAILED':
+    case 'TIMED_OUT':
+      return chalk.red(label)
+    case 'CANCELLED':
+      return chalk.dim(label)
+  }
+}
+
+function formatDuration (milliseconds: number, format: OutputFormat): string {
+  if (milliseconds <= 0) return format === 'terminal' ? chalk.dim('-') : '-'
+  if (milliseconds < 1_000) return `${Math.round(milliseconds)}ms`
+
+  const totalSeconds = Math.round(milliseconds / 1_000)
+  const seconds = totalSeconds % 60
+  const totalMinutes = Math.floor(totalSeconds / 60)
+  if (totalMinutes === 0) return `${seconds}s`
+
+  const minutes = totalMinutes % 60
+  const hours = Math.floor(totalMinutes / 60)
+  if (hours === 0) return seconds === 0 ? `${minutes}m` : `${minutes}m ${seconds}s`
+  if (minutes === 0 && seconds === 0) return `${hours}h`
+  if (minutes === 0) return `${hours}h ${seconds}s`
+  return seconds === 0 ? `${hours}h ${minutes}m` : `${hours}h ${minutes}m ${seconds}s`
+}
+
+function formatLocations (locations: string[], format: OutputFormat): string {
+  if (locations.length === 0) return format === 'terminal' ? chalk.dim('-') : '-'
+  return locations.join(', ')
+}
+
+function buildColumns (format: OutputFormat): ColumnDef<CheckSession>[] {
+  if (format === 'md') {
+    return [
+      { header: 'Status', value: (session, fmt) => formatStatus(session.status, fmt) },
+      { header: 'Name', value: session => session.name ?? '-' },
+      { header: 'Type', value: session => formatCheckType(session.checkType) },
+      { header: 'Locations', value: (session, fmt) => formatLocations(session.runLocations, fmt) },
+      { header: 'Duration', value: (session, fmt) => formatDuration(session.timeElapsed, fmt) },
+      { header: 'Check ID', value: session => session.checkId },
+      {
+        header: 'Session ID',
+        value: session => `[${session.checkSessionId}](${session.checkSessionLink})`,
+      },
+    ]
+  }
+
+  return [
+    { header: 'Status', minWidth: 11, maxWidth: 18, value: (session, fmt) => formatStatus(session.status, fmt) },
+    { header: 'Name', minWidth: 18, maxWidth: 42, value: session => session.name ?? chalk.dim('-') },
+    { header: 'Type', minWidth: 10, maxWidth: 14, value: session => formatCheckType(session.checkType) },
+    {
+      header: 'Locations',
+      minWidth: 14,
+      maxWidth: 30,
+      value: (session, fmt) => formatLocations(session.runLocations, fmt),
+    },
+    { header: 'Duration', minWidth: 10, maxWidth: 12, value: (session, fmt) => formatDuration(session.timeElapsed, fmt) },
+    { header: 'Check ID', minWidth: 12, maxWidth: 38, value: session => chalk.dim(session.checkId) },
+    { header: 'Session ID', minWidth: 12, maxWidth: 38, value: session => chalk.dim(session.checkSessionId) },
+  ]
+}
+
+function formatSummary (sessions: CheckSession[], detached: boolean): string {
+  const count = sessions.length
+  const noun = `check session${count === 1 ? '' : 's'}`
+  if (detached) return `${count} ${noun} started.`
+
+  const statuses = new Map<CheckSessionStatus, number>()
+  for (const session of sessions) {
+    statuses.set(session.status, (statuses.get(session.status) ?? 0) + 1)
+  }
+  const summary = [...statuses.entries()]
+    .map(([status, statusCount]) => `${statusCount} ${status.toLowerCase().replace(/_/g, ' ')}`)
+    .join(', ')
+  return `${count} ${noun} completed: ${summary}.`
+}
+
+export function formatCheckSessionsRun (
+  sessions: CheckSession[],
+  format: OutputFormat,
+  options: { detached: boolean },
+): string {
+  const summary = formatSummary(sessions, options.detached)
+  const alertingNote = 'Configured alerting rules apply to these check runs.'
+  const table = renderAdaptiveTable(buildColumns(format), sessions, format)
+
+  if (format === 'md') {
+    return [
+      '# Check sessions',
+      '',
+      summary,
+      '',
+      `> ${alertingNote}`,
+      '',
+      table,
+    ].join('\n')
+  }
+
+  const hints = renderCommandHints([
+    { label: 'Inspect check', command: 'checkly checks get <check-id>' },
+    { label: sessions.length === 1 ? 'Open session' : 'Open first session', command: sessions[0].checkSessionLink },
+  ], { gap: 3 })
+
+  return [summary, chalk.dim(alertingNote), '', table, '', hints].join('\n')
+}

--- a/packages/cli/src/rest/__tests__/check-sessions.spec.ts
+++ b/packages/cli/src/rest/__tests__/check-sessions.spec.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import CheckSessions, {
+  CheckSessionWaitTimeoutError,
+  NoMatchingChecksError,
+} from '../check-sessions.js'
+import { NotFoundError, RequestTimeoutError } from '../errors.js'
+
+const completedSession = {
+  checkSessionId: '8166fa86-c9b4-4162-8541-d380c6c212d8',
+  checkSessionLink: 'https://app.checklyhq.com/check-sessions/session-id',
+  checkId: 'a4cd4ad9-4815-4a9e-92d2-0a7c562ee69a',
+  checkType: 'API',
+  name: 'Production API',
+  status: 'PASSED',
+  startedAt: '2026-07-21T12:00:00.000Z',
+  stoppedAt: '2026-07-21T12:00:01.000Z',
+  timeElapsed: 1_000,
+  runLocations: ['us-east-1'],
+  runSource: 'TRIGGER_API',
+  results: [],
+} as const
+
+describe('CheckSessions REST client', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('triggers v2 check sessions with the provided target', async () => {
+    const response = { sessions: [{ ...completedSession, status: 'PROGRESS', stoppedAt: null }] }
+    const api = { post: vi.fn().mockResolvedValue({ data: response }) }
+    const checkSessions = new CheckSessions(api as any)
+    const payload = {
+      target: {
+        matchTags: [['production', 'api'], ['critical']],
+        checkId: ['a4cd4ad9-4815-4a9e-92d2-0a7c562ee69a'],
+      },
+      refreshCache: true,
+    }
+
+    await expect(checkSessions.trigger(payload)).resolves.toEqual(response)
+    expect(api.post).toHaveBeenCalledWith('/v2/check-sessions/trigger', payload)
+  })
+
+  it('maps a trigger 404 to no matching checks', async () => {
+    const api = {
+      post: vi.fn().mockRejectedValue(new NotFoundError({
+        statusCode: 404,
+        error: 'Not Found',
+        message: 'No matching checks were found.',
+      })),
+    }
+    const checkSessions = new CheckSessions(api as any)
+
+    await expect(checkSessions.trigger({})).rejects.toBeInstanceOf(NoMatchingChecksError)
+  })
+
+  it('requests completion with the backend maximum long-poll duration', async () => {
+    const api = { get: vi.fn().mockResolvedValue({ data: completedSession }) }
+    const checkSessions = new CheckSessions(api as any)
+
+    await expect(checkSessions.getCompletion(completedSession.checkSessionId)).resolves.toEqual(completedSession)
+    expect(api.get).toHaveBeenCalledWith(
+      `/v2/check-sessions/${completedSession.checkSessionId}/completion`,
+      { params: { maxWaitSeconds: 30 } },
+    )
+  })
+
+  it('repeats retryable completion long-polls until the session completes', async () => {
+    const api = {
+      get: vi.fn()
+        .mockRejectedValueOnce(new RequestTimeoutError({
+          statusCode: 408,
+          error: 'Request Timeout',
+          message: 'Check session is still in progress.',
+        }))
+        .mockResolvedValueOnce({ data: completedSession }),
+    }
+    const checkSessions = new CheckSessions(api as any)
+
+    await expect(checkSessions.pollUntilComplete(completedSession.checkSessionId)).resolves.toEqual(completedSession)
+    expect(api.get).toHaveBeenCalledTimes(2)
+  })
+
+  it('caps each long-poll to the remaining overall timeout', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(10_000)
+    const api = { get: vi.fn().mockResolvedValue({ data: completedSession }) }
+    const checkSessions = new CheckSessions(api as any)
+
+    await checkSessions.pollUntilComplete(completedSession.checkSessionId, 15_500)
+
+    expect(api.get).toHaveBeenCalledWith(
+      `/v2/check-sessions/${completedSession.checkSessionId}/completion`,
+      { params: { maxWaitSeconds: 5 } },
+    )
+  })
+
+  it('fails before another request once the overall timeout is exhausted', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(10_000)
+    const api = { get: vi.fn() }
+    const checkSessions = new CheckSessions(api as any)
+
+    await expect(checkSessions.pollUntilComplete(completedSession.checkSessionId, 10_000))
+      .rejects
+      .toBeInstanceOf(CheckSessionWaitTimeoutError)
+    expect(api.get).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cli/src/rest/api.ts
+++ b/packages/cli/src/rest/api.ts
@@ -11,6 +11,7 @@ import Runtimes from './runtimes.js'
 import PrivateLocations from './private-locations.js'
 import Locations from './locations.js'
 import TestSessions from './test-sessions.js'
+import CheckSessions from './check-sessions.js'
 import EnvironmentVariables from './environment-variables.js'
 import HeartbeatChecks from './heartbeat-checks.js'
 import ChecklyStorage from './checkly-storage.js'
@@ -120,6 +121,7 @@ export const runtimes = new Runtimes(api)
 export const locations = new Locations(api)
 export const privateLocations = new PrivateLocations(api)
 export const testSessions = new TestSessions(api)
+export const checkSessions = new CheckSessions(api)
 export const environmentVariables = new EnvironmentVariables(api)
 export const heartbeatCheck = new HeartbeatChecks(api)
 export const checklyStorage = new ChecklyStorage(api)

--- a/packages/cli/src/rest/check-sessions.ts
+++ b/packages/cli/src/rest/check-sessions.ts
@@ -1,0 +1,140 @@
+import type { AxiosInstance } from 'axios'
+
+import { NotFoundError, RequestTimeoutError } from './errors.js'
+
+const COMPLETION_MAX_WAIT_SECONDS = 30
+
+export type CheckSessionStatus =
+  | 'STARTED'
+  | 'PROGRESS'
+  | 'FAILED'
+  | 'PASSED'
+  | 'DEGRADED'
+  | 'PROGRESS_FAILED'
+  | 'PROGRESS_DEGRADED'
+  | 'TIMED_OUT'
+  | 'CANCELLED'
+
+export type FinalCheckSessionStatus = 'PASSED' | 'FAILED' | 'DEGRADED' | 'TIMED_OUT' | 'CANCELLED'
+
+export interface CheckSessionResult {
+  checkResultId: string
+  checkResultLink: string
+  checkId: string
+  checkType: string
+  name: string
+  runLocation: string
+  resultType: 'FINAL' | 'ATTEMPT' | null
+  hasErrors: boolean
+  hasFailures: boolean
+  isDegraded: boolean
+  aborted: boolean
+  isCancelled: boolean
+  responseTime?: number | null
+  startedAt?: string | null
+  stoppedAt?: string | null
+}
+
+export interface CheckSession {
+  checkSessionId: string
+  checkSessionLink: string
+  checkId: string
+  checkType: string
+  name?: string
+  status: CheckSessionStatus
+  startedAt: string
+  stoppedAt: string | null
+  timeElapsed: number
+  runLocations: string[]
+  runSource: string | null
+}
+
+export interface CompletedCheckSession extends CheckSession {
+  status: FinalCheckSessionStatus
+  stoppedAt: string
+  results: CheckSessionResult[]
+}
+
+export interface TriggerCheckSessionsRequest {
+  target?: {
+    matchTags?: string[][]
+    checkId?: string[]
+  }
+  refreshCache?: boolean
+}
+
+export interface TriggerCheckSessionsResponse {
+  sessions: CheckSession[]
+}
+
+export class NoMatchingChecksError extends Error {
+  constructor (options?: ErrorOptions) {
+    super('No matching checks found.', options)
+    this.name = 'NoMatchingChecksError'
+  }
+}
+
+export class CheckSessionWaitTimeoutError extends Error {
+  checkSessionId: string
+
+  constructor (checkSessionId: string) {
+    super(`Timed out waiting for check session ${checkSessionId} to complete.`)
+    this.name = 'CheckSessionWaitTimeoutError'
+    this.checkSessionId = checkSessionId
+  }
+}
+
+class CheckSessions {
+  api: AxiosInstance
+
+  constructor (api: AxiosInstance) {
+    this.api = api
+  }
+
+  async trigger (payload: TriggerCheckSessionsRequest): Promise<TriggerCheckSessionsResponse> {
+    try {
+      const response = await this.api.post<TriggerCheckSessionsResponse>('/v2/check-sessions/trigger', payload)
+      return response.data
+    } catch (err) {
+      // The trigger endpoint has no path resource that can be missing. Its 404
+      // response specifically means that no activated, runnable checks matched.
+      if (err instanceof NotFoundError) {
+        throw new NoMatchingChecksError({ cause: err })
+      }
+      throw err
+    }
+  }
+
+  async getCompletion (id: string, maxWaitSeconds = COMPLETION_MAX_WAIT_SECONDS): Promise<CompletedCheckSession> {
+    const response = await this.api.get<CompletedCheckSession>(`/v2/check-sessions/${id}/completion`, {
+      params: { maxWaitSeconds },
+    })
+    return response.data
+  }
+
+  async pollUntilComplete (id: string, deadlineAt?: number): Promise<CompletedCheckSession> {
+    while (true) {
+      const remainingMs = deadlineAt === undefined ? Number.POSITIVE_INFINITY : deadlineAt - Date.now()
+      if (remainingMs <= 0) {
+        throw new CheckSessionWaitTimeoutError(id)
+      }
+
+      const maxWaitSeconds = Number.isFinite(remainingMs)
+        ? Math.min(COMPLETION_MAX_WAIT_SECONDS, Math.max(1, Math.floor(remainingMs / 1_000)))
+        : COMPLETION_MAX_WAIT_SECONDS
+
+      try {
+        return await this.getCompletion(id, maxWaitSeconds)
+      } catch (err) {
+        // The completion endpoint long-polls. A 408 means the session is still
+        // running, so start another bounded long-poll until the overall deadline.
+        if (err instanceof RequestTimeoutError) {
+          continue
+        }
+        throw err
+      }
+    }
+  }
+}
+
+export default CheckSessions


### PR DESCRIPTION
## Summary

- add `checkly checks run` backed by the existing public v2 Check Sessions trigger API
- wait for all sessions by default through bounded completion long-polls, with `--timeout` and `--detach` support
- select checks with `--tags` and `--check-id`, preserve configured locations, and make the normal configured alerting behavior explicit
- add consistent table, JSON, and Markdown output plus failure/no-match handling
- document the difference between ordinary Check Sessions and non-alerting Test Sessions in the bundled agent guidance

## Backend contract

This uses the already-shipped `POST /v2/check-sessions/trigger` and `GET /v2/check-sessions/{checkSessionId}/completion` endpoints. No backend PR is required. The API supports deployed configuration, check IDs, tag groups, and cache refresh; Test Session overrides such as location, environment variables, and retries are intentionally not exposed.

## Validation

- `pnpm run lint`
- `pnpm --filter checkly test`
- `pnpm --filter checkly run prepare:dist`
- `pnpm --filter checkly run prepack`
- `CHECKLY_SKIP_AUTH=1 CHECKLY_CLI_VERSION=99.0.0 ./packages/cli/bin/run checks run --help`

## Follow-up

Checkly Action support belongs in its own repository and can follow once a CLI version containing this command is published.