### PR TITLE
fix(cli): close write stream before temp-file cleanup in downloadAssetToFile [RED-860] [ship]

### DIFF
--- a/packages/cli/src/helpers/result-assets.ts
+++ b/packages/cli/src/helpers/result-assets.ts
@@ -4,7 +4,8 @@ import { randomUUID } from 'node:crypto'
 import { constants, createWriteStream } from 'node:fs'
 import { access, mkdir, rename, rm } from 'node:fs/promises'
 import { Transform } from 'node:stream'
-import { pipeline } from 'node:stream/promises'
+import { finished, pipeline } from 'node:stream/promises'
+import Debug from 'debug'
 import { minimatch } from 'minimatch'
 import * as api from '../rest/api.js'
 import { assignProxy } from '../services/proxy.js'
@@ -14,6 +15,8 @@ import type {
   AssetManifestEntry,
 } from '../rest/asset-manifests.js'
 import { assetSelectorValue } from '../formatters/assets.js'
+
+const debug = Debug('checkly:cli:helpers:result-assets')
 
 export const assetTypes = [
   'log',
@@ -404,17 +407,29 @@ export async function downloadAssetToFile (
   await mkdir(path.dirname(filePath), { recursive: true })
   const tempPath = temporaryDownloadPath(filePath)
 
+  const response = await fetchAssetStream(asset.url)
+  const transform = progressTransform(parseContentLength(response.headers), options.onProgress)
+  const writable = createWriteStream(tempPath)
+
   try {
-    const response = await fetchAssetStream(asset.url)
-    const transform = progressTransform(parseContentLength(response.headers), options.onProgress)
     if (transform) {
-      await pipeline(response.data, transform, createWriteStream(tempPath))
+      await pipeline(response.data, transform, writable)
     } else {
-      await pipeline(response.data, createWriteStream(tempPath))
+      await pipeline(response.data, writable)
     }
     await rename(tempPath, filePath)
   } catch (err) {
-    await rm(tempPath, { force: true })
+    writable.destroy()
+    // Wait for the underlying file handle to finish opening and close before
+    // removing the temp file; otherwise a still-pending open can recreate it
+    // after rm, or (on Windows) keep the unlinked entry visible in readdir.
+    await finished(writable).catch(() => {})
+    // Cleanup is best-effort: a leaked temp file is preferable to masking the
+    // original download error with an rm failure. maxRetries covers Windows
+    // EBUSY/EPERM from external processes briefly holding the fresh temp file.
+    await rm(tempPath, { force: true, maxRetries: 3 }).catch((cleanupErr: unknown) => {
+      debug('Failed to remove temporary download file %s: %O', tempPath, cleanupErr)
+    })
     throw err
   }
 


### PR DESCRIPTION
Linear: RED-860

## Problem

`downloadAssetToFile` cleans up its temp file with `rm(tempPath, { force: true })` on failure, but cleanup is not sequenced after the write stream has fully closed. When the source stream errors immediately, `pipeline` can reject while the `createWriteStream` open is still in flight: `rm` swallows `ENOENT`, and the pending open then recreates the temp file with nothing left to delete it. On Windows the same race also shows up as the unlinked entry lingering in `readdir` while a handle is still open.

Observable as:

- A real (minor) bug: a failed download can leak a `.<name>.<pid>.<uuid>.tmp` file into the user's assets directory.
- The flaky Windows CI test `assets.spec.ts > preserves existing files when a forced download fails`, which intermittently sees the leftover temp file.

## Fix

- Create the write stream explicitly as a `const` (fetch and progress transform hoisted above the try — errors before the stream exists create no temp file, so they need no cleanup).
- On failure, `destroy()` the stream and await `finished(writable)` so the fd — including a still-pending open — fully settles before cleanup.
- Make the `rm` best-effort: `maxRetries: 3` covers Windows `EBUSY`/`EPERM` from external processes briefly holding the fresh file, and its rejection is debug-logged (`DEBUG=checkly:cli:helpers:result-assets`) instead of masking the original download error.

No test changes: the existing test already asserts the observable behavior (no leftover files) and becomes deterministic with this fix.

## Verification

- Full unit suite passes; the previously-flaky test passed 100/100 stress iterations locally.
- The race was empirically reproduced on macOS/Node 20.20 by stress-running the old code shape (1 leak in 300 iterations); the fixed shape produced 0 leaks in 400 iterations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
