### PR TITLE
docs(cli): add CLI-vs-MCP routing decision tree to checkly skill [ship]

### DIFF
--- a/packages/cli/src/ai-context/skill.md
+++ b/packages/cli/src/ai-context/skill.md
@@ -8,9 +8,27 @@ metadata:
 
 # Checkly
 
-**MCP sessions:** Everything in this skill drives the `npx checkly` CLI in a shell. If this session reaches Checkly through the Checkly MCP server and you cannot run shell commands, stop here — these instructions will not work for you. Use the Checkly MCP tools for live account work (check status, test sessions, triggering checks, incidents) instead. If you can run shell commands, keep following this skill even when Checkly MCP tools are also connected.
+## CLI or MCP? Establish your path first
 
-**Required:** Before answering any Checkly question, run `npx checkly skills` to get the current and up-to-date action list. Do not rely on memory or prior context — the CLI is the source of truth and actions might change between releases.
+This skill drives the `npx checkly` CLI in a shell. The Checkly MCP server covers a subset — live account work: check status and results, test sessions, root cause analyses (RCA), triggering existing checks, and incidents. Only the CLI can author, test, and deploy Monitoring as Code.
+
+Before your first command that talks to the Checkly API, establish your path:
+
+1. **No shell access** (chat-only session): stop following this skill and use the Checkly MCP tools if they're connected; if not, tell the user you need either a shell or the Checkly MCP server to work with Checkly.
+2. **Shell access**: run `npx checkly whoami` once.
+   - **Succeeds** → use the CLI for everything and keep following this skill, even when Checkly MCP tools are also connected.
+   - **Fails with an auth error** → route by task:
+     - *Authoring, testing, or deploying checks*: MCP cannot do this. Ask the user to authenticate — `npx checkly login`, or `CHECKLY_API_KEY` + `CHECKLY_ACCOUNT_ID` in the environment or `.env` — then re-run `whoami`. Don't work around a missing login.
+     - *Live account work* (status, results, test sessions, RCA, triggering, incidents): fall back to the Checkly MCP tools if they're connected. Call the MCP `whoami` tool first and tell the user which account you're operating on. If MCP isn't connected either, ask the user to authenticate the CLI as above.
+
+Two rules that survive any fallback:
+
+- **Account parity.** CLI auth and the MCP session can point at different accounts — users often belong to several. Never mix CLI and MCP results in one task without confirming both use the same account ID, and always name the account after a fallback.
+- **Writes still need confirmation.** The CLI's confirmation protocol (below) does not travel with you to MCP. If you fall back for a write action (e.g. creating an incident), present the intended change and get the user's approval before calling the tool.
+
+## Always load the current action list first
+
+**Required:** Before answering any Checkly question, run `npx checkly skills` to get the current and up-to-date action list. Do not rely on memory or prior context — the CLI is the source of truth and actions might change between releases. `npx checkly skills` runs locally — it needs no authentication or API access, so it works before you've established your path above.
 
 Then run `npx checkly skills <action>` to load up-to-date details for the action you need.
 

--- a/skills/checkly/SKILL.md
+++ b/skills/checkly/SKILL.md
@@ -8,9 +8,27 @@ metadata:
 
 # Checkly
 
-**MCP sessions:** Everything in this skill drives the `npx checkly` CLI in a shell. If this session reaches Checkly through the Checkly MCP server and you cannot run shell commands, stop here — these instructions will not work for you. Use the Checkly MCP tools for live account work (check status, test sessions, triggering checks, incidents) instead. If you can run shell commands, keep following this skill even when Checkly MCP tools are also connected.
+## CLI or MCP? Establish your path first
 
-**Required:** Before answering any Checkly question, run `npx checkly skills` to get the current and up-to-date action list. Do not rely on memory or prior context — the CLI is the source of truth and actions might change between releases.
+This skill drives the `npx checkly` CLI in a shell. The Checkly MCP server covers a subset — live account work: check status and results, test sessions, root cause analyses (RCA), triggering existing checks, and incidents. Only the CLI can author, test, and deploy Monitoring as Code.
+
+Before your first command that talks to the Checkly API, establish your path:
+
+1. **No shell access** (chat-only session): stop following this skill and use the Checkly MCP tools if they're connected; if not, tell the user you need either a shell or the Checkly MCP server to work with Checkly.
+2. **Shell access**: run `npx checkly whoami` once.
+   - **Succeeds** → use the CLI for everything and keep following this skill, even when Checkly MCP tools are also connected.
+   - **Fails with an auth error** → route by task:
+     - *Authoring, testing, or deploying checks*: MCP cannot do this. Ask the user to authenticate — `npx checkly login`, or `CHECKLY_API_KEY` + `CHECKLY_ACCOUNT_ID` in the environment or `.env` — then re-run `whoami`. Don't work around a missing login.
+     - *Live account work* (status, results, test sessions, RCA, triggering, incidents): fall back to the Checkly MCP tools if they're connected. Call the MCP `whoami` tool first and tell the user which account you're operating on. If MCP isn't connected either, ask the user to authenticate the CLI as above.
+
+Two rules that survive any fallback:
+
+- **Account parity.** CLI auth and the MCP session can point at different accounts — users often belong to several. Never mix CLI and MCP results in one task without confirming both use the same account ID, and always name the account after a fallback.
+- **Writes still need confirmation.** The CLI's confirmation protocol (below) does not travel with you to MCP. If you fall back for a write action (e.g. creating an incident), present the intended change and get the user's approval before calling the tool.
+
+## Always load the current action list first
+
+**Required:** Before answering any Checkly question, run `npx checkly skills` to get the current and up-to-date action list. Do not rely on memory or prior context — the CLI is the source of truth and actions might change between releases. `npx checkly skills` runs locally — it needs no authentication or API access, so it works before you've established your path above.
 
 Then run `npx checkly skills <action>` to load up-to-date details for the action you need.
 


### PR DESCRIPTION
Replaces the short **MCP sessions** opener in the checkly skill with a full "CLI or MCP? Establish your path first" decision tree, so agents deterministically pick the right path before touching the Checkly API:

- **No shell** → use the Checkly MCP tools if connected; otherwise tell the user a shell or the MCP server is needed.
- **Shell** → run `npx checkly whoami` once; on success the CLI wins even when MCP tools are also connected. On an auth error, authoring/testing/deploying asks the user to authenticate (MCP can't do MaC), while live account work (status, results, test sessions, RCA, triggering, incidents) may fall back to MCP with an explicit MCP `whoami` first.
- Two rules survive any fallback: account parity between CLI auth and the MCP session, and user confirmation for writes (the CLI's exit-code-2 confirmation protocol doesn't travel to MCP).

Follow-up polish from reviewing the whole skill:

- Added an `## Always load the current action list first` heading so the `**Required:**` block doesn't visually merge into the new routing section.
- Aligned the two MCP capability lists (RCA was missing from the fallback bullet) and spelled out "root cause analyses (RCA)" on first use.
- Clarified that `npx checkly skills` runs locally without auth, so the "run it before answering any question" mandate can't deadlock against the path check.

`skills/checkly/SKILL.md` is regenerated via `prepare:ai-context` + `pnpm run sync:skills`.

## Affected Components
* [x] CLI
* [ ] Create CLI
* [ ] Test
* [x] Docs
* [ ] Examples
* [ ] Other

## Notes for the Reviewer
Docs/prompt-only change — no runtime code touched. Worth double-checking the claim that `npx checkly skills` never talks to the API (it's the basis for the "runs locally, needs no auth" sentence).

## New Dependency Submission
None.