### PR TITLE
feat(cli): allow overriding the events endpoint via CHECKLY_MQTT_URL [RED-876] [ship]

### DIFF
--- a/packages/cli/src/services/__tests__/config.spec.ts
+++ b/packages/cli/src/services/__tests__/config.spec.ts
@@ -12,4 +12,13 @@ describe('config', () => {
     expect(Conf).toHaveBeenCalledTimes(0)
     delete process.env.CHECKLY_API_KEY
   })
+
+  it('should let CHECKLY_MQTT_URL override the events endpoint in the local environment', () => {
+    process.env.CHECKLY_ENV = 'local'
+    expect(config.getMqttUrl()).toEqual('wss://events-local.checklyhq.com')
+    process.env.CHECKLY_MQTT_URL = 'ws://localhost:8085/mqtt'
+    expect(config.getMqttUrl()).toEqual(process.env.CHECKLY_MQTT_URL)
+    delete process.env.CHECKLY_MQTT_URL
+    delete process.env.CHECKLY_ENV
+  })
 })

--- a/packages/cli/src/services/config.ts
+++ b/packages/cli/src/services/config.ts
@@ -89,7 +89,9 @@ class ChecklyConfig {
 
   getMqttUrl (): string {
     const environments = {
-      local: 'wss://events-local.checklyhq.com',
+      // Overridable for local development setups whose event stream is served
+      // from a different broker, mirroring how CHECKLY_API_URL overrides the API.
+      local: process.env.CHECKLY_MQTT_URL || 'wss://events-local.checklyhq.com',
       development: 'wss://events-dev.checklyhq.com',
       staging: 'wss://events-test.checklyhq.com',
       production: 'wss://events.checklyhq.com',


### PR DESCRIPTION
## What

Adds a `CHECKLY_MQTT_URL` environment variable that overrides the MQTT/events endpoint in the `local` environment, mirroring the existing `CHECKLY_API_URL` override for the API URL.

## Why

The events endpoint was hardcoded per environment. A local development setup whose event stream is served from a different broker had no way to point the CLI at it, so `checkly test` would run the session but wait for run events forever. With the override, e.g. `CHECKLY_MQTT_URL=ws://localhost:8085/mqtt`, the CLI receives events from the local broker and exits normally (verified end to end).

## Testing

Unit test in `config.spec.ts` covers the default and the override. Also verified manually against a local backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)