### PR TITLE
fix(cli): use valid allowed-tools syntax in checkly skill frontmatter [ship]

### DIFF
--- a/packages/cli/src/ai-context/skill.md
+++ b/packages/cli/src/ai-context/skill.md
@@ -1,7 +1,7 @@
 ---
 name: checkly
 description: Set up, create, test and manage monitoring checks using the Checkly CLI. Use when working with API Checks, Browser Checks, URL Monitors, ICMP Monitors, Playwright Check Suites, Heartbeat Monitors, Alert Channels, Dashboards, or Status Pages. Access Checkly account plan, entitlements, feature limits, members, and pending invites. Includes generic API pass-through (`checkly api`) for endpoints without dedicated commands.
-allowed-tools: Bash(npx:checkly:*) Bash(npm:install:*)
+allowed-tools: Bash(npx checkly:*), Bash(npm install:*)
 metadata:
   author: checkly
 ---

--- a/skills/checkly/SKILL.md
+++ b/skills/checkly/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: checkly
 description: Set up, create, test and manage monitoring checks using the Checkly CLI. Use when working with API Checks, Browser Checks, URL Monitors, ICMP Monitors, Playwright Check Suites, Heartbeat Monitors, Alert Channels, Dashboards, or Status Pages. Access Checkly account plan, entitlements, feature limits, members, and pending invites. Includes generic API pass-through (`checkly api`) for endpoints without dedicated commands.
-allowed-tools: Bash(npx:checkly:*) Bash(npm:install:*)
+allowed-tools: Bash(npx checkly:*), Bash(npm install:*)
 metadata:
   author: checkly
 ---


### PR DESCRIPTION
## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [ ] Docs
* [ ] Examples
* [ ] Other

## Notes for the Reviewer
The `allowed-tools` frontmatter in the public checkly skill was invalid on two counts: entries must be comma-separated, and Bash permission rules use spaces between command words, not colons. As written, `Bash(npx:checkly:*)` only matches a literal command starting with `npx:checkly:`, which never occurs, so the intended pre-approval did nothing.

Fixed to:

```
allowed-tools: Bash(npx checkly:*), Bash(npm install:*)
```

Changed in the source (`packages/cli/src/ai-context/skill.md`) and regenerated the published copy at `skills/checkly/SKILL.md` via `pnpm --filter checkly run prepare` + `pnpm run sync:skills`.