### PR TITLE
feat: rename CHECKLY_CLI_VERSION env var to CHECKLY_E2E_CLI_VERSION [RED-821] [ship]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,7 +245,7 @@ jobs:
           pnpm pack
           npm publish create-checkly-*.tgz --provenance --tag "$TAG"
         working-directory: packages/create-cli
-      # CHECKLY_CLI_VERSION is the git ref packages/create-cli fetches `examples/`
+      # CHECKLY_E2E_CLI_VERSION is the git ref packages/create-cli fetches `examples/`
       # templates from, hence the dispatched branch rather than the canary version.
       - name: Publish summary
         run: |
@@ -253,8 +253,8 @@ jobs:
             echo "Published \`checkly@${CANARY_VERSION}\` and \`create-checkly@${CANARY_VERSION}\` (dist-tag: \`${TAG}\`)"
             echo '```'
             echo "npm install checkly@${CANARY_VERSION}"
-            echo "CHECKLY_CLI_VERSION=${GITHUB_REF_NAME} npm create checkly@${CANARY_VERSION}"
+            echo "CHECKLY_E2E_CLI_VERSION=${GITHUB_REF_NAME} npm create checkly@${CANARY_VERSION}"
             echo '```'
-            echo "\`CHECKLY_CLI_VERSION\` is the git ref create-checkly fetches \`examples/\` templates from; the canary version is not a valid ref."
+            echo "\`CHECKLY_E2E_CLI_VERSION\` is the git ref create-checkly fetches \`examples/\` templates from; the canary version is not a valid ref."
             echo "The scaffolded project pins \`checkly@latest\`; set \`\"checkly\": \"${CANARY_VERSION}\"\` in its package.json to test the canary CLI inside it."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ Source in `src/ai-context/`, built during `prepare`. Generates examples from fix
 - `CHECKLY_ACCOUNT_ID`, `CHECKLY_API_KEY` — authentication
 - `CHECKLY_ENV` — target environment (`production`, `staging`, `development`, `local`)
 - `CHECKLY_API_URL` — override API base URL (used when `CHECKLY_ENV=local`)
-- `CHECKLY_CLI_VERSION` — override reported CLI version (useful for testing `create-checkly`)
+- `CHECKLY_E2E_CLI_VERSION` — e2e/local-development override of the version the CLI reports to the API (`x-checkly-cli-version` header); for `create-checkly` it also selects the banner version and the template git tag. It never changes which CLI version runs
 - `CHECKLY_CACHE_DIR` — override the CLI's cache directory (embedded-package tarball downloads)
 - `CHECKLY_SKIP_NODE_VERSION_CHECK` — set to `1` to bypass the bin's hard Node version preflight (unsupported Node may then fail in unexpected ways); must be set in the shell environment — the preflight runs before `.env` is loaded
 - `CHECKLY_LOCKFILE_PRUNE` — set to `0` to disable pruning the bundled lockfile to the code bundle's contents; when a lockfile is bundled this also disables `bundle.packages.prune` (the manifest rewrite rolls back)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ When running commands from the `packages/create-cli` directory, the `--workspace
 
 ## Running locally
 
-Use `CHECKLY_CLI_VERSION` environment variable to set the latest version you want to test.
+Set the `CHECKLY_E2E_CLI_VERSION` environment variable to override the version the CLI reports to the Checkly API (the `x-checkly-cli-version` header). It is an e2e/local-development hook only and does not change which CLI version runs.
 
 You can configure the stage (`production`, `staging`, `development` or `local`) using `CHECKLY_ENV` environment variable. Use `CHECKLY_ENV=local` if you want to point the API URL to your local backend `http://localhost:3000`.
 
@@ -133,10 +133,10 @@ npm install checkly@0.0.0-canary.<short-sha>   # or checkly@experimental
 To test `create-checkly`:
 
 ```bash
-CHECKLY_CLI_VERSION=<branch> npm create checkly@0.0.0-canary.<short-sha>
+CHECKLY_E2E_CLI_VERSION=<branch> npm create checkly@0.0.0-canary.<short-sha>
 ```
 
