### PR TITLE
Hide legacy Agentic Checks from CLI discovery [ship]

### DIFF
--- a/packages/cli/src/ai-context/__tests__/references.spec.ts
+++ b/packages/cli/src/ai-context/__tests__/references.spec.ts
@@ -2,7 +2,6 @@ import { readFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
-import { REFERENCES, SKILL } from '../context.js'
 
 const referencesDir = join(dirname(fileURLToPath(import.meta.url)), '../references')
 
@@ -15,18 +14,6 @@ function normalizeLineEndings (content: string): string {
 }
 
 describe('AI context investigation references', () => {
-  it('does not advertise Agentic Checks in default discovery or the public skill', async () => {
-    const publicSkill = normalizeLineEndings(await readFile(
-      join(referencesDir, '../../../../../skills/checkly/SKILL.md'),
-      'utf8',
-    ))
-
-    expect(REFERENCES.some(reference => reference.id === 'configure-agentic-checks')).toBe(false)
-    expect(SKILL.description).not.toContain('Agentic Checks')
-    expect(publicSkill).not.toContain('Agentic Checks')
-    expect(publicSkill).not.toContain('AgenticCheck')
-  })
-
   it('does not promise every disabled entitlement has an upgrade URL', async () => {
     const files = ['configure.md', 'initialize.md', 'manage.md', 'manage-plan.md']
     const contents = await Promise.all(files.map(async file => normalizeLineEndings(await readReference(file))))

--- a/packages/cli/src/ai-context/__tests__/references.spec.ts
+++ b/packages/cli/src/ai-context/__tests__/references.spec.ts
@@ -2,6 +2,7 @@ import { readFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
+import { REFERENCES, SKILL } from '../context.js'
 
 const referencesDir = join(dirname(fileURLToPath(import.meta.url)), '../references')
 
@@ -14,6 +15,28 @@ function normalizeLineEndings (content: string): string {
 }
 
 describe('AI context investigation references', () => {
+  it('does not advertise Agentic Checks in default discovery or the public skill', async () => {
+    const publicSkill = normalizeLineEndings(await readFile(
+      join(referencesDir, '../../../../../skills/checkly/SKILL.md'),
+      'utf8',
+    ))
+
+    expect(REFERENCES.some(reference => reference.id === 'configure-agentic-checks')).toBe(false)
+    expect(SKILL.description).not.toContain('Agentic Checks')
+    expect(publicSkill).not.toContain('Agentic Checks')
+    expect(publicSkill).not.toContain('AgenticCheck')
+  })
+
+  it('does not promise every disabled entitlement has an upgrade URL', async () => {
+    const files = ['configure.md', 'initialize.md', 'manage.md', 'manage-plan.md']
+    const contents = await Promise.all(files.map(async file => normalizeLineEndings(await readReference(file))))
+
+    for (const content of contents) {
+      expect(content).not.toMatch(/each disabled entitlement includes an `upgradeUrl`/i)
+      expect(content).toMatch(/may include an `upgradeUrl`|only when .*includes|only when present/i)
+    }
+  })
+
   it('documents read-only alerting investigation without claiming unavailable globals', async () => {
     const content = normalizeLineEndings(await readReference('investigate-alerting.md'))
 

--- a/packages/cli/src/ai-context/context.ts
+++ b/packages/cli/src/ai-context/context.ts
@@ -1,9 +1,5 @@
 export const REFERENCES = [
   {
-    id: 'configure-agentic-checks',
-    description: 'Agentic Check construct (`AgenticCheck`) for AI-powered prompt-driven monitoring with skill and env var allowlists',
-  },
-  {
     id: 'configure-api-checks',
     description: 'Api Check construct (`ApiCheck`), assertions, and authentication setup scripts',
   },
@@ -178,11 +174,6 @@ export default defineConfig({
 })
 `,
     reference: 'https://www.checklyhq.com/docs/constructs/project/',
-  },
-  AGENTIC_CHECK: {
-    templateString: '<!-- EXAMPLE: AGENTIC_CHECK -->',
-    exampleConfigPath: 'resources/agentic-checks/example-agentic-check.check.ts',
-    reference: 'https://www.checklyhq.com/docs/constructs/agentic-check/',
   },
   BROWSER_CHECK: {
     templateString: '<!-- EXAMPLE: BROWSER_CHECK -->',

--- a/packages/cli/src/ai-context/references/configure.md
+++ b/packages/cli/src/ai-context/references/configure.md
@@ -64,7 +64,7 @@ Not all features and locations are available on all plans. **Before configuring 
 npx checkly account plan --output json
 ```
 
-This returns your exact entitlements and available locations. Use only locations where `available` is `true` in the `locations.all` array. If a feature is disabled, the response includes an `upgradeUrl` to share with the user.
+This returns your exact entitlements and available locations. Use only locations where `available` is `true` in the `locations.all` array. A disabled feature may include an `upgradeUrl`; share it only when present. Without one, the feature is unavailable.
 
 Run `npx checkly skills manage plan` for the full reference.
 

--- a/packages/cli/src/ai-context/references/initialize.md
+++ b/packages/cli/src/ai-context/references/initialize.md
@@ -75,7 +75,7 @@ This shows your entitlements, limits, and available locations. Use this data whe
 - **Check feature availability** before configuring constructs like private locations, advanced alert channels, or higher-frequency schedules.
 - **Respect metered limits** — the `quantity` field shows maximums for each metered feature.
 
-If a feature the user wants is disabled, the response includes an `upgradeUrl` — share it so they can upgrade their plan.
+If a feature the user wants is disabled, share its `upgradeUrl` only when the response includes one. A disabled entitlement without an upgrade URL is unavailable.
 
 Run `npx checkly skills manage plan` for the full reference.
 

--- a/packages/cli/src/ai-context/references/investigate-test-sessions.md
+++ b/packages/cli/src/ai-context/references/investigate-test-sessions.md
@@ -112,7 +112,7 @@ Flags:
 - `-w, --watch` - wait for completion and print the analysis.
 - `-o, --output <format>` - `detail` (default), `json`, or `md`; watch mode is only supported with detail output.
 
-If RCA is unavailable because of plan or entitlement limits, run `npx checkly account plan --output json` and report the relevant entitlement or upgrade URL.
+If RCA is unavailable because of plan or entitlement limits, run `npx checkly account plan --output json` and report the relevant entitlement and its upgrade URL only if one is present.
 
 ## Retrieve result assets
 

--- a/packages/cli/src/ai-context/references/manage-plan.md
+++ b/packages/cli/src/ai-context/references/manage-plan.md
@@ -46,4 +46,4 @@ npx checkly account plan --help                    # Full flag reference
 1. **Locations:** Filter `locations.all` to entries where `available === true`. Use only those IDs in `checkly.config.ts` and check constructs. Respect `maxPerCheck` as the upper bound per check.
 2. **Metered entitlements:** Check `quantity` for limits. `enabled: false` means the feature is not available.
 3. **Flag entitlements:** `enabled: true` means available, `false` means not on this plan.
-4. **Disabled features:** Each includes an `upgradeUrl`. Share this with the user — it points to the self-service checkout page or the enterprise contact sales page depending on the required plan.
+4. **Disabled features:** An entitlement may include an `upgradeUrl`. Share it only when present; it points to self-service checkout or enterprise contact sales depending on the required plan. Without one, the entitlement is unavailable.

--- a/packages/cli/src/ai-context/references/manage.md
+++ b/packages/cli/src/ai-context/references/manage.md
@@ -12,12 +12,12 @@ Checkly accounts have different capabilities depending on the plan (Hobby, Start
 npx checkly account plan --output json
 ```
 
-This returns your entitlements (enabled/disabled with limits), available locations, and upgrade URLs. Use this to:
+This returns your entitlements (enabled/disabled with limits), available locations, and any applicable upgrade URLs. Use this to:
 
 - **Filter locations** to only those where `available` is `true` in `locations.all`
 - **Check feature flags** before using constructs (e.g. private locations, advanced alert channels)
 - **Respect metered limits** (e.g. max browser checks, max alert channels)
-- **Surface upgrade paths** when a feature is disabled — each disabled entitlement includes an `upgradeUrl` pointing to the self-service checkout or the contact sales page
+- **Surface upgrade paths** only when a disabled entitlement includes an `upgradeUrl`; otherwise report the entitlement as unavailable
 
 ## Applying entitlements to check configuration
 
@@ -40,7 +40,7 @@ npx checkly account plan --output json --search "uptime"
 npx checkly account plan --disabled --search "retry"
 ```
 
-**When a feature is disabled:** Do not use it. Omit the property from the construct — Checkly will apply safe defaults. If the user needs the feature, share the `upgradeUrl` from the entitlement.
+**When a feature is disabled:** Do not use it. Omit the property from the construct — Checkly will apply safe defaults. If the entitlement includes an `upgradeUrl`, share it with the user; otherwise report that the feature is unavailable.
 
 ## Available Commands
 

--- a/packages/cli/src/ai-context/skill.md
+++ b/packages/cli/src/ai-context/skill.md
@@ -1,6 +1,6 @@
 ---
 name: checkly
-description: Set up, create, test and manage monitoring checks using the Checkly CLI. Use when working with Agentic Checks, API Checks, Browser Checks, URL Monitors, ICMP Monitors, Playwright Check Suites, Heartbeat Monitors, Alert Channels, Dashboards, or Status Pages. Access Checkly account plan, entitlements, feature limits, members, and pending invites. Includes generic API pass-through (`checkly api`) for endpoints without dedicated commands.
+description: Set up, create, test and manage monitoring checks using the Checkly CLI. Use when working with API Checks, Browser Checks, URL Monitors, ICMP Monitors, Playwright Check Suites, Heartbeat Monitors, Alert Channels, Dashboards, or Status Pages. Access Checkly account plan, entitlements, feature limits, members, and pending invites. Includes generic API pass-through (`checkly api`) for endpoints without dedicated commands.
 allowed-tools: Bash(npx:checkly:*) Bash(npm:install:*)
 metadata:
   author: checkly
@@ -28,7 +28,7 @@ Agents load what they need for each task.
 
 ## Plan Awareness
 
-Before configuring checks, run `npx checkly account plan --output json` to see what features, locations, and limits are available on the current plan. Disabled features include an `upgradeUrl` pointing to the self-service checkout page or the enterprise contact sales page — share these with the user when they need a feature that's not on their plan.
+Before configuring checks, run `npx checkly account plan --output json` to see what features, locations, and limits are available on the current plan. A disabled entitlement may include an `upgradeUrl` for self-service checkout or enterprise contact sales. Share it only when present; otherwise the entitlement is unavailable.
 
 Run `npx checkly skills manage` for the full reference.
 

--- a/packages/cli/src/commands/__tests__/account-plan.spec.ts
+++ b/packages/cli/src/commands/__tests__/account-plan.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { withUpgradeUrl } from '../account/plan.js'
+import type { Entitlement } from '../../rest/entitlements.js'
+
+const unavailableEntitlement: Entitlement = {
+  key: 'AGENTIC_CHECKS',
+  name: 'Agentic Checks',
+  description: 'Legacy AI-powered checks',
+  type: 'metered',
+  enabled: false,
+}
+
+const upgradeableEntitlement: Entitlement = {
+  ...unavailableEntitlement,
+  key: 'PRIVATE_LOCATIONS',
+  requiredPlan: 'TEAM',
+}
+
+describe('account plan JSON entitlements', () => {
+  it('omits upgradeUrl when the API does not provide an upgrade path', () => {
+    expect(withUpgradeUrl(unavailableEntitlement, 'https://example.com')).not.toHaveProperty('upgradeUrl')
+  })
+
+  it('adds upgradeUrl when the API provides a required plan or add-on', () => {
+    expect(withUpgradeUrl(upgradeableEntitlement, 'https://example.com')).toMatchObject({
+      upgradeUrl: 'https://example.com',
+    })
+  })
+})

--- a/packages/cli/src/commands/account/plan.ts
+++ b/packages/cli/src/commands/account/plan.ts
@@ -12,9 +12,10 @@ import {
 } from '../../formatters/account-plan.js'
 import type { Entitlement } from '../../rest/entitlements.js'
 
-function withUpgradeUrl (e: Entitlement, checkoutUrl: string) {
+export function withUpgradeUrl (e: Entitlement, checkoutUrl: string) {
   if (e.enabled) return e
-  return { ...e, upgradeUrl: getEntitlementUpgradeUrl(e, checkoutUrl) }
+  const upgradeUrl = getEntitlementUpgradeUrl(e, checkoutUrl)
+  return upgradeUrl ? { ...e, upgradeUrl } : e
 }
 
 export default class AccountPlan extends AuthCommand {

--- a/packages/cli/src/formatters/__tests__/account-plan.spec.ts
+++ b/packages/cli/src/formatters/__tests__/account-plan.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { stripAnsi } from '../render.js'
 import {
   formatUpgradePath,
+  getEntitlementUpgradeUrl,
   formatLocations,
   formatPlanHeader,
   formatPlanSummary,
@@ -45,6 +46,20 @@ describe('formatUpgradePath', () => {
       requiredPlanDisplayName: undefined,
     }
     expect(formatUpgradePath(entitlement)).toBe('Team plan')
+  })
+})
+
+describe('getEntitlementUpgradeUrl', () => {
+  it('returns no upgrade URL for a disabled entitlement with no upgrade data', () => {
+    expect(getEntitlementUpgradeUrl(disabledFlagNoUpgradeData, 'https://example.com')).toBeUndefined()
+  })
+
+  it('preserves checkout and contact-sales upgrade URLs when the API provides upgrade data', () => {
+    expect(getEntitlementUpgradeUrl(disabledFlagPlanOnly, 'https://example.com')).toBe('https://example.com')
+    expect(getEntitlementUpgradeUrl({
+      ...disabledFlagPlanOnly,
+      requiredPlan: 'CONTRACT',
+    }, 'https://example.com')).toContain('checklyhq.com/contact-sales')
   })
 })
 
@@ -162,12 +177,12 @@ describe('formatEntitlementDetail', () => {
     expect(plain).not.toContain('Upgrade Link:')
   })
 
-  it('shows Contact sales for disabled entitlement with no upgrade data', () => {
+  it('shows Unavailable with no upgrade link for disabled entitlement with no upgrade data', () => {
     const result = formatEntitlementDetail(hobbyPlan, disabledFlagNoUpgradeData, 'terminal', 'https://example.com')
     const plain = stripAnsi(result)
     expect(plain).toContain('Required Upgrade:')
-    expect(plain).toContain('Contact sales')
-    expect(plain).toContain('checklyhq.com/contact-sales')
+    expect(plain).toContain('Unavailable')
+    expect(plain).not.toContain('Upgrade Link:')
   })
 })
 
@@ -178,7 +193,7 @@ describe('formatFilteredEntitlements', () => {
     const plain = stripAnsi(result)
     expect(plain).toContain('REQUIRED UPGRADE')
     expect(plain).toContain('Team plan')
-    expect(plain).toContain('Contact sales')
+    expect(plain).toContain('Unavailable')
   })
 
   it('includes REQUIRED UPGRADE column in metered table', () => {

--- a/packages/cli/src/formatters/account-plan.ts
+++ b/packages/cli/src/formatters/account-plan.ts
@@ -71,23 +71,23 @@ export function formatLocations (locations: AccountLocations, format: OutputForm
 // --- Column definitions ---
 
 export const CONTACT_SALES_URL = 'https://www.checklyhq.com/contact-sales/'
-const CONTACT_SALES_LABEL = 'Contact sales'
+const UNAVAILABLE_LABEL = 'Unavailable'
 
 /**
  * Returns the appropriate upgrade URL for a disabled entitlement:
  * - CONTRACT plan → contact sales
  * - Self-serve plan/addon → billing checkout
- * - No upgrade data → contact sales (fallback)
+ * - No upgrade data → no upgrade path is available
  */
-export function getEntitlementUpgradeUrl (e: Entitlement, checkoutUrl: string): string {
+export function getEntitlementUpgradeUrl (e: Entitlement, checkoutUrl: string): string | undefined {
   if (e.requiredPlan === 'CONTRACT') return CONTACT_SALES_URL
   if (e.requiredPlan || e.requiredAddon) return checkoutUrl
-  return CONTACT_SALES_URL
+  return undefined
 }
 
 function upgradeLabel (e: Entitlement): string {
   if (e.enabled) return '-'
-  return formatUpgradePath(e) ?? CONTACT_SALES_LABEL
+  return formatUpgradePath(e) ?? UNAVAILABLE_LABEL
 }
 
 const upgradeColumn: ColumnDef<Entitlement> = {
@@ -189,11 +189,11 @@ const detailFields = (upgradeUrl: string): DetailField<Entitlement>[] => [
   },
   {
     label: 'Required Upgrade',
-    value: e => e.enabled ? null : (formatUpgradePath(e) ?? CONTACT_SALES_LABEL),
+    value: e => e.enabled ? null : (formatUpgradePath(e) ?? UNAVAILABLE_LABEL),
   },
   {
     label: 'Upgrade Link',
-    value: e => e.enabled ? null : getEntitlementUpgradeUrl(e, upgradeUrl),
+    value: e => e.enabled ? null : (getEntitlementUpgradeUrl(e, upgradeUrl) ?? null),
   },
 ]
 

--- a/skills/checkly/SKILL.md
+++ b/skills/checkly/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: checkly
-description: Set up, create, test and manage monitoring checks using the Checkly CLI. Use when working with Agentic Checks, API Checks, Browser Checks, URL Monitors, ICMP Monitors, Playwright Check Suites, Heartbeat Monitors, Alert Channels, Dashboards, or Status Pages. Access Checkly account plan, entitlements, feature limits, members, and pending invites. Includes generic API pass-through (`checkly api`) for endpoints without dedicated commands.
+description: Set up, create, test and manage monitoring checks using the Checkly CLI. Use when working with API Checks, Browser Checks, URL Monitors, ICMP Monitors, Playwright Check Suites, Heartbeat Monitors, Alert Channels, Dashboards, or Status Pages. Access Checkly account plan, entitlements, feature limits, members, and pending invites. Includes generic API pass-through (`checkly api`) for endpoints without dedicated commands.
 allowed-tools: Bash(npx:checkly:*) Bash(npm:install:*)
 metadata:
   author: checkly
@@ -28,7 +28,7 @@ Agents load what they need for each task.
 
 ## Plan Awareness
 
-Before configuring checks, run `npx checkly account plan --output json` to see what features, locations, and limits are available on the current plan. Disabled features include an `upgradeUrl` pointing to the self-service checkout page or the enterprise contact sales page — share these with the user when they need a feature that's not on their plan.
+Before configuring checks, run `npx checkly account plan --output json` to see what features, locations, and limits are available on the current plan. A disabled entitlement may include an `upgradeUrl` for self-service checkout or enterprise contact sales. Share it only when present; otherwise the entitlement is unavailable.
 
 Run `npx checkly skills manage` for the full reference.
 


### PR DESCRIPTION
## Summary
- remove Agentic Checks from default generated skills and public skill metadata while retaining the legacy construct
- render disabled entitlements without backend upgrade metadata as Unavailable and omit their JSON `upgradeUrl`
- preserve checkout and contact-sales links when the API supplies required plan or add-on metadata

## Validation
- `pnpm --filter checkly exec vitest --run src/formatters/__tests__/account-plan.spec.ts src/commands/__tests__/account-plan.spec.ts src/ai-context/__tests__/references.spec.ts`
- `pnpm --filter checkly exec tsc -p tsconfig.json --skipLibCheck`
- `pnpm lint`
- `pnpm --filter checkly run clean:dist && pnpm --filter checkly run prepare:dist && pnpm --filter checkly run prepare:ai-context`
- `pnpm --filter checkly run prepack`
- `./packages/cli/bin/run skills`