### PR TITLE
ci: update GitHub Actions to latest versions and pin by commit SHA [RED-923] [ship]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+# Only GitHub Actions are managed here. npm dependencies are deliberately not:
+# they are updated by a weekly batch that checks the Node floor and applies the
+# minimumReleaseAge embargo from pnpm-workspace.yaml consistently.
+#
+# The workflows pin every action by commit SHA with a `# vX.Y.Z` comment;
+# Dependabot rewrites both the SHA and the comment when it bumps an action.
+#
+# The example workflows under examples/*/.github/workflow.yml are templates
+# that users copy. They live outside .github/workflows, so Dependabot does not
+# see them and they are maintained by hand.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    # One PR for all minor and patch bumps. Majors open one PR each so they can
+    # be reviewed individually; the release workflows only run on a release, so
+    # a breaking action change there gets no signal from pull-request CI.
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: ci
+    # Action bumps are not user-facing; keep them out of generated release notes
+    # (see the exclude list in .github/release.yml).
+    labels:
+      - ignore-for-release

--- a/.github/workflows/check-ai-context.yml
+++ b/.github/workflows/check-ai-context.yml
@@ -12,22 +12,22 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # Path filtering is done inside the job (not via an `on:` paths filter) so
       # this required check always runs and reports a status. A workflow skipped
       # by an `on:` paths filter stays "pending" forever and blocks merge.
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: changes
         with:
           filters: |
             cli:
               - 'packages/cli/**'
       - if: steps.changes.outputs.cli == 'true'
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 10
       - if: steps.changes.outputs.cli == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22.x'
           cache: "pnpm"

--- a/.github/workflows/release-create-package.yml
+++ b/.github/workflows/release-create-package.yml
@@ -6,12 +6,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 10
       # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