-`CHECKLY_CLI_VERSION` is a git ref of this repository from which `create-checkly` fetches the project templates in `examples/`. The canary version is not a git ref, so the variable must be set; using the branch under test picks up any template changes on it. The scaffolded project pins `checkly@latest`, so to test a canary `checkly` inside it, edit the project's `package.json`.
+`CHECKLY_E2E_CLI_VERSION` is a git ref of this repository from which `create-checkly` fetches the project templates in `examples/`. The canary version is not a git ref, so the variable must be set; using the branch under test picks up any template changes on it. The scaffolded project pins `checkly@latest`, so to test a canary `checkly` inside it, edit the project's `package.json`.
 
 Canary builds authenticate to npm the same way releases do; see [NPM authentication](#npm-authentication).
 
@@ -157,7 +157,7 @@ To release packages to NPM:
 1. Publish a GitHub Release with a valid tag `#.#.#` (do **not** include a `v` prefix) and click the `Generate release notes` button to auto-generate notes following format defined [here](https://github.com/checkly/checkly-cli/blob/main/.github/release.yml). Under **Release label**, select **None** (not "Latest") — the workflow will mark it as latest automatically.
 2. When release is published the GitHub action is triggered. It builds and publishes `#.#.#-prerelease` prereleases (for both packages).
 3. Test the prerelease version to make sure that it's working.
-    * To test `npm create checkly`, run `CHECKLY_CLI_VERSION=4.6.2 npm create checkly@4.6.2-prerelease-c6e8165` (substituting `4.6.2` and `4.6.2-prerelease` for your versions, which you can find at https://www.npmjs.com/package/checkly?activeTab=versions). `CHECKLY_CLI_VERSION` is needed since the `create-checkly` package looks up the corresponding tag on GitHub to pull project templates.
+    * To test `npm create checkly`, run `CHECKLY_E2E_CLI_VERSION=4.6.2 npm create checkly@4.6.2-prerelease-c6e8165` (substituting `4.6.2` and `4.6.2-prerelease` for your versions, which you can find at https://www.npmjs.com/package/checkly?activeTab=versions). `CHECKLY_E2E_CLI_VERSION` is needed since the `create-checkly` package looks up the corresponding tag on GitHub to pull project templates. Published `create-checkly` versions older than the one that introduced `CHECKLY_E2E_CLI_VERSION` (9.0.0 and earlier) read the former name `CHECKLY_CLI_VERSION` instead.
     * Ensure your project `package.json` has `"checkly": "4.6.2-prerelease-c6e8165"`
 4. A `production` deployment will be waiting for approval. After it's approved, the `#.#.#` version will be published. The workflow will then automatically mark the GitHub Release as latest (if the version is higher than the current latest).
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,6 @@ Check out our [AI Agents & Coding Assistants docs](https://www.checklyhq.com/doc
 
 # Local Development
 
-Use `CHECKLY_CLI_VERSION` environment variable to set the latest version you want to test.
+Set the `CHECKLY_E2E_CLI_VERSION` environment variable to override the version the CLI reports to the Checkly API (the `x-checkly-cli-version` header). It is an e2e/local-development hook only and does not change which CLI version runs.
 
 To get started with local development check [CONTRIBUTING.MD](https://github.com/checkly/checkly-cli/blob/main/CONTRIBUTING.md)

--- a/packages/cli/e2e/__tests__/check-parse-error.spec.ts
+++ b/packages/cli/e2e/__tests__/check-parse-error.spec.ts
@@ -30,7 +30,7 @@ describe('check parse error', () => {
           CHECKLY_API_KEY: config.get('apiKey') as string,
           CHECKLY_ACCOUNT_ID: config.get('accountId') as string,
           CHECKLY_ENV: process.env.CHECKLY_ENV,
-          CHECKLY_CLI_VERSION: '4.8.0',
+          CHECKLY_E2E_CLI_VERSION: '4.8.0',
         },
         timeout: 30_000,
       })

--- a/packages/cli/e2e/__tests__/deploy.spec.ts
+++ b/packages/cli/e2e/__tests__/deploy.spec.ts
@@ -207,7 +207,7 @@ describe('deploy', { timeout: 45_000 }, () => {
         env: {
           PROJECT_LOGICAL_ID: projectLogicalId,
           PRIVATE_LOCATION_SLUG_NAME: privateLocationSlugname,
-          CHECKLY_CLI_VERSION: '4.0.8',
+          CHECKLY_E2E_CLI_VERSION: '4.0.8',
         },
       })
 
@@ -232,7 +232,7 @@ describe('deploy', { timeout: 45_000 }, () => {
         env: {
           PROJECT_LOGICAL_ID: projectLogicalId,
           PRIVATE_LOCATION_SLUG_NAME: privateLocationSlugname,
-          CHECKLY_CLI_VERSION: undefined,
+          CHECKLY_E2E_CLI_VERSION: undefined,
         },
       })
       expect(stderr).toBe('')
@@ -256,7 +256,7 @@ describe('deploy', { timeout: 45_000 }, () => {
         env: {
           PROJECT_LOGICAL_ID: projectLogicalId,
           PRIVATE_LOCATION_SLUG_NAME: privateLocationSlugname,
-          CHECKLY_CLI_VERSION: '4.8.0',
+          CHECKLY_E2E_CLI_VERSION: '4.8.0',
         },
         timeout: 10000,
       })
@@ -264,7 +264,7 @@ describe('deploy', { timeout: 45_000 }, () => {
         env: {
           PROJECT_LOGICAL_ID: projectLogicalId,
           PRIVATE_LOCATION_SLUG_NAME: privateLocationSlugname,
-          CHECKLY_CLI_VERSION: '4.8.0',
+          CHECKLY_E2E_CLI_VERSION: '4.8.0',
         },
         timeout: 10000,
       })
@@ -338,7 +338,7 @@ describe('deploy', { timeout: 45_000 }, () => {
         env: {
           PROJECT_LOGICAL_ID: projectLogicalId,
           PRIVATE_LOCATION_SLUG_NAME: privateLocationSlugname,
-          CHECKLY_CLI_VERSION: '4.8.0',
+          CHECKLY_E2E_CLI_VERSION: '4.8.0',
         },
       })
 
@@ -366,7 +366,7 @@ describe('deploy', { timeout: 45_000 }, () => {
           PROJECT_LOGICAL_ID: projectLogicalId,
           PRIVATE_LOCATION_SLUG_NAME: privateLocationSlugname,
           TEST_ONLY: 'true',
-          CHECKLY_CLI_VERSION: '4.8.0',
+          CHECKLY_E2E_CLI_VERSION: '4.8.0',
         },
       })
       expect(stdout).toContain(
@@ -386,7 +386,7 @@ Skip (testOnly):
           PROJECT_LOGICAL_ID: projectLogicalId,
           PRIVATE_LOCATION_SLUG_NAME: privateLocationSlugname,
           TEST_ONLY: 'false',
-          CHECKLY_CLI_VERSION: '4.8.0',
+          CHECKLY_E2E_CLI_VERSION: '4.8.0',
         },
       })
       // Deploy a check (testOnly=true)
@@ -395,7 +395,7 @@ Skip (testOnly):
           PROJECT_LOGICAL_ID: projectLogicalId,
           PRIVATE_LOCATION_SLUG_NAME: privateLocationSlugname,
           TEST_ONLY: 'true',
-          CHECKLY_CLI_VERSION: '4.8.0',
+          CHECKLY_E2E_CLI_VERSION: '4.8.0',
         },
       })
       // Moving the check to testOnly causes it to be deleted.
