### PR TITLE
docs(cli): tell MCP-only sessions to skip the CLI skill opener [ship]

### DIFF
--- a/packages/cli/src/ai-context/skill.md
+++ b/packages/cli/src/ai-context/skill.md
@@ -8,6 +8,8 @@ metadata:
 
 # Checkly
 
+**MCP sessions:** Everything in this skill drives the `npx checkly` CLI in a shell. If this session reaches Checkly through the Checkly MCP server and you cannot run shell commands, stop here — these instructions will not work for you. Use the Checkly MCP tools for live account work (check status, test sessions, triggering checks, incidents) instead. If you can run shell commands, keep following this skill even when Checkly MCP tools are also connected.
+
 **Required:** Before answering any Checkly question, run `npx checkly skills` to get the current and up-to-date action list. Do not rely on memory or prior context — the CLI is the source of truth and actions might change between releases.
 
 Then run `npx checkly skills <action>` to load up-to-date details for the action you need.

--- a/skills/checkly/SKILL.md
+++ b/skills/checkly/SKILL.md
@@ -8,6 +8,8 @@ metadata:
 
 # Checkly
 
+**MCP sessions:** Everything in this skill drives the `npx checkly` CLI in a shell. If this session reaches Checkly through the Checkly MCP server and you cannot run shell commands, stop here — these instructions will not work for you. Use the Checkly MCP tools for live account work (check status, test sessions, triggering checks, incidents) instead. If you can run shell commands, keep following this skill even when Checkly MCP tools are also connected.
+
 **Required:** Before answering any Checkly question, run `npx checkly skills` to get the current and up-to-date action list. Do not rely on memory or prior context — the CLI is the source of truth and actions might change between releases.
 
 Then run `npx checkly skills <action>` to load up-to-date details for the action you need.


### PR DESCRIPTION
## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [x] Docs
* [ ] Examples
* [ ] Other

## Notes for the Reviewer

The checkly skill is written entirely for CLI usage, but agents can also reach Checkly through the [Checkly MCP server](https://www.checklyhq.com/docs/ai/overview/). An MCP-only session (e.g. a desktop or sandboxed agent without shell access) that loads this skill would try to run `npx checkly skills` and fail.

This adds an **MCP sessions** gate as the first paragraph of the skill body, before the "Required" directive, telling such agents to stop and use the Checkly MCP tools for live account work instead.

The condition is deliberately "MCP **and** no shell", not just "MCP connected": a coding-agent session can have both the repo and the MCP server attached, and skills + CLI remain the recommended path there — the closing sentence guards that case so agents don't abandon the skill unnecessarily.

Edited the source at `packages/cli/src/ai-context/skill.md` and regenerated `skills/checkly/SKILL.md` via `prepare` + `sync:skills`, so the CI sync check should pass.