### PR TITLE
fix(cli): tolerate concurrent same-content embedded-package cache writes [RED-903] [ship]

### DIFF
--- a/packages/cli/src/services/embedded-packages/__tests__/cache.spec.ts
+++ b/packages/cli/src/services/embedded-packages/__tests__/cache.spec.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
 import { TarballCache, lookupNpmCacache, resolveCacheDirs } from '../cache.js'
 
@@ -52,6 +52,7 @@ describe('TarballCache', () => {
   })
 
   afterEach(async () => {
+    vi.restoreAllMocks()
     await fs.rm(dir, { recursive: true, force: true })
   })
 
@@ -74,6 +75,47 @@ describe('TarballCache', () => {
 
   it('rejects put without a supported integrity hash', async () => {
     await expect(cache.put('md5-abcdef', content)).rejects.toThrow(/supported integrity hash/)
+  })
+
+  // On Windows, a rename losing a race against a concurrent writer of the
+  // same content-addressed path fails with EPERM instead of replacing the
+  // destination like POSIX does. The spied rename pins that shape
+  // deterministically on every platform.
+  const failRename = () => {
+    vi.spyOn(fs, 'rename').mockRejectedValue(
+      Object.assign(new Error('EPERM: operation not permitted, rename'), { code: 'EPERM' }),
+    )
+  }
+
+  it('treats a failed rename as success when the destination already holds verified content', async () => {
+    const putPath = await cache.put(integrity, content)
+    failRename()
+    await expect(cache.put(integrity, content)).resolves.toBe(putPath)
+    await expect(cache.get(integrity)).resolves.toBe(putPath)
+  })
+
+  it('keeps failing the put when a failed rename leaves no destination', async () => {
+    failRename()
+    await expect(cache.put(integrity, content)).rejects.toThrow(/Unable to write the embedded-packages cache/)
+  })
+
+  it('does not accept a mismatching destination when the rename fails', async () => {
+    const putPath = await cache.put(integrity, content)
+    await fs.writeFile(putPath, 'corrupted')
+    failRename()
+    await expect(cache.put(integrity, content)).rejects.toThrow(/Unable to write the embedded-packages cache/)
+  })
+
+  it('recovers against the failing root itself, not an earlier root', async () => {
+    // The blocking regular file makes the first root fail before anything
+    // exists at its destination, so a recovery that consulted anything but
+    // the failing root's own destination could not find the seeded entry.
+    const blocked = path.join(dir, 'blocked')
+    await fs.writeFile(blocked, 'not a directory')
+    const fallback = path.join(dir, 'fallback')
+    const seeded = await new TarballCache(fallback).put(integrity, content)
+    failRename()
+    await expect(new TarballCache([blocked, fallback]).put(integrity, content)).resolves.toBe(seeded)
   })
 })
 

--- a/packages/cli/src/services/embedded-packages/__tests__/materializer.spec.ts
+++ b/packages/cli/src/services/embedded-packages/__tests__/materializer.spec.ts
@@ -646,6 +646,20 @@ packages: {}
       expect(requests).toHaveLength(1)
     })
 