@@ -23,7 +23,7 @@ jobs:
       # Slack failure alert
       - name: Slack Failure Notification
         if: ${{ failure() }}
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58 # v2.4.0
         env:
           SLACK_USERNAME: Checkly Github Bot
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
@@ -36,7 +36,7 @@ jobs:
       # Slack success alert
       - name: Slack Success Notification
         if: ${{ success() }}
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58 # v2.4.0
         env:
           SLACK_USERNAME: Checkly Github Bot
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     if: ${{ github.event_name == 'release' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-ecosystem/action-regex-match@v2
+      - uses: actions-ecosystem/action-regex-match@9e6c4fb3d5e898f505be7a1fb6e7b0a278f6665b # v2.0.2
         id: tag-match
         with:
           text: ${{ github.event.release.tag_name }}
@@ -32,7 +32,7 @@ jobs:
       # Old create-checkly versions still look for the tag with a `v` prefix.
       # We can automatically push the necessary tag to keep those working.
       - name: Create tag for old create-checkly versions
-        uses: actions/github-script@v6
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             github.rest.git.createRef({
@@ -49,11 +49,11 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 10
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24.x'
           cache: "pnpm"
@@ -75,7 +75,7 @@ jobs:
           npm publish create-checkly-*.tgz --provenance --tag prerelease
         working-directory: packages/create-cli
       - name: Save LLM rules as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: llm-rules-prerelease
           if-no-files-found: error
@@ -83,7 +83,7 @@ jobs:
       # Slack failure alert
       - name: Slack Failure Notification
         if: ${{ failure() }}
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58 # v2.4.0
         env:
           SLACK_USERNAME: Checkly Github Bot
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
@@ -96,7 +96,7 @@ jobs:
       # Slack success alert
       - name: Slack Success Notification
         if: ${{ success() }}
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58 # v2.4.0
         env:
           SLACK_USERNAME: Checkly Github Bot
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
@@ -114,13 +114,13 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 10
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24.x'
           cache: "pnpm"
@@ -140,7 +140,7 @@ jobs:
           npm publish create-checkly-*.tgz --provenance
         working-directory: packages/create-cli
       - name: Save LLM rules as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: llm-rules-release
           if-no-files-found: error
@@ -148,7 +148,7 @@ jobs:
       # Slack failure alert
       - name: Slack Failure Notification
         if: ${{ failure() }}
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58 # v2.4.0
         env:
           SLACK_USERNAME: Checkly Github Bot
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
@@ -161,7 +161,7 @@ jobs:
       # Slack success alert
       - name: Slack Success Notification
         if: ${{ success() }}
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58 # v2.4.0
         env:
           SLACK_USERNAME: Checkly Github Bot
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
@@ -203,11 +203,11 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 10
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24.x'
           cache: "pnpm"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            github.rest.git.createRef({
+            await github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: 'refs/tags/v${{ github.event.release.tag_name }}',

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,13 +22,17 @@ jobs:
     if: ${{ github.event_name == 'release' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-ecosystem/action-regex-match@9e6c4fb3d5e898f505be7a1fb6e7b0a278f6665b # v2.0.2
-        id: tag-match
-        with:
-          text: ${{ github.event.release.tag_name }}
-          regex: '^\d+\.\d+\.\d+$'
-      - run: echo "Please create tag for release with format like 4.0.1" && exit 1
-        if: ${{ steps.tag-match.outputs.match == '' }}
+      # This step must stay first: later steps interpolate the tag name directly
+      # and rely on this check having rejected anything unexpected. Here the tag
+      # is read from an env var so the check itself cannot be injected.
+      - name: Validate release tag format
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          if [[ ! "$TAG_NAME" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Please create tag for release with format like 4.0.1 (got '$TAG_NAME')"
+            exit 1
+          fi
       # Old create-checkly versions still look for the tag with a `v` prefix.
       # We can automatically push the necessary tag to keep those working.
       - name: Create tag for old create-checkly versions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,8 +38,8 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         with:
           # 'every' makes a file match `code` only when it matches *all* the
@@ -62,11 +62,11 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 10
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22.x'
           cache: "pnpm"
@@ -84,8 +84,8 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 10
       # The lockfile-pruner tests exercising a real bun install skip themselves
@@ -93,10 +93,10 @@ jobs:
       # run in CI. The version is pinned because the tests regenerate a
       # committed bun.lock fixture and a future bun may serialize it
       # differently.
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: '1.3.11'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22.x'
           cache: "pnpm"
@@ -137,7 +137,7 @@ jobs:
           # real-yarn lockfile-pruner tests.
           CHECKLY_EXPECT_YARN: '1'
       - name: Save LLM rules as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: llm-rules-test-ubuntu
           if-no-files-found: error
@@ -149,16 +149,16 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: blacksmith-4vcpu-windows-2025
     steps:
-      - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 10
       # See test-ubuntu: provisions bun for the real-bun lockfile-pruner tests,
       # which otherwise skip themselves.
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: '1.3.11'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22.x'
           cache: "pnpm"
@@ -182,7 +182,7 @@ jobs:
           CHECKLY_EXPECT_BUN: '1'
           CHECKLY_EXPECT_YARN: '1'
       - name: Save LLM rules as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: llm-rules-test-windows
           if-no-files-found: error
@@ -199,11 +199,11 @@ jobs:
     if: github.event_name == 'pull_request' && needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 10
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22.x'
           cache: "pnpm"
@@ -226,11 +226,11 @@ jobs:
         shard: ['1/4', '2/4', '3/4', '4/4']
     runs-on: blacksmith-4vcpu-windows-2025
     steps:
-      - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 10
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22.x'
           cache: "pnpm"
@@ -261,11 +261,11 @@ jobs:
     if: github.event_name == 'pull_request' && needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 10
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22.x'
           cache: "pnpm"
@@ -277,11 +277,11 @@ jobs:
     if: github.event_name == 'pull_request' && needs.changes.outputs.code == 'true'
     runs-on: blacksmith-4vcpu-windows-2025
     steps:
-      - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 10
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22.x'
           cache: "pnpm"

--- a/examples/advanced-project-js/.github/workflow.yml
+++ b/examples/advanced-project-js/.github/workflow.yml
@@ -24,18 +24,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           ref: '${{ github.event.deployment_status.deployment.ref }}'
           fetch-depth: 0
       - name: Set branch name # this is workaround to get the branch name.
         run: echo "CHECKLY_TEST_REPO_BRANCH=$(git show -s --pretty=%D HEAD | tr -s ',' '\n' | sed 's/^ //' | grep -e 'origin/' | head -1 | sed 's/\origin\///g')" >> $GITHUB_ENV
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
       - name: Restore or cache node_modules
         id: cache-node-modules
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}

--- a/examples/advanced-project/.github/workflow.yml
+++ b/examples/advanced-project/.github/workflow.yml
@@ -24,18 +24,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           ref: '${{ github.event.deployment_status.deployment.ref }}'
           fetch-depth: 0
       - name: Set branch name # this is workaround to get the branch name.
         run: echo "CHECKLY_TEST_REPO_BRANCH=$(git show -s --pretty=%D HEAD | tr -s ',' '\n' | sed 's/^ //' | grep -e 'origin/' | head -1 | sed 's/\origin\///g')" >> $GITHUB_ENV
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
       - name: Restore or cache node_modules
         id: cache-node-modules
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}


### PR DESCRIPTION
Linear: RED-923

Every `uses:` in `.github/workflows` referenced a floating major tag, several majors behind. A floating tag lets a compromised upstream tag silently change what runs in CI and in the npm publish pipeline. Each reference now points at the full commit SHA of the latest release, with the version kept as a trailing comment (the format Dependabot rewrites).

| Action | Before | After |
|---|---|---|
| actions/checkout | v3 | v7.0.1 |
| actions/setup-node | v4 | v7.0.0 |
| actions/upload-artifact | v4 | v7.0.1 |
| actions/github-script | v6 | v9.0.0 |
| pnpm/action-setup | v5 | v6.0.10 |
| dorny/paths-filter | v3 | v4.0.3 |
| oven-sh/setup-bun | v2 | v2.2.0 |
| rtCamp/action-slack-notify | v2 | v2.4.0 |

SHAs were resolved with `gh api repos/<owner>/<repo>/commits/<tag>` (dereferences annotated tags) and re-verified against the `# vX.Y.Z` comments after editing.

### Compatibility notes

- All upgraded actions run on the Node 24 runtime (runner >= 2.327.1). The Blacksmith Windows runners already run node24 `pnpm/action-setup@v5` today.
- checkout v6 moved persisted credentials out of `.git/config`. No job runs authenticated git after checkout, so this is inert.
- setup-node v6 limited automatic caching to npm. Every job passes `cache: pnpm` explicitly, so this is inert.
- pnpm/action-setup remains the right action for pnpm 10; its successor `pnpm/setup` targets pnpm 11+.
- setup-node v7 no longer exports a placeholder `NODE_AUTH_TOKEN`. In `release-create-package.yml` the `pnpm install` step runs with `registry-url` set but no token, so pnpm logs a warning about the generated `.npmrc` and ignores it. The install still succeeds (the file only sets the default registry) and the publish step sets the token itself.

### Follow-ups included as separate commits

- `await` the `createRef` call in the release tag step. github-script's unhandled-rejection handler already fails the step, so this makes the failure path explicit rather than changing behaviour.
- Replace `actions-ecosystem/action-regex-match` (unmaintained since 2021, node16, uses the deprecated `set-output`) with an inline bash regex check. The tag name is passed via an env var.
- Add `.github/dependabot.yml` for the github-actions ecosystem only. npm stays with the weekly batch update (RED-695). Minor and patch bumps are grouped into one weekly PR; majors get individual PRs because the release workflows get no pull-request CI signal. PRs are labeled `ignore-for-release` (label created) so they stay out of generated release notes.
- Bump the example workflow in `examples/advanced-project{,-js}` from `actions/*@v3` to current majors. These are user-facing templates outside `.github/workflows`, so they use major tags rather than SHAs.

### Verification

- `test.yml` and `check-ai-context.yml` run on this PR and exercise checkout, pnpm/action-setup, setup-node, setup-bun, paths-filter and upload-artifact on the new pins.
- `release.yml` only runs on a release, so github-script v9, the new tag check and slack-notify are verified by inspection only. The `canary` job can be dispatched on this branch to exercise the release-path setup steps, but it publishes an experimental npm build.
- `actionlint` reports only pre-existing findings (unquoted `$GITHUB_ENV`, custom runner label).

### Not included

- `release-create-package.yml` is a leftover token-based publish workflow; both packages already publish via OIDC in `release.yml`. Its removal, together with the stale canary section in CONTRIBUTING.md, is tracked in RED-924.
- The example workflow references an `.nvmrc` that the templates do not ship, which predates this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
