### PR TITLE
fix(cli): trust the bundled lockfile when pruning under pnpm 11 [RED-901] [ship]

### DIFF
--- a/packages/cli/src/services/check-parser/package-files/__tests__/package-manager.spec.ts
+++ b/packages/cli/src/services/check-parser/package-files/__tests__/package-manager.spec.ts
@@ -575,13 +575,14 @@ describe('detectNearestConfigFiles', () => {
 })
 
 describe('lockfileOnlyInstallCommand', () => {
-  it('regenerates the lockfile without installing for pnpm, pinning the lockfile location'
-    + ' and tolerating patches that apply to nothing', () => {
+  it('regenerates the lockfile without installing for pnpm, pinning the lockfile location,'
+    + ' tolerating patches that apply to nothing and trusting the lockfile', () => {
     const runnable = new PNpmDetector().lockfileOnlyInstallCommand()
     expect(runnable?.executable).toEqual('pnpm')
     expect(runnable?.args).toEqual([
       'install', '--lockfile-only', '--ignore-scripts', '--no-frozen-lockfile', '--lockfile-dir', '.',
       '--config.allowUnusedPatches=true',
+      '--config.trustLockfile=true',
     ])
   })
 

--- a/packages/cli/src/services/check-parser/package-files/package-manager.ts
+++ b/packages/cli/src/services/check-parser/package-files/package-manager.ts
@@ -370,12 +370,29 @@ export class PNpmDetector extends PackageManagerDetector implements PackageManag
     // and pnpm 10+ fails the install with ERR_PNPM_UNUSED_PATCH. The flag
     // downgrades that to a warning, so the prune produces a lockfile instead
     // of falling back; the unused declaration itself is filtered out of the
-    // bundle afterwards. Verified on pnpm 10 and 11: the setting does not
-    // reach the regenerated lockfile's `settings` section, so the snapshot
+    // bundle afterwards.
+    //
+    // --config.trustLockfile skips pnpm 11's pre-install supply-chain
+    // verification, which re-resolves every lockfile entry against the
+    // registry to re-apply minimumReleaseAge/trustPolicy. Left enabled, it
+    // fails the lockfile-only install for any entry the registry cannot
+    // resolve from this environment (private packages without auth,
+    // air-gapped runs) with e.g. ERR_PNPM_FETCH_404. The input lockfile was
+    // produced by the user's own install, where those policies were already
+    // enforced, and pruning only ever removes entries — the
+    // "already-verified lockfile" case the setting is documented for. The
+    // --config. form is deliberate: pnpm 10 accepts and ignores unknown
+    // --config. settings but rejects a bare --trust-lockfile flag, and the
+    // npm_config_trust_lockfile env var does not disable the verification
+    // on pnpm 11.
+    //
+    // Verified on pnpm 10 and 11: neither --config. setting reaches the
+    // regenerated lockfile's `settings` section, so the snapshot
     // comparisons below are unaffected.
     return new Runnable('pnpm', [
       'install', '--lockfile-only', '--ignore-scripts', '--no-frozen-lockfile', '--lockfile-dir', '.',
       '--config.allowUnusedPatches=true',
+      '--config.trustLockfile=true',
     ])
   }
 


### PR DESCRIPTION
Linear: RED-901

## Problem

The lockfile prune regenerates the bundled lockfile with `pnpm install --lockfile-only` in a temp dir. pnpm 11 runs a pre-install supply-chain verification that re-resolves every lockfile entry against the registry (re-applying `minimumReleaseAge`/`trustPolicy`). Entries the pruning environment cannot resolve — private packages without ambient credentials, air-gapped runs — fail the verification with `ERR_PNPM_FETCH_404`, the prune falls back to the original unpruned lockfile, and with `bundle.packages.embed` configured the materializer then fails hard (`EmbeddedPackageError`) trying to download packages the prune should have removed.

## Fix

Pass `--config.trustLockfile=true` in the pnpm lockfile-only install command. This skips the verification on pnpm 11 (equivalent to its `--trust-lockfile` flag), and pnpm 10 accepts and ignores the `--config.` form — so no pnpm version detection is needed. (The bare `--trust-lockfile` flag would be rejected by pnpm 10, and the `npm_config_trust_lockfile` env var does not disable the verification on pnpm 11.)

Skipping the verification here is safe: the input lockfile was produced by the user's own install, where those policies were already enforced, and pruning only ever removes entries — on failure the CLI ships the same entries anyway via the unpruned fallback, so the re-verification never protected the bundle, it only degraded it. This matches the use case pnpm documents for `--trust-lockfile` ("CI runs against an already-verified lockfile").

Verified on pnpm 11.22.0 and 10.33.4: the previously-failing pruned-lockfile + embedded-packages test now passes on both majors, and the setting does not leak into the regenerated lockfile's `settings` section (byte-identical output with and without the flag on both majors).

Note: CI pins pnpm to major 10, which has no supply-chain verification, so the pnpm 11 behavior this fixes is not exercised by CI; dedicated regression coverage is deliberately deferred and tracked in the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