@@ -418,7 +418,7 @@ Update and Unchanged:
           PROJECT_LOGICAL_ID: projectLogicalId,
           PRIVATE_LOCATION_SLUG_NAME: privateLocationSlugname,
           TEST_ONLY: 'true',
-          CHECKLY_CLI_VERSION: '4.8.0',
+          CHECKLY_E2E_CLI_VERSION: '4.8.0',
         },
       })
       const uuid = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
@@ -457,7 +457,7 @@ Update and Unchanged:
           env: {
             PROJECT_LOGICAL_ID: projectLogicalId,
             PRIVATE_LOCATION_SLUG_NAME: privateLocationSlugname,
-            CHECKLY_CLI_VERSION: '4.8.0',
+            CHECKLY_E2E_CLI_VERSION: '4.8.0',
           },
         })
       } catch (err: any) {
@@ -488,7 +488,7 @@ Update and Unchanged:
       await runDeploy(fixt, ['--force'], {
         env: {
           PROJECT_LOGICAL_ID: projectLogicalId,
-          CHECKLY_CLI_VERSION: '4.8.0',
+          CHECKLY_E2E_CLI_VERSION: '4.8.0',
         },
       })
       // TODO: Add assertions that the snapshots are successfully uploaded.

--- a/packages/cli/e2e/run-checkly.ts
+++ b/packages/cli/e2e/run-checkly.ts
@@ -26,7 +26,7 @@ export function checklyEnv (overrides?: {
     CHECKLY_API_KEY: apiKey,
     CHECKLY_ACCOUNT_ID: accountId,
     CHECKLY_ENV: process.env.CHECKLY_ENV,
-    CHECKLY_CLI_VERSION: cliVersion,
+    CHECKLY_E2E_CLI_VERSION: cliVersion,
     CHECKLY_E2E_PROMPTS_INJECTIONS: promptsInjection?.length ? JSON.stringify(promptsInjection) : undefined,
     CHECKLY_E2E_DISABLE_FANCY_OUTPUT: '1',
     // Set SHELL so @oclif/core's getShell() short-circuits instead of running

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,7 +19,7 @@
     "clean:gen": "rimraf ./gen",
     "clean": "pnpm run clean:dist && pnpm run clean:gen",
     "prepack": "pnpm exec oclif manifest",
-    "prepare:ai-context": "cross-env CHECKLY_SKIP_AUTH=1 CHECKLY_CLI_VERSION=99.0.0 ./bin/run.cjs import plan --root gen --debug-import-plan-input-file ./src/ai-context/context.fixtures.json && jiti ./scripts/prepare-ai-context.ts",
+    "prepare:ai-context": "cross-env CHECKLY_SKIP_AUTH=1 CHECKLY_E2E_CLI_VERSION=99.0.0 ./bin/run.cjs import plan --root gen --debug-import-plan-input-file ./src/ai-context/context.fixtures.json && jiti ./scripts/prepare-ai-context.ts",
     "prepare:dist": "tsc --build",
     "prepare": "pnpm run clean && pnpm run prepare:dist && pnpm run prepare:ai-context",
     "test": "pnpm pack && pnpm run test:types && vitest --run",

--- a/packages/cli/src/commands/__tests__/reported-cli-version.spec.ts
+++ b/packages/cli/src/commands/__tests__/reported-cli-version.spec.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { resolveReportedCliVersion } from '../baseCommand.js'
+
+// A release-style version keeps the resolver away from the npm registry
+// fallback, which only triggers for development builds.
+const configVersion = '9.0.0'
+
+// The e2e harness exports CHECKLY_E2E_CLI_VERSION, so a developer's shell may
+// have it set; the "unset" cases clear it explicitly instead of assuming.
+
+describe('resolveReportedCliVersion', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('reports the package version by default', async () => {
+    vi.stubEnv('CHECKLY_E2E_CLI_VERSION', undefined)
+    await expect(resolveReportedCliVersion(configVersion)).resolves.toBe(configVersion)
+  })
+
+  it('lets CHECKLY_E2E_CLI_VERSION override the reported version', async () => {
+    vi.stubEnv('CHECKLY_E2E_CLI_VERSION', '4.8.0')
+    await expect(resolveReportedCliVersion(configVersion)).resolves.toBe('4.8.0')
+  })
+
+  it('ignores the former CHECKLY_CLI_VERSION variable', async () => {
+    vi.stubEnv('CHECKLY_E2E_CLI_VERSION', undefined)
+    vi.stubEnv('CHECKLY_CLI_VERSION', 'latest')
+    await expect(resolveReportedCliVersion(configVersion)).resolves.toBe(configVersion)
+  })
+})

--- a/packages/cli/src/commands/baseCommand.ts
+++ b/packages/cli/src/commands/baseCommand.ts
@@ -13,6 +13,35 @@ import { detectNearestPackageJson } from '../services/check-parser/package-files
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
+/**
+ * Resolves the CLI version reported to the Checkly API in the
+ * `x-checkly-cli-version` header.
+ *
+ * `CHECKLY_E2E_CLI_VERSION` is an internal override used by the e2e suite and
+ * the AI-context build. It only changes the reported value; it never changes
+ * which CLI version actually runs. Development builds (`0.0.1-dev`, `0.0.0-*`)
+ * report the latest published version instead, because the backend parses the
+ * header as semver and rejects unknown versions.
+ */
+export async function resolveReportedCliVersion (configVersion: string): Promise<string> {
+  let version = process.env.CHECKLY_E2E_CLI_VERSION ?? configVersion
+
+  if (version === '0.0.1-dev' || version.startsWith('0.0.0')) {
+    try {
+      const registryUrl = 'https://registry.npmjs.org/checkly/latest'
+      const { data: packageInformation } = await axios.get(
+        registryUrl,
+        assignProxy(registryUrl, {}),
+      )
+      version = packageInformation.version
+    } catch {
+      // Reporting a dev version is harmless; never block the command.
+    }
+  }
+
+  return version
+}
+
 export type BaseCommandClass = typeof Command & {
   coreCommand: boolean
 }
@@ -113,23 +142,7 @@ export abstract class BaseCommand extends Command {
     await this.checkEngineCompatibility()
     await this.checkSkillFreshness()
 
-    let version = process.env.CHECKLY_CLI_VERSION ?? this.config.version
-
-    // use latest version from NPM if it's running from the local environment or E2E
-    if (version === '0.0.1-dev' || version?.startsWith('0.0.0')) {
-      try {
-        const registryUrl = 'https://registry.npmjs.org/checkly/latest'
-        const { data: packageInformation } = await axios.get(
-          registryUrl,
-          assignProxy(registryUrl, {}),
-        )
-        version = packageInformation.version
-      } catch {
-        // No-op
-      }
-    }
-
-    api.defaults.headers['x-checkly-cli-version'] = version
+    api.defaults.headers['x-checkly-cli-version'] = await resolveReportedCliVersion(this.config.version)
 
     // This overrides prompts answers/selections (used on E2E tests)
     if (process.env.CHECKLY_E2E_PROMPTS_INJECTIONS) {

--- a/packages/create-cli/e2e/run-create-cli.ts
+++ b/packages/create-cli/e2e/run-create-cli.ts
@@ -31,7 +31,7 @@ export async function runChecklyCreateCli (options: {
       // Force npm as the package manager. Without this, pnpm is detected via
       // PATH and treats the scaffolded project as part of the monorepo workspace.
       npm_config_user_agent: 'npm/10.0.0 node/v20.0.0',
-      CHECKLY_CLI_VERSION: version,
+      CHECKLY_E2E_CLI_VERSION: version,
       CHECKLY_E2E_PROMPTS_INJECTIONS: promptsInjection?.length ? JSON.stringify(promptsInjection) : undefined,
       CHECKLY_E2E_LOCAL_TEMPLATE_ROOT: path.join(__dirname, '../../../examples'),
       CHECKLY_E2E_ISTTY: 'true',

--- a/packages/create-cli/src/commands/bootstrap.ts
+++ b/packages/create-cli/src/commands/bootstrap.ts
@@ -73,7 +73,11 @@ export default class Bootstrap extends Command {
       }
     }
 
-    let version = process.env.CHECKLY_CLI_VERSION ?? this.config.version
+    // CHECKLY_E2E_CLI_VERSION is an internal override used by the e2e suite and
+    // for testing prereleases. It selects the version shown in the banner and
+    // the git tag project templates are fetched from; it does not change which
+    // create-checkly version runs.
+    let version = process.env.CHECKLY_E2E_CLI_VERSION ?? this.config.version
 
     // use latest version from NPM if it's running from the local environment or E2E
     if (version === '0.0.1-dev') {


### PR DESCRIPTION
Linear: RED-821

## Summary

`CHECKLY_CLI_VERSION` read like a supported way to pin the CLI version. It never was: in `checkly` it only overrides the value sent in the `x-checkly-cli-version` request header, and in `create-checkly` it selects the banner version and the `examples/` git tag project templates are fetched from. Setting it to a non-semver value such as `latest` breaks backend version parsing. Users also own variables of that name for unrelated reasons.

This renames it to `CHECKLY_E2E_CLI_VERSION`, joining the existing `CHECKLY_E2E_*` family of internal test hooks. The old name is no longer read: no fallback, no warning. The variable was only ever documented in README/CONTRIBUTING/CLAUDE.md as a local-development hook, not in the public docs.

## Changes

- `checkly`: version resolution extracted into `resolveReportedCliVersion` (`packages/cli/src/commands/baseCommand.ts`) so it is unit-testable. New spec covers the override, the default, and that the old name has no effect.
- `create-checkly`: reads the new name in `bootstrap.ts`.
- Renamed in the `prepare:ai-context` script, both e2e harnesses and the e2e specs, and the canary run summary in `release.yml`.
- README, CONTRIBUTING and CLAUDE.md now describe what the variable actually does. CONTRIBUTING notes that published `create-checkly` 9.0.0 and earlier still read the old name when testing prereleases.

## Verification

- `pnpm lint` and the full unit suite pass for both packages.
- Built `create-checkly` shows `v4.8.0` in its banner with `CHECKLY_E2E_CLI_VERSION=4.8.0`, and falls back to the package version when only `CHECKLY_CLI_VERSION` is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
