### PR TITLE
fix(cli): make executable presence detection actually probe PATH [RED-887] [ship]

### DIFF
--- a/packages/cli/src/services/check-parser/package-files/__tests__/package-manager.spec.ts
+++ b/packages/cli/src/services/check-parser/package-files/__tests__/package-manager.spec.ts
@@ -632,4 +632,10 @@ describe('PathLookup', () => {
     expect(await lookup.lookupPath('node')).toBeDefined()
     expect(await lookup.lookupPath('checkly-no-such-executable-xyz')).toBeUndefined()
   })
+
+  it('detects the presence of an executable on PATH and throws for one that is missing', async () => {
+    const lookup = new PathLookup()
+    await expect(lookup.detectPresence('node')).resolves.toBeUndefined()
+    await expect(lookup.detectPresence('checkly-no-such-executable-xyz')).rejects.toThrow()
+  })
 })

--- a/packages/cli/src/services/check-parser/package-files/package-manager.ts
+++ b/packages/cli/src/services/check-parser/package-files/package-manager.ts
@@ -819,15 +819,8 @@ export class PathLookup {
     }
   }
 
-  // FIXME(RED-887): the missing `await` below means `foundPath` is a
-  // Promise — always defined — so this never throws and executable
-  // detection always "succeeds". Fixing it changes package-manager
-  // detection outcomes on machines that lack the executable, so it is
-  // tracked as a follow-up rather than fixed in passing; use lookupPath()
-  // for a working check.
-  // eslint-disable-next-line require-await
   async detectPresence (executable: string): Promise<void> {
-    const foundPath = this.lookupPath(executable)
+    const foundPath = await this.lookupPath(executable)
     if (foundPath === undefined) {
       throw new NotDetectedError()
     }


### PR DESCRIPTION
Linear: RED-887

`PathLookup.detectPresence()` was missing an `await` on its `lookupPath()` call: the returned Promise was always defined, so the `NotDetectedError` branch was unreachable and executable-presence detection always "succeeded". Every detector's `detectExecutable()` delegates to it, so the executable-on-PATH fallback tier of package-manager detection unconditionally returned the highest-priority detector — pnpm — regardless of what is installed, e.g. offering `pnpm install` in the `checkly import` prompt on machines without pnpm.

This adds the `await`, removes the now-stale `FIXME(RED-887)` comment and `require-await` eslint-disable, and adds a direct `detectPresence` test pair (resolves for an executable on PATH, rejects for a nonexistent one — verified to fail with the `await` reverted).

## Behavior change

Only the executable-fallback tier is affected, i.e. detection with no lockfile, no config file, no matching user agent, and no runtime signal:

| Machine | Before | After |
|---|---|---|
| pnpm installed | pnpm | pnpm (no change) |
| pnpm absent; bun/deno/yarn/cnpm installed | pnpm | first installed of bun > deno > yarn > cnpm > npm |
| only npm installed | pnpm | npm |
| nothing installed | pnpm | npm (final fallback) |

No working setup regresses: machines where the outcome changes were previously offered commands for a package manager that is not installed. As a side effect, an npm-`workspaces` monorepo with no lockfile now gets workspace detection (the wrong pnpm verdict previously found no workspace, since pnpm's lookup requires `pnpm-workspace.yaml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
