### PR TITLE
fix(constructs): treat null webhookSecret as unset in MSTeams codegen [ship]

### DIFF
--- a/packages/cli/src/constructs/__tests__/msteams-alert-channel-codegen.spec.ts
+++ b/packages/cli/src/constructs/__tests__/msteams-alert-channel-codegen.spec.ts
@@ -1,0 +1,61 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { MSTeamsAlertChannelCodegen, type MSTeamsAlertChannelResource } from '../msteams-alert-channel-codegen.js'
+import { Context } from '../internal/codegen/index.js'
+import { Program } from '../../sourcegen/index.js'
+
+describe('MSTeamsAlertChannelCodegen', () => {
+  let rootDirectory: string
+
+  beforeEach(async () => {
+    rootDirectory = await mkdtemp(path.join(tmpdir(), 'msteams-alert-channel-codegen-'))
+  })
+
+  afterEach(async () => {
+    await rm(rootDirectory, { recursive: true, force: true })
+  })
+
+  it('imports as MSTeamsAlertChannel when webhookSecret is null', async () => {
+    const program = new Program({
+      rootDirectory,
+      constructFileSuffix: '.check',
+      specFileSuffix: '.spec',
+      language: 'typescript',
+    })
+    const codegen = new MSTeamsAlertChannelCodegen(program)
+    const context = new Context()
+    const resource: MSTeamsAlertChannelResource = {
+      id: 123,
+      type: 'WEBHOOK',
+      config: {
+        name: 'Teams channel',
+        webhookType: 'WEBHOOK_MSTEAMS',
+        url: 'https://example.webhook.office.com/webhookb2/abc',
+        method: 'POST',
+        headers: [],
+        webhookSecret: null,
+      },
+      sendRecovery: true,
+      sendFailure: true,
+      sendDegraded: false,
+      sslExpiry: false,
+      sslExpiryThreshold: 30,
+    }
+
+    codegen.prepare('teams-channel', resource, context)
+    codegen.gencode('teams-channel', resource, context)
+    await program.realize()
+
+    const [filePath] = program.paths
+    if (filePath === undefined) {
+      throw new Error('Codegen did not register a generated file')
+    }
+    const source = await readFile(filePath, 'utf8')
+
+    expect(source).toContain('MSTeamsAlertChannel')
+  })
+})

--- a/packages/cli/src/constructs/msteams-alert-channel-codegen.ts
+++ b/packages/cli/src/constructs/msteams-alert-channel-codegen.ts
@@ -28,7 +28,7 @@ export class MSTeamsAlertChannelCodegen extends Codegen<MSTeamsAlertChannelResou
       throw new ImportSafetyViolation(`Unsupported value for property 'queryParameters' (expected no value or an empty array)`)
     }
 
-    if (config.webhookSecret !== undefined) {
+    if (config.webhookSecret) {
       throw new ImportSafetyViolation(`Unsupported value for property 'webhookSecret' (expected no value)`)
     }
   }


### PR DESCRIPTION
## Summary
- `MSTeamsAlertChannelCodegen.validateSafety()` checked `config.webhookSecret !== undefined`, so a `null` webhookSecret (the shape real API responses use for "no secret configured") incorrectly threw `ImportSafetyViolation`.
- This made `checkly import plan` silently fall back to a generic `WebhookAlertChannel` construct instead of the more readable `MSTeamsAlertChannel`, since `WebhookAlertChannelCodegen` catches `ImportSafetyViolation` and falls back.
- Changed the check to a truthy check (`if (config.webhookSecret)`), matching the existing, correct behavior in the sibling `TelegramAlertChannelCodegen` and `IncidentioAlertChannelCodegen`, and matching the `webhookSecret?: string | null` type.

## Test plan
- [x] Added `msteams-alert-channel-codegen.spec.ts` asserting a resource with `config.webhookSecret: null` generates a `MSTeamsAlertChannel` construct (not a fallback), mirroring the existing `telegram-alert-channel-codegen.spec.ts` pattern.
- [x] Confirmed the new test fails against the old code (thrown `ImportSafetyViolation`) and passes after the fix.
- [x] `pnpm --filter checkly test` — 131 test files / 1688 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)