+    it('fetches entries sharing one integrity once, into one cache entry', async () => {
+      // bar@2.0.0 and bar@3.0.0 resolve to identical bytes, and the
+      // download queue runs them concurrently. Sourcing must collapse to
+      // one download and one content-addressed cache write — concurrent
+      // writes onto the shared cache path are a race the loser fails on
+      // Windows, where a rename cannot replace a destination the winner
+      // still holds open (EPERM).
+      const tarballs = await materializeAll(makeMaterializer(['bar']))
+      expect(tarballs.map(t => t.archiveFilename)).toEqual(['bar@2.0.0.tgz', 'bar@3.0.0.tgz'])
+      expect(requests).toHaveLength(1)
+      expect(new Set(tarballs.map(t => t.filePath)).size).toBe(1)
+      await expect(fs.readFile(tarballs[0].filePath)).resolves.toEqual(barTarball)
+    })
+
     it('uses npm cacache content without hitting the network', async () => {
       const npmCacheDir = path.join(homedir, '.npm')
       const hex = createHash('sha512').update(barTarball).digest('hex')

--- a/packages/cli/src/services/embedded-packages/cache.ts
+++ b/packages/cli/src/services/embedded-packages/cache.ts
@@ -72,7 +72,8 @@ export function resolveCacheDirs (
  * Reads consult every root and verify the content, so a corrupt entry
  * degrades to a cache miss rather than a user-facing error. Writes go to
  * the first root that accepts them, so an unwritable project tree falls
- * back to the per-user cache instead of failing.
+ * back to the per-user cache instead of failing — unless the unwritable
+ * root already holds a verifying entry, which satisfies the write as-is.
  */
 export class TarballCache {
   #rootDirs: string[]
@@ -130,9 +131,12 @@ export class TarballCache {
   /**
    * Stores verified tarball content in the first writable root and returns
    * its path. The write is atomic (temp file + rename), so concurrent
-   * processes sharing the cache never observe a torn file. The caller is
-   * responsible for verifying the content against the lockfile integrity
-   * beforehand.
+   * processes sharing the cache never observe a torn file — and because
+   * the store is content-addressed, losing a write race is itself a
+   * success: a write that fails while the destination already holds
+   * content matching the integrity returns that entry instead of erroring.
+   * The caller is responsible for verifying the content against the
+   * lockfile integrity beforehand.
    */
   async put (integrity: string, content: Buffer): Promise<string> {
     const hash = strongestIntegrityHash(integrity)
@@ -153,7 +157,24 @@ export class TarballCache {
         }
         return filePath
       } catch (err) {
-        debug('cache root %s is not writable: %s', rootDir, (err as Error).message)
+        // Concurrent writers race onto the same content-addressed path —
+        // two same-integrity puts in this process, or another process
+        // sharing the cache. POSIX rename silently replaces, but on
+        // Windows the losing rename fails with EPERM while the winner
+        // still holds the destination open. Whatever failed, a
+        // destination that verifies means the content is cached, which is
+        // all a put promises. The recovery read is deliberately
+        // single-shot and best-effort: retrying would add fixed latency to
+        // every genuinely unwritable root (the common non-race case), so a
+        // read that itself hits a transient lock falls through to the
+        // normal failure path instead.
+        const existing = await fs.readFile(filePath).catch(() => undefined)
+        if (existing !== undefined && verifyIntegrity(existing, integrity)) {
+          debug('cache write under %s failed (%s), but the destination already verifies',
+            rootDir, (err as Error).message)
+          return filePath
+        }
+        debug('cache write under %s failed: %s', rootDir, (err as Error).message)
         lastError = err
       } finally {
         await fs.rm(tempPath, { force: true }).catch(() => {})
@@ -162,7 +183,8 @@ export class TarballCache {
 
     throw new Error(
       `Unable to write the embedded-packages cache`
-      + ` (tried ${this.#rootDirs.map(dir => `'${dir}'`).join(', ')}).`
+      + ` (tried ${this.#rootDirs.map(dir => `'${dir}'`).join(', ')}):`
+      + ` ${(lastError as Error | undefined)?.message ?? 'unknown error'}.`
       + ` Set CHECKLY_CACHE_DIR to a writable directory to override the cache location.`,
       { cause: lastError },
     )

--- a/packages/cli/src/services/embedded-packages/materializer.ts
+++ b/packages/cli/src/services/embedded-packages/materializer.ts
@@ -20,7 +20,7 @@ import {
   RecordedUrlOrigin,
   redactUrl,
 } from './diagnostics.js'
-import { verifyIntegrity } from './integrity.js'
+import { integrityHashToHex, strongestIntegrityHash, verifyIntegrity } from './integrity.js'
 import {
   LockfileRegistryPackage,
   UnsupportedLockfileError,
@@ -189,6 +189,19 @@ export class EmbeddedPackagesMaterializer {
   #homedir: string
 
   #plan?: Promise<EmbeddedPackagesPlan>
+
+  /**
+   * In-flight tarball sourcing, keyed by the strongest integrity hash —
+   * the same addressing the cache stores under. Plan entries can share
+   * tarball content (two versions published with identical bytes), and the
+   * download queue runs them concurrently; sharing one sourcing promise
+   * per distinct hash fetches and writes such content once instead of
+   * racing identical writes onto one cache path. Entries are dropped as
+   * soon as sourcing settles: later materializations must read through the
+   * cache, whose reads re-verify content, rather than trust a memoized
+   * path.
+   */
+  #inFlightTarballs = new Map<string, Promise<string>>()
 
   constructor (options: EmbeddedPackagesMaterializerOptions) {
     this.#options = options
@@ -579,16 +592,58 @@ export class EmbeddedPackagesMaterializer {
       }
     }
 
+    // An integrity without a supported hash has no cache address to key
+    // the deduplication on, so it sources directly (and fails at download
+    // verification, since no supported hash can match the content).
+    const hash = strongestIntegrityHash(integrity)
+    if (hash === undefined) {
+      return { filePath: await this.#sourceTarball(tarball, integrity, tarballUrl, metadataOrigin, npmrc), integrity }
+    }
+
+    const key = `${hash.algorithm}:${integrityHashToHex(hash)}`
+    let pending = this.#inFlightTarballs.get(key)
+    if (pending === undefined) {
+      pending = this.#sourceTarball(tarball, integrity, tarballUrl, metadataOrigin, npmrc)
+      this.#inFlightTarballs.set(key, pending)
+      // Dropped as soon as sourcing settles, whichever way: a later
+      // materialization must read through the cache's own verification,
+      // and a failed attempt must not poison a retry with its stored
+      // rejection.
+      pending.then(
+        () => this.#inFlightTarballs.delete(key),
+        () => this.#inFlightTarballs.delete(key),
+      )
+    }
+    return { filePath: await pending, integrity }
+  }
+
+  /**
+   * Sources one tarball's verified content into the CLI cache — CLI cache
+   * → npm cacache → registry download, verified against `integrity` — and
+   * returns its cache path.
+   *
+   * When concurrent plan entries share an integrity, only the first
+   * entry's identity reaches this method: the URL, registry, and any
+   * failure's wording all follow that entry, not whichever entry awaited
+   * the shared sourcing.
+   */
+  async #sourceTarball (
+    tarball: PlannedTarball,
+    integrity: string,
+    tarballUrl: string | undefined,
+    metadataOrigin: RecordedUrlOrigin | undefined,
+    npmrc: LoadedNpmrcConfig,
+  ): Promise<string> {
     const cached = await this.#cache.get(integrity)
     if (cached !== undefined) {
       debug('%s@%s: CLI cache hit', tarball.name, tarball.version)
-      return { filePath: cached, integrity }
+      return cached
     }
 
     const fromNpmCacache = await lookupNpmCacache(integrity, this.#env, process.platform, this.#homedir)
     if (fromNpmCacache !== undefined) {
       debug('%s@%s: npm cache hit', tarball.name, tarball.version)
-      return { filePath: await this.#cache.put(integrity, fromNpmCacache), integrity }
+      return await this.#cache.put(integrity, fromNpmCacache)
     }
 
     // Where the URL came from decides who to blame for credentials embedded
@@ -629,7 +684,7 @@ export class EmbeddedPackagesMaterializer {
       )
     }
 
-    return { filePath: await this.#cache.put(integrity, content), integrity }
+    return await this.#cache.put(integrity, content)
   }
 
   /**


### PR DESCRIPTION
Linear: RED-903

## Affected Components
* [x] CLI

Fixes a Windows-only CI flake: `TarballCache.put` writes via temp file + rename into a content-addressed cache, so when two embedded-package plan entries share one tarball integrity (two versions published with identical bytes, as in the materializer spec's `bar@2.0.0`/`bar@3.0.0` fixture), the download queue raced two renames onto the same destination path. POSIX rename silently replaces, but on Windows the losing rename fails with `EPERM` while the winner still holds the destination open — failing the test "reports unfetchable wildcard matches as plan warnings without writing to stderr" intermittently (e.g. Actions runs 32845329511 and 32780509102; both passed on rerun). The same race exists across processes sharing the per-user cache.

Two independent layers, one commit each:

* **Cache**: on any write failure, `put()` reads the destination once — content that verifies against the integrity satisfies the put, so losing a same-content race is a success. The recovery read is deliberately single-shot: a retry would add fixed latency to every genuinely unwritable root (the common non-race case). The terminal error now also includes the underlying error message instead of burying it in `cause`.
* **Materializer**: concurrent sourcing is deduped per strongest integrity hash (the same addressing the cache stores under), so shared-content entries download once and write the cache once. Map entries are dropped as soon as sourcing settles, so repeat materializations still read through the cache's own content verification.

## Notes for the Reviewer

* Regression tests pin the `EPERM` shape deterministically on every platform via a spied `fs.rename` (recovery success, no-destination and corrupt-destination failures, and a two-root case proving recovery consults the failing root's own destination); the materializer test asserts exactly one HTTP download and one shared cache path for the shared-integrity fixture. Each key test fails without its fix.
* Accepted residual: a cross-process race where the recovery read itself hits a transient Windows lock can still fail the put — no worse than before, and the in-process trigger (the CI flake's actual cause) is removed entirely by the dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
