### PR TITLE
feat: add timezone and pause/silence scope to the maintenance window construct

### DIFF
--- a/packages/cli/src/ai-context/context.fixtures.json
+++ b/packages/cli/src/ai-context/context.fixtures.json
@@ -900,6 +900,12 @@
           "repeatInterval": 1,
           "repeatUnit": "WEEK",
           "repeatEndsAt": "2025-08-01T00:00:00.000Z",
+          "timezone": "America/New_York",
+          "pauseAllChecks": false,
+          "silenceAlertsTags": [
+            "app:webshop"
+          ],
+          "silenceAllAlerts": false,
           "created_at": "2025-07-07T08:43:03.466Z",
           "updated_at": "2025-07-07T08:43:03.465Z"
         }

--- a/packages/cli/src/constructs/maintenance-window-codegen.ts
+++ b/packages/cli/src/constructs/maintenance-window-codegen.ts
@@ -9,6 +9,10 @@ export interface MaintenanceWindowResource {
   repeatInterval?: number | null
   repeatUnit?: string
   repeatEndsAt?: string
+  timezone?: string | null
+  pauseAllChecks?: boolean
+  silenceAlertsTags?: Array<string>
+  silenceAllAlerts?: boolean
 }
 
 const construct = 'MaintenanceWindow'
@@ -66,6 +70,29 @@ export class MaintenanceWindowCodegen extends Codegen<MaintenanceWindowResource>
                 builder.string(repeatEndsAt)
               })
             })
+          }
+
+          if (resource.timezone) {
+            builder.string('timezone', resource.timezone)
+          }
+
+          // The default value for pauseAllChecks is false, only include if true.
+          if (resource.pauseAllChecks !== undefined && resource.pauseAllChecks) {
+            builder.boolean('pauseAllChecks', resource.pauseAllChecks)
+          }
+
+          if (resource.silenceAlertsTags?.length) {
+            const silenceAlertsTags = resource.silenceAlertsTags
+            builder.array('silenceAlertsTags', builder => {
+              for (const tag of silenceAlertsTags) {
+                builder.string(tag)
+              }
+            })
+          }
+
+          // The default value for silenceAllAlerts is false, only include if true.
+          if (resource.silenceAllAlerts !== undefined && resource.silenceAllAlerts) {
+            builder.boolean('silenceAllAlerts', resource.silenceAllAlerts)
           }
         })
       })

--- a/packages/cli/src/constructs/maintenance-window.ts
+++ b/packages/cli/src/constructs/maintenance-window.ts
@@ -10,8 +10,9 @@ export interface MaintenanceWindowProps {
   name: string
   /**
    * A list of one or more tags that filter which checks are affected by the maintenance window.
+   * Not needed when `pauseAllChecks` is true.
    */
-  tags: Array<string>
+  tags?: Array<string>
   /**
    * The start date and time of the maintenance window in ISO 8601 format, "YYYY-MM-DDTHH:mm:ss.sssZ" as returned by
    * `new Date()`
@@ -34,6 +35,25 @@ export interface MaintenanceWindowProps {
    * The end date and time when the maintenance window should stop repeating.
    */
   repeatEndsAt?: Date
+  /**
+   * Named IANA time zone used for recurring maintenance scheduling, e.g. "America/New_York".
+   * UTC offset identifiers such as "+05:00" are not accepted. Defaults to UTC.
+   */
+  timezone?: string
+  /**
+   * When true, checks are paused for every check in the account, regardless of `tags`.
+   */
+  pauseAllChecks?: boolean
+  /**
+   * A list of tags that filter which checks have their alerts silenced. Ignored when
+   * `silenceAllAlerts` is true.
+   */
+  silenceAlertsTags?: Array<string>
+  /**
+   * When true, alerts are silenced for every check in the account, overriding
+   * `silenceAlertsTags`.
+   */
+  silenceAllAlerts?: boolean
 }
 
 /**
@@ -45,12 +65,16 @@ export interface MaintenanceWindowProps {
  */
 export class MaintenanceWindow extends Construct {
   name: string
-  tags: Array<string>
+  tags?: Array<string>
   startsAt: Date
   endsAt: Date
   repeatInterval?: number
   repeatUnit?: MaintenanceWindowRepeatUnit
   repeatEndsAt?: Date
+  timezone?: string
+  pauseAllChecks?: boolean
+  silenceAlertsTags?: Array<string>
+  silenceAllAlerts?: boolean
 
   static readonly __checklyType = 'maintenance-window'
 
@@ -71,6 +95,10 @@ export class MaintenanceWindow extends Construct {
     this.repeatInterval = props.repeatInterval
     this.repeatUnit = props.repeatUnit
     this.repeatEndsAt = props.repeatEndsAt
+    this.timezone = props.timezone
+    this.pauseAllChecks = props.pauseAllChecks
+    this.silenceAlertsTags = props.silenceAlertsTags
+    this.silenceAllAlerts = props.silenceAllAlerts
     Session.registerConstruct(this)
   }
 
@@ -87,6 +115,10 @@ export class MaintenanceWindow extends Construct {
       repeatInterval: this.repeatInterval,
       repeatUnit: this.repeatUnit,
       repeatEndsAt: this.repeatEndsAt,
+      timezone: this.timezone,
+      pauseAllChecks: this.pauseAllChecks,
+      silenceAlertsTags: this.silenceAlertsTags,
+      silenceAllAlerts: this.silenceAllAlerts,
     }
   }
 }


### PR DESCRIPTION
**Adds `timezone`, `pauseAllChecks`, `silenceAlertsTags` and `silenceAllAlerts` to the `MaintenanceWindow` construct** — all four are already accepted by the CLI deploy schema, so they were being silently stripped from any config that tried to set them.

**`tags` is now optional.** The backend has always had it as `.optional().default([])`, and requiring it made no sense once `pauseAllChecks` exists — pausing every check in the account shouldn't need a tag list. Loosening a required prop is backwards-compatible.

**The codegen twin is updated too**, so `checkly import` round-trips the new properties instead of dropping them. Booleans follow the existing convention of emitting only when they differ from the backend default.

**Independent of the Go chain** — this talks to the API directly and isn't gated on any release.