### PR TITLE
fix(cli): resolve bare '.' and '..' import specifiers to directory index files [RED-918] [ship]

### DIFF
--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/bare-dot-imports/entrypoint.ts
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/bare-dot-imports/entrypoint.ts
@@ -1,0 +1,4 @@
+import { otherValue } from './lib/sub/other'
+import { slashValue } from './lib/sub/slash'
+
+console.log(otherValue, slashValue)

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/bare-dot-imports/lib/index.ts
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/bare-dot-imports/lib/index.ts
@@ -1,0 +1,1 @@
+export const parentValue = 'parent'

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/bare-dot-imports/lib/sub/index.ts
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/bare-dot-imports/lib/sub/index.ts
@@ -1,0 +1,4 @@
+// A bare '..' import of the parent directory's index file.
+import { parentValue } from '..'
+
+export const subValue = `${parentValue}/sub`

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/bare-dot-imports/lib/sub/other.ts
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/bare-dot-imports/lib/sub/other.ts
@@ -1,0 +1,4 @@
+// A bare '.' import of the importing file's own directory index.
+import { subValue } from '.'
+
+export const otherValue = `${subValue}/other`

--- a/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/bare-dot-imports/lib/sub/slash.ts
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser-fixtures/bare-dot-imports/lib/sub/slash.ts
@@ -1,0 +1,4 @@
+// A trailing-slash '../' import of the parent directory's index file.
+import { parentValue } from '../'
+
+export const slashValue = `${parentValue}/slash`

--- a/packages/cli/src/services/check-parser/__tests__/check-parser.spec.ts
+++ b/packages/cli/src/services/check-parser/__tests__/check-parser.spec.ts
@@ -452,6 +452,21 @@ describe('dependency-parser - parser()', () => {
       ])
     })
 
+    it('should resolve bare "." and ".." imports to directory index files', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('bare-dot-imports', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: false,
+      })
+      const { dependencies } = await parser.parse(toAbsolutePath('entrypoint.ts'))
+      expect(dependencies.map(d => d.filePath).sort()).toEqual([
+        toAbsolutePath('lib', 'index.ts'),
+        toAbsolutePath('lib', 'sub', 'index.ts'),
+        toAbsolutePath('lib', 'sub', 'other.ts'),
+        toAbsolutePath('lib', 'sub', 'slash.ts'),
+      ])
+    })
+
     it('should parse typescript dependencies', async () => {
       const toAbsolutePath = (...filepath: string[]) => fixt.abspath('typescript-example', ...filepath)
       const parser = new Parser({
@@ -974,6 +989,21 @@ describe('dependency-parser - parser()', () => {
       expect(dependencies.map(d => d.filePath).sort()).toEqual([
         toAbsolutePath('dep1.js'),
         toAbsolutePath('dep2.js'),
+      ])
+    })
+
+    it('should resolve bare "." and ".." imports to directory index files', async () => {
+      const toAbsolutePath = (...filepath: string[]) => fixt.abspath('bare-dot-imports', ...filepath)
+      const parser = new Parser({
+        supportedNpmModules: defaultNpmModules,
+        restricted: true,
+      })
+      const { dependencies } = await parser.parse(toAbsolutePath('entrypoint.ts'))
+      expect(dependencies.map(d => d.filePath).sort()).toEqual([
+        toAbsolutePath('lib', 'index.ts'),
+        toAbsolutePath('lib', 'sub', 'index.ts'),
+        toAbsolutePath('lib', 'sub', 'other.ts'),
+        toAbsolutePath('lib', 'sub', 'slash.ts'),
       ])
     })
 

--- a/packages/cli/src/services/check-parser/package-files/paths.ts
+++ b/packages/cli/src/services/check-parser/package-files/paths.ts
@@ -253,6 +253,20 @@ export class PathResolver {
 }
 
 export function isLocalPath (importPath: string) {
+  // Bare '.' and '..' are directory imports of the importing file's own
+  // directory and its parent, equivalent to './' and '../'. Without these
+  // checks they would fall through and be misclassified as npm package names.
+  //
+  // Note that this predicate also gates tsconfig `extends` and package.json
+  // `imports` target resolution. Strictly speaking, tsc sends a bare '.'
+  // in `extends` through node module resolution, and Node requires `imports`
+  // targets to start with './' to count as relative — but both of those are
+  // degenerate configs, and treating '.' and '..' as local paths is the more
+  // useful interpretation in every call site.
+  if (importPath === '.' || importPath === '..') {
+    return true
+  }
+
   if (importPath.startsWith('/')) {
     return true
   }


### PR DESCRIPTION
## What

Bare `.` and `..` import specifiers (e.g. `import { foo } from '..'`) were misclassified as npm package names by `isLocalPath` in the check parser, which only tested the `/`, `./` and `../` prefixes. The imported directory's index file was silently omitted from the code bundle — the importing file itself shipped fine — so the gap only surfaced at runtime as `Directory import '…' is not supported resolving ES modules` (in a real customer suite this cascaded to 0 discoverable tests). In restricted mode the same misclassification instead reported the specifier as an unsupported npm module.

## How

`isLocalPath` now treats exact `.` and `..` as local paths. The existing extension-less lookup chain then resolves them to the directory's index file via the normal candidate order; no resolver changes were needed. A code comment notes that the predicate also gates tsconfig `extends` and package.json `imports` target resolution, where a bare `.`/`..` is a degenerate config either way.

## Tests

New `bare-dot-imports` fixture covering `from '.'`, `from '..'` and `from '../'` directory-index imports, exercised in both restricted and unrestricted parser modes. Both tests were verified to fail without the fix.

Closes RED-918.

🤖 Generated with [Claude Code](https://claude.com/claude-code)